### PR TITLE
add a cmd(fstools) in cfs-cli for rmr a dir using batchdelete interface

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -45,7 +45,7 @@ func runCLI() (err error) {
 func setupCommands(cfg *cmd.Config) *cobra.Command {
 	var mc = master.NewMasterClient(cfg.MasterAddr, false)
 	mc.SetTimeout(cfg.Timeout)
-	cfsRootCmd := cmd.NewRootCmd(mc)
+	cfsRootCmd := cmd.NewRootCmd(mc, cfg.MasterAddr)
 	var completionCmd = &cobra.Command{
 		Use:   "completion",
 		Short: "Generate completion bash file",

--- a/cli/cmd/fstools.go
+++ b/cli/cmd/fstools.go
@@ -1,0 +1,76 @@
+// Copyright 2020 The Chubao Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chubaofs/chubaofs/sdk/meta"
+	"github.com/spf13/cobra"
+)
+
+const (
+	cmdFSUse   = "fstools [COMMAND]"
+	cmdFSShort = "filesystem tools"
+)
+
+func newFSToolsCmd(masters []string) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   cmdFSUse,
+		Short: cmdFSShort,
+		Args:  cobra.MinimumNArgs(0),
+	}
+	cmd.AddCommand(
+		newFSrmr(masters),
+	)
+	return cmd
+}
+
+const (
+	cmdFSrmrUse   = "rmr [volume] [file dir]"
+	cmdFSrmrShort = "recursive remove a dir"
+)
+
+func newFSrmr(masters []string) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   cmdFSrmrUse,
+		Short: cmdFSrmrShort,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var volName = args[0]
+			var dirDeleted = args[1]
+
+			var metaConfig = &meta.MetaConfig{
+				Volume:  volName,
+				Masters: masters,
+			}
+
+			gMetaWrapper, err := meta.NewMetaWrapper(metaConfig)
+			if err != nil {
+				fmt.Printf("NewMetaWrapper failed: %v", err)
+			}
+
+			ino, err := gMetaWrapper.GetRootIno(dirDeleted)
+			if err != nil {
+				fmt.Printf("GetRootIno: %v, err:%v", dirDeleted, err)
+			}
+			err = gMetaWrapper.RecursiveRemoveDir(ino)
+			if err != nil {
+				fmt.Printf("RecursiveRemoveDir:%v", err)
+			}
+		},
+	}
+	return cmd
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -34,7 +34,7 @@ type ChubaoFSCmd struct {
 	CFSCmd *cobra.Command
 }
 
