### PR TITLE
fix: raft's vote don't increase the term

### DIFF
--- a/vendor/github.com/tiglabs/raft/raft_fsm.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm.go
@@ -20,9 +20,10 @@ import (
 	"math/rand"
 	"strings"
 
+	"time"
+
 	"github.com/tiglabs/raft/logger"
 	"github.com/tiglabs/raft/proto"
-	"time"
 )
 
 // NoLeader is a placeholder nodeID used when there is no leader.
@@ -175,6 +176,9 @@ func (r *raftFsm) StopFsm() {
 
 // raft main method
 func (r *raftFsm) Step(m *proto.Message) {
+	if m.Type == proto.RespMsgVote {
+		goto stepHandler
+	}
 	if m.Type == proto.LocalMsgHup {
 		if r.state != stateLeader && r.promotable() {
 			ents, err := r.raftLog.slice(r.raftLog.applied+1, r.raftLog.committed+1, noLimit)
@@ -224,7 +228,10 @@ func (r *raftFsm) Step(m *proto.Message) {
 				return
 			}
 		}
-		r.becomeFollower(m.Term, lead)
+
+		if m.LogTerm > r.raftLog.lastTerm() || (m.LogTerm == r.raftLog.lastTerm() && m.Index >= r.raftLog.lastIndex()) {
+			r.becomeFollower(m.Term, lead)
+		}
 
 	case m.Term < r.term:
 		if logger.IsEnableDebug() {
@@ -232,6 +239,7 @@ func (r *raftFsm) Step(m *proto.Message) {
 		}
 		return
 	}
+stepHandler:
 	r.step(r, m)
 }
 
@@ -343,7 +351,9 @@ func (r *raftFsm) quorum() int {
 func (r *raftFsm) send(m *proto.Message) {
 	m.ID = r.id
 	m.From = r.config.NodeID
-	if m.Type != proto.LocalMsgProp {
+	if m.Type == proto.ReqMsgVote {
+		m.Term = r.term + 1
+	} else if m.Type != proto.LocalMsgProp {
 		m.Term = r.term
 	}
 	r.msgs = append(r.msgs, m)
@@ -352,7 +362,6 @@ func (r *raftFsm) send(m *proto.Message) {
 func (r *raftFsm) reset(term, lasti uint64, isLeader bool) {
 	if r.term != term {
 		r.term = term
-		r.vote = NoLeader
 	}
 	r.leader = NoLeader
 	r.electionElapsed = 0

--- a/vendor/github.com/tiglabs/raft/raft_fsm_candidate.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_candidate.go
@@ -29,7 +29,7 @@ func (r *raftFsm) becomeCandidate() {
 
 	r.monitorElection()
 	r.step = stepCandidate
-	r.reset(r.term+1, 0, false)
+	r.reset(r.term, 0, false)
 	r.tick = r.tickElection
 	r.vote = r.config.NodeID
 	r.state = stateCandidate

--- a/vendor/github.com/tiglabs/raft/raft_fsm_leader.go
+++ b/vendor/github.com/tiglabs/raft/raft_fsm_leader.go
@@ -222,7 +222,7 @@ func (r *raftFsm) becomeElectionAck() {
 	logger.Debug("raft[%v] became election at term %d.", r.id, r.term)
 
 	r.step = stepElectionAck
-	r.reset(r.term, 0, false)
+	r.reset(r.term+1, 0, false)
 	r.tick = r.tickElectionAck
 	r.state = stateElectionACK
 	for id := range r.replicas {


### PR DESCRIPTION
raft don't allow to increase the term number when it's in the candidate phase, it only can increase the term number when it's in the electionACK phase.