### PR TITLE
fix: raft leader sending check quorum

### DIFF
--- a/vendor/github.com/tiglabs/raft/raft_fsm_follower.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_follower.go
@@ -70,7 +70,8 @@ func stepFollower(r *raftFsm, m *proto.Message) {
 
 	case proto.ReqCheckQuorum:
 		// TODO: remove this
-		if logger.IsEnableDebug() {
+		// Suppress logs if m.Index == 0
+		if m.Index != 0 && logger.IsEnableDebug() {
 			logger.Debug("raft[%d] recv check quorum from %d, index=%d", r.id, m.From, m.Index)
 		}
 		r.electionElapsed = 0


### PR DESCRIPTION
This commit forces raft leader to send check quorum message to other
inactive nodes. Otherwise, when inactive nodes are back online, there is
a chance that they don't receive check quorum messages and therefore
their fsm remains "noleader" status which lead to unnecessary leader
election.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