-func NewRootCmd(client *master.MasterClient) *ChubaoFSCmd {
+func NewRootCmd(client *master.MasterClient, masters []string) *ChubaoFSCmd {
 	var optShowVersion bool
 	var cmd = &ChubaoFSCmd{
 		CFSCmd: &cobra.Command{
@@ -63,6 +63,7 @@ func NewRootCmd(client *master.MasterClient) *ChubaoFSCmd {
 		newConfigCmd(),
 		newCompatibilityCmd(),
 		newZoneCmd(client),
+		newFSToolsCmd(masters),
 	)
 	return cmd
 }

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -114,18 +114,12 @@ func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet)
 		}
 
 		if dentry := m.Msg; dentry != nil {
-			bddr.Items = append(bddr.Items, &struct {
-				Inode  uint64 `json:"ino"`
-				Status uint8  `json:"status"`
-			}{
+			bddr.Items = append(bddr.Items, &proto.InodeStatus {
 				Inode:  dentry.Inode,
 				Status: m.Status,
 			})
 		} else {
-			bddr.Items = append(bddr.Items, &struct {
-				Inode  uint64 `json:"ino"`
-				Status uint8  `json:"status"`
-			}{
+			bddr.Items = append(bddr.Items, &proto.InodeStatus {
 				Status: m.Status,
 			})
 		}

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -150,10 +150,7 @@ func (mp *metaPartition) UnlinkInodeBatch(req *BatchUnlinkInoReq, p *Packet) (er
 
 		info := &proto.InodeInfo{}
 		replyInfo(info, ir.Msg)
-		result.Items = append(result.Items, &struct {
-			Info   *proto.InodeInfo `json:"info"`
-			Status uint8            `json:"status"`
-		}{
+		result.Items = append(result.Items, &proto.InodeInfoStatus {
 			Info:   info,
 			Status: ir.Status,
 		})

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -159,7 +159,7 @@ type UnlinkInodeRequest struct {
 	Inode       uint64 `json:"ino"`
 }
 
-// UnlinkInodeRequest defines the request to unlink an inode.
+// UnlinkInodeRequest defines the request to unlink many inodes.
 type BatchUnlinkInodeRequest struct {
 	VolName     string   `json:"vol"`
 	PartitionID uint64   `json:"pid"`
@@ -171,12 +171,14 @@ type UnlinkInodeResponse struct {
 	Info *InodeInfo `json:"info"`
 }
 
+type InodeInfoStatus struct {
+	Info   *InodeInfo `json:"info"`
+	Status uint8      `json:"status"`
+}
+
 // batch UnlinkInodeResponse defines the response to the request of unlinking an inode.
 type BatchUnlinkInodeResponse struct {
-	Items []*struct {
-		Info   *InodeInfo `json:"info"`
-		Status uint8      `json:"status"`
-	} `json:"items"`
+	Items []*InodeInfoStatus `json:"items"`
 }
 
 // EvictInodeRequest defines the request to evict an inode.
@@ -237,12 +239,14 @@ type DeleteDentryResponse struct {
 	Inode uint64 `json:"ino"`
 }
 
+type InodeStatus struct {
+	Inode  uint64 `json:"ino"`
+	Status uint8  `json:"status"`
+}
+
 // BatchDeleteDentryResponse defines the response to the request of deleting a dentry.
 type BatchDeleteDentryResponse struct {
-	Items []*struct {
-		Inode  uint64 `json:"ino"`
-		Status uint8  `json:"status"`
-	} `json:"items"`
+	Items []*InodeStatus `json:"items"`
 }
 
 // LookupRequest defines the request for lookup.

--- a/sdk/meta/api.go
+++ b/sdk/meta/api.go
@@ -297,6 +297,181 @@ func (mw *MetaWrapper) BatchGetXAttr(inodes []uint64, keys []string) ([]*proto.X
 	return xattrs, nil
 }
 
+func (mw *MetaWrapper) RecursiveRemoveDir(parentID uint64) error {
+	stack := make([]uint64, 0)
+	dirCache := make(map[uint64]*[]proto.Dentry)
+	visit := make(map[uint64]bool)
+
+	stack = append(stack, parentID) //push
+
+	for len(stack) > 0 {
+		top := stack[len(stack)-1] //get pop
+
+		children, err := mw.getSubDentrys(&dirCache, top)
+		if err != nil {
+			return err
+		}
+
+		//pick any non empty dir not visited
+		var dentryInode uint64 = 0
+		for _, child := range *children {
+			visited, exist := visit[child.Inode]
+			if proto.IsDir(child.Type) && !mw.isDirEmpty(child.Inode) && (!exist || !visited) {
+				dentryInode = child.Inode
+				break
+			}
+		}
+
+		if dentryInode != 0 {
+			stack = append(stack, dentryInode) //push
+		} else {
+			top := stack[len(stack)-1]   //get pop
+			stack = stack[:len(stack)-1] //pop
+
+			log.LogInfof("visit:%v", top)
+			mw.BatchDeleteAndEvict_ll(top, dirCache[top])
+			visit[top] = true
+		}
+		log.LogInfof("stack: %v", stack)
+	}
+	return nil
+}
+
+func (mw *MetaWrapper) getSubDentrys(dirChildren *map[uint64]*[]proto.Dentry, top uint64) (*[]proto.Dentry, error) {
+	_, exist := (*dirChildren)[top]
+	if !exist {
+		log.LogInfof("RecursiveCleanDir: readdir (%v)", top)
+		dentrys, err := mw.ReadDir_ll(top)
+		if err != nil {
+			log.LogErrorf("RecursiveCleanDir: readdir (%v) failed, msg:%v", top, err)
+			return nil, err
+		}
+
+		log.LogInfof("ls:%v", dentrys)
+		//record dirChildren in dir
+		(*dirChildren)[top] = &dentrys
+	}
+
+	children, _ := (*dirChildren)[top] //must exist
+	return children, nil
+}
+
+func (mw *MetaWrapper) BatchDeleteAndEvict_ll(parentID uint64, dentrys *[]proto.Dentry) error {
+	if len(*dentrys) == 0 {
+		return nil
+	}
+
+	parentMP := mw.getPartitionByInode(parentID)
+	if parentMP == nil {
+		log.LogErrorf("BatchDelete_ll: No parent partition, parentID(%v)", parentID)
+		return syscall.ENOENT
+	}
+
+	//filter dentrys which could not be deleted, may be dentry(dir) not empty or not exist
+	deleteDentrys := mw.getValidDentrys(dentrys)
+	if len(deleteDentrys) == 0 {
+		return fmt.Errorf("not found dentrys which could be deleted")
+	}
+
+	status, inodes, err := mw.batchDdelete(parentMP, parentID, &deleteDentrys)
+	if err != nil || status != statusOK {
+		return fmt.Errorf("BatchDdelete: %v", err)
+	}
+
+	inodes_in_partition := mw.getPartition2InodesMap(inodes)
+
+	for mp, inodes := range inodes_in_partition {
+		mw.unlinkAndEvict(mp, inodes)
+	}
+
+	return nil
+}
+
+func (mw *MetaWrapper) unlinkAndEvict(mp *MetaPartition, inodes []uint64) {
+	var infos []*proto.InodeInfoStatus
+	status, infos, err := mw.batchIunlink(mp, &inodes)
+	if err != nil || status != statusOK {
+		log.LogWarnf("BatchIunlink error(%v)", err) //keep running even error occurs
+	}
+
+	deleteInodes := make([]uint64, 0)
+	for _, info := range infos {
+		log.LogDebugf("batchIunlink resp:%v", info.Info)
+		//unlink ok or not exist
+		if info.Status == proto.OpOk || info.Status == proto.OpNotExistErr {
+			if info != nil && !proto.IsDir(info.Info.Mode) && info.Info.Nlink == 0 {
+				log.LogInfof("evict Inode:%v", info)
+				deleteInodes = append(deleteInodes, info.Info.Inode)
+			}
+		}
+	}
+
+	if len(deleteInodes) > 0 {
+		status, err := mw.batchIevict(mp, &deleteInodes)
+		if err != nil || status != statusOK {
+			log.LogWarnf("BatchEvict: err(%v) status(%v)", err, status)
+		}
+	}
+}
+
+func (mw *MetaWrapper) getPartition2InodesMap(inodes []*proto.InodeStatus) map[*MetaPartition][]uint64 {
+	inodes_in_partition := make(map[*MetaPartition][]uint64, 0)
+
+	for _, is := range inodes {
+		//delete dentry success or no dentry
+		if is.Status == proto.OpOk || is.Status == proto.OpNotExistErr {
+			mp := mw.getPartitionByInode(is.Inode)
+			if mp == nil {
+				log.LogErrorf("BatchDelete_ll: No inode partition, ino(%v)", is.Inode)
+				continue
+			}
+
+			v, ok := inodes_in_partition[mp]
+			if ok {
+				inodes_in_partition[mp] = append(v, is.Inode)
+			} else {
+				inodes := make([]uint64, 0)
+				inodes = append(inodes, is.Inode)
+				inodes_in_partition[mp] = inodes
+			}
+
+			log.LogInfof("unlink inode(%v)", is)
+		}
+	}
+	return inodes_in_partition
+}
+
+func (mw *MetaWrapper) isDirEmpty(inode uint64) bool {
+	mp := mw.getPartitionByInode(inode)
+	if mp == nil {
+		log.LogErrorf("BatchDelete_ll: No inode partition, inode(%v)", inode)
+		return false
+	}
+	status, info, err := mw.iget(mp, inode)
+	if err != nil || status != status {
+		log.LogWarnf("BatchDelete_ll: %v", statusToErrno(status).Error())
+		return false
+	}
+	if info == nil || info.Nlink > 2 {
+		return false
+	}
+	return true
+}
+
+func (mw *MetaWrapper) getValidDentrys(dentrys *[]proto.Dentry) []proto.Dentry {
+	deleteDentrys := make([]proto.Dentry, 0)
+
+	for _, dentry := range *dentrys {
+		if proto.IsDir(dentry.Type) && !mw.isDirEmpty(dentry.Inode) {
+			continue
+		}
+
+		log.LogInfof("delete dentry:(%v)", dentry.String())
+		deleteDentrys = append(deleteDentrys, dentry)
+	}
+	return deleteDentrys
+}
+
 /*
  * Note that the return value of InodeInfo might be nil without error,
  * and the caller should make sure InodeInfo is valid before using it.

--- a/sdk/meta/operation.go
+++ b/sdk/meta/operation.go
@@ -76,6 +76,48 @@ func (mw *MetaWrapper) icreate(mp *MetaPartition, mode, uid, gid uint32, target 
 	return statusOK, resp.Info, nil
 }
 
+func (mw *MetaWrapper) batchIunlink(mp *MetaPartition, inodes *[]uint64) (status int, info []*proto.InodeInfoStatus, err error) {
+	req := &proto.BatchUnlinkInodeRequest{
+		VolName:     mw.volname,
+		PartitionID: mp.PartitionID,
+		Inodes:      *inodes,
+	}
+
+	packet := proto.NewPacketReqID()
+	packet.Opcode = proto.OpMetaBatchUnlinkInode
+	err = packet.MarshalData(req)
+	if err != nil {
+		log.LogErrorf("batchIunlink: inos(%v) err(%v)", inodes, err)
+		return
+	}
+
+	log.LogDebugf("batchIunlink enter: packet(%v) mp(%v) req(%v)", packet, mp, string(packet.Data))
+	metric := exporter.NewTPCnt(packet.GetOpMsg())
+	defer metric.Set(err)
+
+	packet, err = mw.sendToMetaPartition(mp, packet)
+	if err != nil {
+		log.LogErrorf("batchIunlink: packet(%v) mp(%v) req(%v) err(%v)", packet, mp, *req, err)
+		return
+	}
+
+	status = parseStatus(packet.ResultCode)
+	if status != statusOK {
+		log.LogErrorf("batchIunlink: packet(%v) mp(%v) req(%v) result(%v)", packet, mp, *req, packet.GetResultMsg())
+		return
+	}
+
+	resp := new(proto.BatchUnlinkInodeResponse)
+	err = packet.UnmarshalData(resp)
+	if err != nil {
+		log.LogErrorf("batchIunlink: packet(%v) mp(%v) req(%v) err(%v) PacketData(%v)", packet, mp, *req, err, string(packet.Data))
+		return
+	}
+
+	log.LogDebugf("batchIunlink exit: packet(%v) mp(%v) req(%v) resp(%v)", packet, mp, *req, *resp)
+	return statusOK, resp.Items, nil
+}
+
 func (mw *MetaWrapper) iunlink(mp *MetaPartition, inode uint64) (status int, info *proto.InodeInfo, err error) {
 	req := &proto.UnlinkInodeRequest{
 		VolName:     mw.volname,
@@ -115,6 +157,41 @@ func (mw *MetaWrapper) iunlink(mp *MetaPartition, inode uint64) (status int, inf
 
 	log.LogDebugf("iunlink: packet(%v) mp(%v) req(%v)", packet, mp, *req)
 	return statusOK, resp.Info, nil
+}
+
+func (mw *MetaWrapper) batchIevict(mp *MetaPartition, inodes *[]uint64) (status int, err error) {
+	req := &proto.BatchEvictInodeRequest{
+		VolName:     mw.volname,
+		PartitionID: mp.PartitionID,
+		Inodes:      *inodes,
+	}
+
+	packet := proto.NewPacketReqID()
+	packet.Opcode = proto.OpMetaBatchEvictInode
+	err = packet.MarshalData(req)
+	if err != nil {
+		log.LogWarnf("batchIevict: ino(%v) err(%v)", inodes, err)
+		return
+	}
+
+	log.LogDebugf("batchIevict enter: packet(%v) mp(%v) req(%v)", packet, mp, string(packet.Data))
+	metric := exporter.NewTPCnt(packet.GetOpMsg())
+	defer metric.Set(err)
+
+	packet, err = mw.sendToMetaPartition(mp, packet)
+	if err != nil {
+		log.LogWarnf("batchIevict: packet(%v) mp(%v) req(%v) err(%v)", packet, mp, *req, err)
+		return
+	}
+
+	status = parseStatus(packet.ResultCode)
+	if status != statusOK {
+		log.LogWarnf("batchIevict: packet(%v) mp(%v) req(%v) result(%v)", packet, mp, *req, packet.GetResultMsg())
+		return
+	}
+
+	log.LogDebugf("batchIevict exit: packet(%v) mp(%v) req(%v)", packet, mp, *req)
+	return statusOK, nil
 }
 
 func (mw *MetaWrapper) ievict(mp *MetaPartition, inode uint64) (status int, err error) {
@@ -236,6 +313,48 @@ func (mw *MetaWrapper) dupdate(mp *MetaPartition, parentID uint64, name string, 
 	}
 	log.LogDebugf("dupdate: packet(%v) mp(%v) req(%v) oldIno(%v)", packet, mp, *req, resp.Inode)
 	return statusOK, resp.Inode, nil
+}
+
+func (mw *MetaWrapper) batchDdelete(mp *MetaPartition, parentID uint64, dens *[]proto.Dentry) (status int, inodestatus []*proto.InodeStatus, err error) {
+	req := &proto.BatchDeleteDentryRequest{
+		VolName:     mw.volname,
+		PartitionID: mp.PartitionID,
+		ParentID:    parentID,
+		Dens:        *dens,
+	}
+
+	packet := proto.NewPacketReqID()
+	packet.Opcode = proto.OpMetaBatchDeleteDentry
+	err = packet.MarshalData(req)
+	if err != nil {
+		log.LogErrorf("batchDdelete: req(%v) err(%v)", *req, err)
+		return
+	}
+
+	log.LogDebugf("batchDdelete enter: packet(%v) mp(%v) req(%v)", packet, mp, string(packet.Data))
+	metric := exporter.NewTPCnt(packet.GetOpMsg())
+	defer metric.Set(err)
+
+	packet, err = mw.sendToMetaPartition(mp, packet)
+	if err != nil {
+		log.LogErrorf("batchDdelete: packet(%v) mp(%v) req(%v) err(%v)", packet, mp, *req, err)
+		return
+	}
+
+	status = parseStatus(packet.ResultCode)
+	if status != statusOK {
+		log.LogErrorf("batchDdelete: packet(%v) mp(%v) req(%v) result(%v)", packet, mp, *req, packet.GetResultMsg())
+		return status, nil, fmt.Errorf(packet.GetResultMsg())
+	}
+
+	resp := new(proto.BatchDeleteDentryResponse)
+	err = packet.UnmarshalData(resp)
+	if err != nil {
+		log.LogErrorf("batchDdelete: packet(%v) mp(%v) err(%v) PacketData(%v)", packet, mp, err, string(packet.Data))
+		return
+	}
+	log.LogDebugf("batchDdelete exit: packet(%v) mp(%v) req(%v) resp(%v)", packet, mp, *req, *resp)
+	return status, resp.Items, nil
 }
 
 func (mw *MetaWrapper) ddelete(mp *MetaPartition, parentID uint64, name string) (status int, inode uint64, err error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
using BatchDeleteDentryRequest, BatchUnlinkInodeRequest and BatchEvictInodeRequest, we can rmr a dir contains many files or dirs even more fast

**Special notes for your reviewer**:
I only add some methods and extract type InodeStatus and InodeInfoStatus for better Type choice, not change the logic of orginal code

**Release note**:
```
rmr a dir in cfs-cli fstools
```
