### PR TITLE
fix: add checksum func for metanode #993

### DIFF
--- a/metanode/checksum.go
+++ b/metanode/checksum.go
@@ -1,0 +1,60 @@
+package metanode
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/chubaofs/chubaofs/util/errors"
+)
+
+func checksumToStr(sum []byte) string {
+	return base64.StdEncoding.EncodeToString(sum)
+}
+
+func strToChecksum(str string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(str)
+}
+
+func writeChecksumToFile(filename string, sum []byte) error {
+	raw := []byte(fmt.Sprintf("crc32|%s", checksumToStr(sum)))
+	fp, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	n, err := fp.Write(raw)
+	if err == nil && n < len(raw) {
+		err = io.ErrShortWrite
+	}
+	if err1 := fp.Sync(); err == nil {
+		err = err1
+	}
+	if err1 := fp.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+func readChecksumFromFile(file string) (sum []byte, err error) {
+	var raw []byte
+	raw, err = ioutil.ReadFile(file)
+	if err != nil {
+		return
+	}
+	str := string(raw)
+	parts := strings.Split(str, "|")
+	if len(parts) != 2 {
+		err = errors.NewErrorf("invalid checksum format, should be [type]|[checksum], but got %s", str)
+		return
+	}
+	typePart, sumPart := parts[0], parts[1]
+	if strings.ToLower(typePart) != "crc32" {
+		err = errors.NewErrorf("unknown checksum type %s", typePart)
+		return
+	}
+	sum, err = strToChecksum(sumPart)
+	return
+}

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -16,9 +16,11 @@ package metanode
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"hash/crc32"
 	"io"
 	"io/ioutil"
@@ -27,11 +29,9 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/chubaofs/chubaofs/util/log"
-
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util/errors"
-	mmap "github.com/edsrzf/mmap-go"
+	"github.com/chubaofs/chubaofs/util/log"
 )
 
 const (
@@ -48,20 +48,51 @@ const (
 	metadataFileTmp = ".meta"
 )
 
+func checksumFileName(originName string) string {
+	return ".checksum." + originName
+}
+
+func (mp *metaPartition) loadChecksum(rootDir string, fileName string, mustExist bool) (sum []byte, err error) {
+	checksumFile := path.Join(rootDir, fileName)
+	sum, err = readChecksumFromFile(checksumFile)
+	if err != nil {
+		if os.IsNotExist(err) && !mustExist {
+			log.LogInfof("LoadChecksumFile: checksum file %s not found", fileName)
+			err = nil
+			return
+		} else {
+			log.LogErrorf("LoadChecksumFile: failed to load checksum file %s, %s", fileName, err)
+			return
+		}
+	} else {
+		log.LogInfof("loadChecksumFile: read checksum success, checksum value %v", sum)
+		return
+	}
+}
+
 func (mp *metaPartition) loadMetadata() (err error) {
 	metaFile := path.Join(mp.config.RootDir, metadataFile)
 	fp, err := os.OpenFile(metaFile, os.O_RDONLY, 0644)
 	if err != nil {
-		err = errors.NewErrorf("[loadMetadata]: OpenFile %s", err.Error())
+		err = errors.NewErrorf("[loadMetadata] OpenFile: %s", err.Error())
 		return
 	}
-	defer fp.Close()
+	//fp close safety
+	closeFp := func(fp *os.File) {
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("loadMetadata: fp.Close %s", closeErr.Error())
+		}
+	}
+	defer closeFp(fp)
+
+	//io proc
 	data, err := ioutil.ReadAll(fp)
 	if err != nil || len(data) == 0 {
-		err = errors.NewErrorf("[loadMetadata]: ReadFile %s, data: %s", err.Error(),
-			string(data))
+		err = errors.NewErrorf("[loadMetadata]: ReadFile %v, data: %s", err, string(data))
 		return
 	}
+
 	mConf := &MetaPartitionConfig{}
 	if err = json.Unmarshal(data, mConf); err != nil {
 		err = errors.NewErrorf("[loadMetadata]: Unmarshal MetaPartitionConfig %s",
@@ -102,8 +133,37 @@ func (mp *metaPartition) loadInode(rootDir string) (err error) {
 		err = errors.NewErrorf("[loadInode] OpenFile: %s", err.Error())
 		return
 	}
-	defer fp.Close()
-	reader := bufio.NewReaderSize(fp, 4*1024*1024)
+	//fp close safety
+	closeFp := func(fp *os.File) {
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("loadInode: fp.Close %s", closeErr.Error())
+		}
+	}
+	defer closeFp(fp)
+
+	reader := io.Reader(fp)
+	//loadChecksum and doSumCheck (if exist)
+	sumLoaded, err := mp.loadChecksum(rootDir, checksumFileName(inodeFile), false)
+	if err != nil {
+		return errors.NewErrorf("[loadInode] loadChecksum: %s", err.Error())
+	}
+	if sumLoaded != nil {
+		doSumCheck := func(want []byte, hashFn hash.Hash) {
+			if err == nil {
+				if actual := hashFn.Sum(nil); !bytes.Equal(actual, want) {
+					log.LogErrorf("loadInode: checksum not equal, want(%v), actual(%v)", want, actual)
+					err = errors.NewErrorf("[loadInode] Checksum failed")
+				}
+			}
+		}
+		crc32Sign := crc32.NewIEEE()
+		reader = io.TeeReader(reader, crc32Sign)
+		defer doSumCheck(sumLoaded, crc32Sign)
+	}
+
+	//io proc
+	reader = io.Reader(bufio.NewReaderSize(reader, 4*1024*1024))
 	inoBuf := make([]byte, 4)
 	for {
 		inoBuf = inoBuf[:4]
@@ -118,7 +178,6 @@ func (mp *metaPartition) loadInode(rootDir string) (err error) {
 			return
 		}
 		length := binary.BigEndian.Uint32(inoBuf)
-
 		// next read body
 		if uint32(cap(inoBuf)) >= length {
 			inoBuf = inoBuf[:length]
@@ -149,7 +208,7 @@ func (mp *metaPartition) loadDentry(rootDir string) (err error) {
 	var numDentries uint64
 	defer func() {
 		if err == nil {
-			log.LogInfof("loadDentry: load complete: partitonID(%v) volume(%v) numDentries(%v)",
+			log.LogInfof("loadDentry: load complete: partitionID(%v) volume(%v) numDentries(%v)",
 				mp.config.PartitionId, mp.config.VolName, numDentries)
 		}
 	}()
@@ -160,16 +219,52 @@ func (mp *metaPartition) loadDentry(rootDir string) (err error) {
 	}
 	fp, err := os.OpenFile(filename, os.O_RDONLY, 0644)
 	if err != nil {
-		if err == os.ErrNotExist {
+		if os.IsNotExist(err) {
 			err = nil
 			return
+		} else {
+			err = errors.NewErrorf("[loadDentry] OpenFile: %s", err.Error())
+			return
 		}
-		err = errors.NewErrorf("[loadDentry] OpenFile: %s", err.Error())
+	}
+	//fp close safety
+	closeFp := func(fp *os.File) {
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("loadDentry: fp.Close %s", closeErr.Error())
+		}
+	}
+	defer closeFp(fp)
+
+	fpStat, err := fp.Stat()
+	if err != nil {
+		err = errors.NewErrorf("[loadDentry] Stat: %s", err.Error())
 		return
 	}
 
-	defer fp.Close()
-	reader := bufio.NewReaderSize(fp, 4*1024*1024)
+	reader := io.Reader(fp)
+
+	//loadChecksum and doSumCheck (if exist)
+	sumLoaded, err := mp.loadChecksum(rootDir, checksumFileName(dentryFile), false)
+	if err != nil {
+		return errors.NewErrorf("[loadDentry] loadChecksum: %s", err.Error())
+	}
+	if sumLoaded != nil {
+		doSumCheck := func(want []byte, hashFn hash.Hash) {
+			if err == nil {
+				if actual := hashFn.Sum(nil); !bytes.Equal(actual, want) {
+					log.LogErrorf("loadDentry: checksum not equal, want(%v), actual(%v)", want, actual)
+					err = errors.NewErrorf("[loadDentry] Checksum failed")
+				}
+			}
+		}
+		crc32Sign := crc32.NewIEEE()
+		reader = io.TeeReader(reader, crc32Sign)
+		defer doSumCheck(sumLoaded, crc32Sign)
+	}
+
+	//io proc
+	reader = bufio.NewReaderSize(reader, 4*1024*1024)
 	dentryBuf := make([]byte, 4)
 	for {
 		dentryBuf = dentryBuf[:4]
@@ -185,7 +280,11 @@ func (mp *metaPartition) loadDentry(rootDir string) (err error) {
 		}
 
 		length := binary.BigEndian.Uint32(dentryBuf)
-
+		if int64(length) > fpStat.Size() {
+			log.LogErrorf("loadDentry: length too large")
+			return errors.NewErrorf("[loadDentry] unexpected length, length(%d), filename(%s)",
+				length, filename)
+		}
 		// next read body
 		if uint32(cap(dentryBuf)) >= length {
 			dentryBuf = dentryBuf[:length]
@@ -194,7 +293,7 @@ func (mp *metaPartition) loadDentry(rootDir string) (err error) {
 		}
 		_, err = io.ReadFull(reader, dentryBuf)
 		if err != nil {
-			err = errors.NewErrorf("[loadDentry]: ReadBody: %s", err.Error())
+			err = errors.NewErrorf("[loadDentry] ReadBody: %s", err.Error())
 			return
 		}
 		dentry := &Dentry{}
@@ -210,8 +309,7 @@ func (mp *metaPartition) loadDentry(rootDir string) (err error) {
 	}
 }
 
-func (mp *metaPartition) loadExtend(rootDir string) error {
-	var err error
+func (mp *metaPartition) loadExtend(rootDir string) (err error) {
 	filename := path.Join(rootDir, extendFile)
 	if _, err = os.Stat(filename); err != nil {
 		return nil
@@ -220,42 +318,86 @@ func (mp *metaPartition) loadExtend(rootDir string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = fp.Close()
-	}()
-	var mem mmap.MMap
-	if mem, err = mmap.Map(fp, mmap.RDONLY, 0); err != nil {
+	//fp close safety
+	closeFp := func(fp *os.File) {
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("loadExtend: fp.Close %s", closeErr.Error())
+		}
+	}
+	defer closeFp(fp)
+
+	fpStat, err := fp.Stat()
+	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = mem.Unmap()
-	}()
-	var offset, n int
+
+	reader := io.Reader(fp)
+
+	//loadChecksum and doSumCheck (if exist)
+	sumLoaded, err := mp.loadChecksum(rootDir, checksumFileName(extendFile), false)
+	if err != nil {
+		return errors.NewErrorf("[loadExtend] loadChecksum: %s", err.Error())
+	}
+	if sumLoaded != nil {
+		doSumCheck := func(want []byte, hashFn hash.Hash) {
+			if err == nil {
+				if actual := hashFn.Sum(nil); !bytes.Equal(actual, want) {
+					log.LogErrorf("loadExtend: checksum not equal, want(%v), actual(%v)", want, actual)
+					err = errors.NewErrorf("[loadExtend] Checksum failed")
+				}
+			}
+		}
+		crc32Sign := crc32.NewIEEE()
+		reader = io.TeeReader(reader, crc32Sign)
+		defer doSumCheck(sumLoaded, crc32Sign)
+	}
+
+	//io proc
+	bufReader := bufio.NewReader(reader)
 	// read number of extends
 	var numExtends uint64
-	numExtends, n = binary.Uvarint(mem)
-	offset += n
+	numExtends, err = binary.ReadUvarint(bufReader)
+	if err != nil {
+		log.LogErrorf("loadExtend: failed to load numExtends: %s", err.Error())
+		return errors.NewErrorf("[loadDentry] ReadUvarint: %s", err.Error())
+	}
+	xattrBuf := make([]byte, 4096)
 	for i := uint64(0); i < numExtends; i++ {
 		// read length
 		var numBytes uint64
-		numBytes, n = binary.Uvarint(mem[offset:])
-		offset += n
+		if numBytes, err = binary.ReadUvarint(bufReader); err != nil {
+			log.LogErrorf("loadExtend: failed to load numBytes: %s", err.Error())
+			return errors.NewErrorf("[loadDentry] ReadUvarint: %s", err.Error())
+		}
+		if numBytes > uint64(fpStat.Size()) {
+			log.LogErrorf("loadExtend: numBytes too large")
+			return errors.NewErrorf("[loadExtend] unexpected numBytes, numBytes(%d), filename(%s)",
+				numBytes, filename)
+		}
+		if cap(xattrBuf) >= int(numBytes) {
+			xattrBuf = xattrBuf[:numBytes]
+		} else {
+			xattrBuf = make([]byte, numBytes)
+		}
+		if _, err = io.ReadFull(bufReader, xattrBuf); err != nil {
+			log.LogErrorf("loadExtend: failed to load extent: %s", err.Error())
+			return errors.NewErrorf("[loadExtend]  ReadFull: %s", err.Error())
+		}
 		var extend *Extend
-		if extend, err = NewExtendFromBytes(mem[offset : offset+int(numBytes)]); err != nil {
+		if extend, err = NewExtendFromBytes(xattrBuf); err != nil {
 			return err
 		}
 		log.LogDebugf("loadExtend: new extend from bytes: partitionID（%v) volume(%v) inode(%v)",
 			mp.config.PartitionId, mp.config.VolName, extend.inode)
 		_ = mp.fsmSetXAttr(extend)
-		offset += int(numBytes)
 	}
 	log.LogInfof("loadExtend: load complete: partitionID(%v) volume(%v) numExtends(%v) filename(%v)",
 		mp.config.PartitionId, mp.config.VolName, numExtends, filename)
 	return nil
 }
 
-func (mp *metaPartition) loadMultipart(rootDir string) error {
-	var err error
+func (mp *metaPartition) loadMultipart(rootDir string) (err error) {
 	filename := path.Join(rootDir, multipartFile)
 	if _, err = os.Stat(filename); err != nil {
 		return nil
@@ -264,31 +406,76 @@ func (mp *metaPartition) loadMultipart(rootDir string) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = fp.Close()
-	}()
-	var mem mmap.MMap
-	if mem, err = mmap.Map(fp, mmap.RDONLY, 0); err != nil {
+	//fp close safety
+	closeFp := func(fp *os.File) {
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("loadMultipart: fp.Close %s", closeErr.Error())
+		}
+	}
+	defer closeFp(fp)
+
+	fpStat, err := fp.Stat()
+	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = mem.Unmap()
-	}()
-	var offset, n int
+
+	//loadChecksum and doSumCheck (if exist)
+	sumLoaded, err := mp.loadChecksum(rootDir, checksumFileName(multipartFile), false)
+	if err != nil {
+		return errors.NewErrorf("[loadMultipart] loadChecksum: %s", err.Error())
+	}
+	reader := io.Reader(fp)
+	if sumLoaded != nil {
+		doSumCheck := func(want []byte, hashFn hash.Hash) {
+			if err == nil {
+				if actual := hashFn.Sum(nil); !bytes.Equal(actual, want) {
+					log.LogErrorf("loadMultipart: checksum not equal, want(%v), actual(%v)", want, actual)
+					err = errors.NewErrorf("[loadMultipart] Checksum failed")
+				}
+			}
+		}
+		crc32Sign := crc32.NewIEEE()
+		reader = io.TeeReader(reader, crc32Sign)
+		defer doSumCheck(sumLoaded, crc32Sign)
+	}
+
+	//io proc
+	bufReader := bufio.NewReader(reader)
 	// read number of extends
 	var numMultiparts uint64
-	numMultiparts, n = binary.Uvarint(mem)
-	offset += n
+	numMultiparts, err = binary.ReadUvarint(bufReader)
+	if err != nil {
+		log.LogErrorf("loadMultipart: failed to load numMultiparts: %s", err.Error())
+		return errors.NewErrorf("[loadMultipart] ReadUvarint: %s", err.Error())
+	}
+	multipartBuf := make([]byte, 4096)
 	for i := uint64(0); i < numMultiparts; i++ {
 		// read length
 		var numBytes uint64
-		numBytes, n = binary.Uvarint(mem[offset:])
-		offset += n
+		if numBytes, err = binary.ReadUvarint(bufReader); err != nil {
+			log.LogErrorf("loadMultipart: failed to load numBytes: %s", err.Error())
+			return errors.NewErrorf("[loadMultipart]  ReadUvarint: %s", err.Error())
+		}
+
+		if numBytes > uint64(fpStat.Size()) {
+			log.LogErrorf("loadMultipart: numBytes too large")
+			return errors.NewErrorf("[loadMultipart] unexpected numBytes, numBytes(%d), filename(%s)",
+				numBytes, filename)
+		}
+		if cap(multipartBuf) >= int(numBytes) {
+			multipartBuf = multipartBuf[:numBytes]
+		} else {
+			multipartBuf = make([]byte, numBytes)
+		}
+		if _, err = io.ReadFull(bufReader, multipartBuf); err != nil {
+			log.LogErrorf("loadMultipart: failed to load multipart: %s", err.Error())
+			return errors.NewErrorf("[loadMultipart]  ReadFull: %s", err.Error())
+		}
 		var multipart *Multipart
-		multipart = MultipartFromBytes(mem[offset : offset+int(numBytes)])
+		multipart = MultipartFromBytes(multipartBuf)
 		log.LogDebugf("loadMultipart: create multipart from bytes: partitionID（%v) multipartID(%v)", mp.config.PartitionId, multipart.id)
 		mp.fsmCreateMultipart(multipart)
-		offset += int(numBytes)
 	}
 	log.LogInfof("loadMultipart: load complete: partitionID(%v) numMultiparts(%v) filename(%v)",
 		mp.config.PartitionId, numMultiparts, filename)
@@ -301,7 +488,41 @@ func (mp *metaPartition) loadApplyID(rootDir string) (err error) {
 		err = nil
 		return
 	}
-	data, err := ioutil.ReadFile(filename)
+	fp, err := os.OpenFile(filename, os.O_RDONLY, 0644)
+	if err != nil {
+		return err
+	}
+	//fp close safety
+	closeFp := func(fp *os.File) {
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("loadApplyID: fp.Close %s", closeErr.Error())
+		}
+	}
+	defer closeFp(fp)
+
+	//loadChecksum and doSumCheck (if exist)
+	sumLoaded, err := mp.loadChecksum(rootDir, checksumFileName(applyIDFile), false)
+	if err != nil {
+		return errors.NewErrorf("[loadApplyID] loadChecksum: %s", err.Error())
+	}
+	reader := io.Reader(fp)
+	if sumLoaded != nil {
+		doSumCheck := func(want []byte, hashFn hash.Hash) {
+			if err == nil {
+				if actual := hashFn.Sum(nil); !bytes.Equal(actual, want) {
+					log.LogErrorf("loadApplyID: checksum not equal, want(%v), actual(%v)", want, actual)
+					err = errors.NewErrorf("[loadApplyID] Checksum failed")
+				}
+			}
+		}
+		crc32Sign := crc32.NewIEEE()
+		reader = io.TeeReader(reader, crc32Sign)
+		defer doSumCheck(sumLoaded, crc32Sign)
+	}
+
+	//io proc
+	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		if err == os.ErrNotExist {
 			err = nil
@@ -324,7 +545,6 @@ func (mp *metaPartition) loadApplyID(rootDir string) (err error) {
 		err = errors.NewErrorf("[loadApplyID] ReadApplyID: %s", err.Error())
 		return
 	}
-
 	if cursor > atomic.LoadUint64(&mp.config.Cursor) {
 		atomic.StoreUint64(&mp.config.Cursor, cursor)
 	}
@@ -333,25 +553,64 @@ func (mp *metaPartition) loadApplyID(rootDir string) (err error) {
 	return
 }
 
+func (mp *metaPartition) persistChecksum(sum []byte, root, fileName string) (err error) {
+	tmpName := ".tmp" + fileName
+	tmpFile := path.Join(root, tmpName)
+	if err = writeChecksumToFile(tmpFile, sum); err != nil {
+		log.LogErrorf("persistChecksum: failed to persist checksum to tmpFile %s: %s", tmpFile, err)
+		return
+	}
+	defer func() {
+		if rmErr := os.Remove(tmpFile); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.LogErrorf("persistChecksum: failed to delete checksum tmpFile %s: %s", tmpFile, rmErr)
+		}
+	}()
+	checksumFile := path.Join(root, fileName)
+	err = os.Rename(tmpFile, checksumFile)
+	if err != nil {
+		log.LogErrorf("persistChecksum: failed to rename tmpFile %s to checksumFile %s", tmpFile, checksumFile)
+	} else {
+		log.LogInfof("persistChecksum: create checksumFile %s success", checksumFile)
+	}
+	return err
+}
+
 func (mp *metaPartition) persistMetadata() (err error) {
 	if err = mp.config.checkMeta(); err != nil {
 		err = errors.NewErrorf("[persistMetadata]->%s", err.Error())
 		return
 	}
 
-	// TODO Unhandled errors
-	os.MkdirAll(mp.config.RootDir, 0755)
+	if err = os.MkdirAll(mp.config.RootDir, 0755); err != nil {
+		err = errors.NewErrorf("[persistMetadata] MkdirAll: %s", err.Error())
+		return err
+	}
+
 	filename := path.Join(mp.config.RootDir, metadataFileTmp)
 	fp, err := os.OpenFile(filename, os.O_RDWR|os.O_TRUNC|os.O_APPEND|os.O_CREATE, 0755)
 	if err != nil {
 		return
 	}
-	defer func() {
-		// TODO Unhandled errors
-		fp.Sync()
-		fp.Close()
-		os.Remove(filename)
-	}()
+	//fp safety
+	syncCloseFp := func(fp *os.File) {
+		if err == nil {
+			syncErr := fp.Sync()
+			if syncErr != nil {
+				log.LogErrorf("persistMetadata: fp.Sync %s", syncErr.Error())
+				err = errors.NewErrorf("[persistMetadata] fp.Sync: %s", syncErr)
+			}
+		}
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("persistMetadata: fp.Close %s", closeErr.Error())
+			if err == nil {
+				err = errors.NewErrorf("[persistMetadata] fp.Close: %s", closeErr)
+			}
+		}
+	}
+	defer syncCloseFp(fp)
+	// TODO Unhandled rm errors
+	defer os.Remove(filename)
 
 	data, err := json.Marshal(mp.config)
 	if err != nil {
@@ -375,15 +634,43 @@ func (mp *metaPartition) storeApplyID(rootDir string, sm *storeMsg) (err error) 
 	if err != nil {
 		return
 	}
-	defer func() {
-		err = fp.Sync()
-		fp.Close()
-	}()
-	if _, err = fp.WriteString(fmt.Sprintf("%d|%d", sm.applyIndex, atomic.LoadUint64(&mp.config.Cursor))); err != nil {
+	//fp safety
+	syncCloseFp := func(fp *os.File) {
+		if err == nil {
+			syncErr := fp.Sync()
+			if syncErr != nil {
+				log.LogErrorf("storeApplyID: fp.Sync %s", syncErr.Error())
+				err = errors.NewErrorf("[storeApplyID] fp.Sync: %s", syncErr)
+			}
+		}
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("storeApplyID: fp.Close %s", closeErr.Error())
+			if err == nil {
+				err = errors.NewErrorf("[storeApplyID] fp.Close: %s", closeErr)
+			}
+		}
+	}
+	defer syncCloseFp(fp)
+
+	crc32Sign := crc32.NewIEEE()
+	writer := io.MultiWriter(fp, crc32Sign)
+	//io proc
+	data := []byte(fmt.Sprintf("%d|%d", sm.applyIndex, atomic.LoadUint64(&mp.config.Cursor)))
+	if _, err = writer.Write(data); err != nil {
 		return
 	}
-	log.LogInfof("storeApplyID: store complete: partitionID(%v) volume(%v) applyID(%v)",
-		mp.config.PartitionId, mp.config.VolName, sm.applyIndex)
+
+	//persist checksum file if success
+	err = mp.persistChecksum(crc32Sign.Sum(nil), rootDir, checksumFileName(applyIDFile))
+	if err != nil {
+		log.LogErrorf("storeApplyID: failed to persist applyId checksum: %s", err.Error())
+		return
+	}
+
+	crc := crc32Sign.Sum32()
+	log.LogInfof("storeApplyID: store complete: partitionID(%v) volume(%v) applyID(%v) crc(%v)",
+		mp.config.PartitionId, mp.config.VolName, sm.applyIndex, crc)
 	return
 }
 
@@ -395,14 +682,31 @@ func (mp *metaPartition) storeInode(rootDir string,
 	if err != nil {
 		return
 	}
-	defer func() {
-		err = fp.Sync()
-		// TODO Unhandled errors
-		fp.Close()
-	}()
+	//fp safety
+	syncCloseFp := func(fp *os.File) {
+		if err == nil {
+			syncErr := fp.Sync()
+			if syncErr != nil {
+				log.LogErrorf("storeInode: fp.Sync %s", syncErr.Error())
+				err = errors.NewErrorf("[storeInode] fp.Sync: %s", syncErr)
+			}
+		}
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("storeInode: fp.Close %s", closeErr.Error())
+			if err == nil {
+				err = errors.NewErrorf("[storeInode] fp.Close: %s", closeErr)
+			}
+		}
+	}
+	defer syncCloseFp(fp)
+
+	crc32Sign := crc32.NewIEEE()
+	writer := io.MultiWriter(fp, crc32Sign)
+
+	//io proc
 	var data []byte
 	lenBuf := make([]byte, 4)
-	sign := crc32.NewIEEE()
 	sm.inodeTree.Ascend(func(i BtreeItem) bool {
 		ino := i.(*Inode)
 		if data, err = ino.Marshal(); err != nil {
@@ -410,22 +714,23 @@ func (mp *metaPartition) storeInode(rootDir string,
 		}
 		// set length
 		binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))
-		if _, err = fp.Write(lenBuf); err != nil {
+		if _, err = writer.Write(lenBuf); err != nil {
 			return false
 		}
-		if _, err = sign.Write(lenBuf); err != nil {
-			return false
-		}
-		// set body
-		if _, err = fp.Write(data); err != nil {
-			return false
-		}
-		if _, err = sign.Write(data); err != nil {
+		if _, err = writer.Write(data); err != nil {
 			return false
 		}
 		return true
 	})
-	crc = sign.Sum32()
+
+	//persist checksum file if success
+	err = mp.persistChecksum(crc32Sign.Sum(nil), rootDir, checksumFileName(inodeFile))
+	if err != nil {
+		log.LogErrorf("storeInode: failed to persist inode checksum: %s", err.Error())
+		return
+	}
+
+	crc = crc32Sign.Sum32()
 	log.LogInfof("storeInode: store complete: partitoinID(%v) volume(%v) numInodes(%v) crc(%v)",
 		mp.config.PartitionId, mp.config.VolName, sm.inodeTree.Len(), crc)
 	return
@@ -439,14 +744,31 @@ func (mp *metaPartition) storeDentry(rootDir string,
 	if err != nil {
 		return
 	}
-	defer func() {
-		err = fp.Sync()
-		// TODO Unhandled errors
-		fp.Close()
-	}()
+	//fp safety
+	syncCloseFp := func(fp *os.File) {
+		if err == nil {
+			syncErr := fp.Sync()
+			if syncErr != nil {
+				log.LogErrorf("storeDentry: fp.Sync %s", syncErr.Error())
+				err = errors.NewErrorf("[storeDentry] fp.Sync: %s", syncErr)
+			}
+		}
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("storeDentry: fp.Close %s", closeErr.Error())
+			if err == nil {
+				err = errors.NewErrorf("[storeDentry] fp.Close: %s", closeErr)
+			}
+		}
+	}
+	defer syncCloseFp(fp)
+
+	crc32Sign := crc32.NewIEEE()
+	writer := io.MultiWriter(fp, crc32Sign)
+
+	//io proc
 	var data []byte
 	lenBuf := make([]byte, 4)
-	sign := crc32.NewIEEE()
 	sm.dentryTree.Ascend(func(i BtreeItem) bool {
 		dentry := i.(*Dentry)
 		data, err = dentry.Marshal()
@@ -455,21 +777,23 @@ func (mp *metaPartition) storeDentry(rootDir string,
 		}
 		// set length
 		binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))
-		if _, err = fp.Write(lenBuf); err != nil {
+		if _, err = writer.Write(lenBuf); err != nil {
 			return false
 		}
-		if _, err = sign.Write(lenBuf); err != nil {
-			return false
-		}
-		if _, err = fp.Write(data); err != nil {
-			return false
-		}
-		if _, err = sign.Write(data); err != nil {
+		if _, err = writer.Write(data); err != nil {
 			return false
 		}
 		return true
 	})
-	crc = sign.Sum32()
+
+	//persist checksum file if success
+	err = mp.persistChecksum(crc32Sign.Sum(nil), rootDir, checksumFileName(dentryFile))
+	if err != nil {
+		log.LogErrorf("storeDentry: failed to persist dentry checksum: %s", err.Error())
+		return
+	}
+
+	crc = crc32Sign.Sum32()
 	log.LogInfof("storeDentry: store complete: partitoinID(%v) volume(%v) numDentries(%v) crc(%v)",
 		mp.config.PartitionId, mp.config.VolName, sm.dentryTree.Len(), crc)
 	return
@@ -477,28 +801,43 @@ func (mp *metaPartition) storeDentry(rootDir string,
 
 func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc uint32, err error) {
 	var extendTree = sm.extendTree
-	var fp = path.Join(rootDir, extendFile)
-	var f *os.File
-	f, err = os.OpenFile(fp, os.O_RDWR|os.O_TRUNC|os.O_APPEND|os.O_CREATE, 0755)
+	var filename = path.Join(rootDir, extendFile)
+	var fp *os.File
+	fp, err = os.OpenFile(filename, os.O_RDWR|os.O_TRUNC|os.O_APPEND|os.O_CREATE, 0755)
 	if err != nil {
 		return
 	}
-	defer func() {
-		closeErr := f.Close()
-		if err == nil && closeErr != nil {
-			err = closeErr
+	//fp safety
+	syncCloseFp := func(fp *os.File) {
+		if err == nil {
+			syncErr := fp.Sync()
+			if syncErr != nil {
+				log.LogErrorf("storeExtend: fp.Sync %s", syncErr.Error())
+				err = errors.NewErrorf("[storeExtend] fp.Sync: %s", syncErr)
+			}
 		}
-	}()
-	var writer = bufio.NewWriterSize(f, 4*1024*1024)
-	var crc32 = crc32.NewIEEE()
-	var varintTmp = make([]byte, binary.MaxVarintLen64)
-	var n int
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("storeExtend: fp.Close %s", closeErr.Error())
+			if err == nil {
+				err = errors.NewErrorf("[storeExtend] fp.Close: %s", closeErr)
+			}
+		}
+	}
+	defer syncCloseFp(fp)
+
+	buffer := bufio.NewWriterSize(fp, 4*1024*1024)
+	crc32Sign := crc32.NewIEEE()
+	writer := io.MultiWriter(buffer, crc32Sign)
+
+	//io proc
+	var (
+		varintTmp = make([]byte, binary.MaxVarintLen64)
+		n         int
+	)
 	// write number of extends
 	n = binary.PutUvarint(varintTmp, uint64(extendTree.Len()))
 	if _, err = writer.Write(varintTmp[:n]); err != nil {
-		return
-	}
-	if _, err = crc32.Write(varintTmp[:n]); err != nil {
 		return
 	}
 	extendTree.Ascend(func(i BtreeItem) bool {
@@ -512,14 +851,8 @@ func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc uint32, 
 		if _, err = writer.Write(varintTmp[:n]); err != nil {
 			return false
 		}
-		if _, err = crc32.Write(varintTmp[:n]); err != nil {
-			return false
-		}
 		// write raw
 		if _, err = writer.Write(raw); err != nil {
-			return false
-		}
-		if _, err = crc32.Write(raw); err != nil {
 			return false
 		}
 		return true
@@ -528,13 +861,17 @@ func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc uint32, 
 		return
 	}
 
-	if err = writer.Flush(); err != nil {
+	if err = buffer.Flush(); err != nil {
 		return
 	}
-	if err = f.Sync(); err != nil {
-		return
+
+	//persist checksum file if success
+	err = mp.persistChecksum(crc32Sign.Sum(nil), rootDir, checksumFileName(extendFile))
+	if err != nil {
+		log.LogErrorf("storeExtend: failed to persist extend checksum: %s", err.Error())
 	}
-	crc = crc32.Sum32()
+
+	crc = crc32Sign.Sum32()
 	log.LogInfof("storeExtend: store complete: partitoinID(%v) volume(%v) numExtends(%v) crc(%v)",
 		mp.config.PartitionId, mp.config.VolName, extendTree.Len(), crc)
 	return
@@ -542,28 +879,43 @@ func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc uint32, 
 
 func (mp *metaPartition) storeMultipart(rootDir string, sm *storeMsg) (crc uint32, err error) {
 	var multipartTree = sm.multipartTree
-	var fp = path.Join(rootDir, multipartFile)
-	var f *os.File
-	f, err = os.OpenFile(fp, os.O_RDWR|os.O_TRUNC|os.O_APPEND|os.O_CREATE, 0755)
+	var filename = path.Join(rootDir, multipartFile)
+	var fp *os.File
+	fp, err = os.OpenFile(filename, os.O_RDWR|os.O_TRUNC|os.O_APPEND|os.O_CREATE, 0755)
 	if err != nil {
 		return
 	}
-	defer func() {
-		closeErr := f.Close()
-		if err == nil && closeErr != nil {
-			err = closeErr
+	//fp safety
+	syncCloseFp := func(fp *os.File) {
+		if err == nil {
+			syncErr := fp.Sync()
+			if syncErr != nil {
+				log.LogErrorf("storeMultipart: fp.Sync %s", syncErr.Error())
+				err = errors.NewErrorf("[storeMultipart] fp.Sync: %s", syncErr)
+			}
 		}
-	}()
-	var writer = bufio.NewWriterSize(f, 4*1024*1024)
-	var crc32 = crc32.NewIEEE()
-	var varintTmp = make([]byte, binary.MaxVarintLen64)
-	var n int
+		closeErr := fp.Close()
+		if closeErr != nil {
+			log.LogErrorf("storeMultipart: fp.Close %s", closeErr.Error())
+			if err == nil {
+				err = errors.NewErrorf("[storeMultipart] fp.Close: %s", closeErr)
+			}
+		}
+	}
+	defer syncCloseFp(fp)
+
+	buffer := bufio.NewWriterSize(fp, 4*1024*1024)
+	crc32Sign := crc32.NewIEEE()
+	writer := io.MultiWriter(buffer, crc32Sign)
+
+	//io proc
+	var (
+		varintTmp = make([]byte, binary.MaxVarintLen64)
+		n         int
+	)
 	// write number of extends
 	n = binary.PutUvarint(varintTmp, uint64(multipartTree.Len()))
 	if _, err = writer.Write(varintTmp[:n]); err != nil {
-		return
-	}
-	if _, err = crc32.Write(varintTmp[:n]); err != nil {
 		return
 	}
 	multipartTree.Ascend(func(i BtreeItem) bool {
@@ -577,14 +929,8 @@ func (mp *metaPartition) storeMultipart(rootDir string, sm *storeMsg) (crc uint3
 		if _, err = writer.Write(varintTmp[:n]); err != nil {
 			return false
 		}
-		if _, err = crc32.Write(varintTmp[:n]); err != nil {
-			return false
-		}
 		// write raw
 		if _, err = writer.Write(raw); err != nil {
-			return false
-		}
-		if _, err = crc32.Write(raw); err != nil {
 			return false
 		}
 		return true
@@ -593,13 +939,17 @@ func (mp *metaPartition) storeMultipart(rootDir string, sm *storeMsg) (crc uint3
 		return
 	}
 
-	if err = writer.Flush(); err != nil {
+	if err = buffer.Flush(); err != nil {
 		return
 	}
-	if err = f.Sync(); err != nil {
-		return
+
+	//persist checksum file if success
+	err = mp.persistChecksum(crc32Sign.Sum(nil), rootDir, checksumFileName(multipartFile))
+	if err != nil {
+		log.LogErrorf("storeMultipart: failed to persist multipart checksum: %s", err.Error())
 	}
-	crc = crc32.Sum32()
+
+	crc = crc32Sign.Sum32()
 	log.LogInfof("storeMultipart: store complete: partitoinID(%v) volume(%v) numMultiparts(%v) crc(%v)",
 		mp.config.PartitionId, mp.config.VolName, multipartTree.Len(), crc)
 	return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
meatanode: add a checksum file for each snapshot file. forward compatible and support fallback

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #993 

**Special notes for your reviewer**:
Taking into account the forward compatibility of the snapshot file, we only create a new "checksum file" for each snapshot, instead of adding a checksum at the end of the snapshot file. For example, the resulting file-tree of snapshot dir will be :
```shell
.
├── .checksum.apply
├── .checksum.dentry
├── .checksum.extend
├── .checksum.inode
├── .checksum.multipart
├── .sign
├── apply
├── dentry
├── extend
├── inode
└── multipart
```

To use md5 as the checksum function, the config file is similar to :
```json
{
  "role": "metanode",
  ....
  "checksumFunc": "md5"
}
```
To neglect the checksum-not-match error (i.e., checksum data corruption), the config file:
 ```json
{
  "role": "metanode",
  ....
  "ignoreChecksumError": "true"
}
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add configure "checksumFunc" for meta node：the value could be crc32|crc64|md5|sha1|sha256|sha512 (No case limit)
add configure "ignoreChecksumError" to neglect checksum not match error. (Once if the data is abnormal)
```
