### PR TITLE
fix: Authorize user with wrong policy but return success and update policy

### DIFF
--- a/master/user.go
+++ b/master/user.go
@@ -271,7 +271,10 @@ func (u *User) updatePolicy(params *proto.UserPermUpdateParam) (userInfo *proto.
 		err = proto.ErrIsOwner
 		return
 	}
-	userInfo.Policy.AddAuthorizedVol(params.Volume, params.Policy)
+	if !userInfo.Policy.AddAuthorizedVol(params.Volume, params.Policy) {
+		err = proto.ErrUnknownPolicy
+		return
+	}
 	if err = u.syncUpdateUserInfo(userInfo); err != nil {
 		err = proto.ErrPersistenceByRaft
 		return

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -81,6 +81,7 @@ var (
 	ErrInvalidAccessKey                = errors.New("invalid access key")
 	ErrInvalidSecretKey                = errors.New("invalid secret key")
 	ErrIsOwner                         = errors.New("user owns the volume")
+	ErrUnknownPolicy                   = errors.New("unknown policy")
 )
 
 // http response error code and error message definitions

--- a/proto/user_proto.go
+++ b/proto/user_proto.go
@@ -198,19 +198,26 @@ func (policy *UserPolicy) RemoveOwnVol(volume string) {
 	}
 }
 
-func (policy *UserPolicy) AddAuthorizedVol(volume string, policies []string) { //todo check duplicate
+func (policy *UserPolicy) AddAuthorizedVol(volume string, policies []string) bool { //todo check duplicate
 	policy.mu.Lock()
 	defer policy.mu.Unlock()
+	var formerLength, afterLength int
 	newPolicies := make([]string, 0)
 	for _, policy := range policies {
+		formerLength = len(newPolicies)
 		if perm := ParsePermission(policy); !perm.IsNone() {
 			newPolicies = append(newPolicies, perm.String())
 		}
 		if act := ParseAction(policy); !act.IsNone() {
 			newPolicies = append(newPolicies, act.String())
 		}
+		afterLength = len(newPolicies)
+		if afterLength == formerLength {
+			return false
+		}
 	}
 	policy.AuthorizedVols[volume] = newPolicies
+	return true
 }
 
 func (policy *UserPolicy) RemoveAuthorizedVol(volume string) {


### PR DESCRIPTION
Signed-off-by: zhangxiangping <240133996@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**when authorize a user with wrong policy,master should return error and  should not change the user's original policy

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
