### PR TITLE
enhance: upload docker_data after ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,19 @@ jobs:
   ci-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v2
       - name: Build and run CI tests
         run: |
           docker/run_docker.sh -t
           docker/run_docker.sh -l
+      - name: Pack docker_data
+        if: ${{ always() }}
+        run: pushd docker && sudo tar --exclude='docker_data/datanode*/disk' --exclude='docker_data/disk' -czvf docker_data.tar.gz docker_data
+      - name: Upload docker_data.tar.gz
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker_data
+          path: docker/docker_data.tar.gz
+          retention-days: 7

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -61,6 +61,7 @@ run_ltptest() {
     build
     start_servers
     start_ltptest
+    clean
 }
 
 run() {


### PR DESCRIPTION
This commit will upload docker_data directory after ci test finishes, so
the logs can be kept to debug tests failure.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
