### PR TITLE
refactor: do not expose owner in simple vol view

### DIFF
--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -52,7 +52,7 @@ const (
 
 	//Flags
 	CliFlagName               = "name"
-	CliFlagOnwer              = "user"
+	CliFlagOwner              = "owner"
 	CliFlagDataPartitionSize  = "dp-size"
 	CliFlagDataPartitionCount = "dp-count"
 	CliFlagMetaPartitionCount = "mp-count"

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -92,7 +92,6 @@ func formatSimpleVolView(svv *proto.SimpleVolView) string {
 	var sb = strings.Builder{}
 	sb.WriteString(fmt.Sprintf("  ID                   : %v\n", svv.ID))
 	sb.WriteString(fmt.Sprintf("  Name                 : %v\n", svv.Name))
-	sb.WriteString(fmt.Sprintf("  Owner                : %v\n", svv.Owner))
 	sb.WriteString(fmt.Sprintf("  Zone                 : %v\n", svv.ZoneName))
 	sb.WriteString(fmt.Sprintf("  Status               : %v\n", formatVolumeStatus(svv.Status)))
 	sb.WriteString(fmt.Sprintf("  Capacity             : %v GB\n", svv.Capacity))

--- a/cli/cmd/http_service.go
+++ b/cli/cmd/http_service.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/sdk/master"
 )
 
 type clientHandler interface {
-	excuteHttp() (err error)
+	excuteHttp(owner string) (err error)
 }
 
 type volumeClient struct {
@@ -23,28 +22,18 @@ func NewVolumeClient(opCode MasterOp, client *master.MasterClient) (vol *volumeC
 	return
 }
 
-func (vol *volumeClient) excuteHttp() (err error) {
+func (vol *volumeClient) excuteHttp(owner string) (err error) {
 	switch vol.opCode {
 	case OpExpandVol:
-		var vv *proto.SimpleVolView
-		if vv, err = vol.client.AdminAPI().GetVolumeSimpleInfo(vol.name); err != nil {
-			return
-		}
-		if err = vol.client.AdminAPI().VolExpand(vol.name, vol.capacity, calcAuthKey(vv.Owner)); err != nil {
+		if err = vol.client.AdminAPI().VolExpand(vol.name, vol.capacity, calcAuthKey(owner)); err != nil {
 			return
 		}
 	case OpShrinkVol:
-		var vv *proto.SimpleVolView
-		if vv, err = vol.client.AdminAPI().GetVolumeSimpleInfo(vol.name); err != nil {
-			return
-		}
-		if err = vol.client.AdminAPI().VolShrink(vol.name, vol.capacity, calcAuthKey(vv.Owner)); err != nil {
+		if err = vol.client.AdminAPI().VolShrink(vol.name, vol.capacity, calcAuthKey(owner)); err != nil {
 			return
 		}
 	case OpDeleteVol:
 	default:
-
 	}
-
 	return
 }

--- a/docker/script/run_test.sh
+++ b/docker/script/run_test.sh
@@ -223,7 +223,7 @@ stop_client() {
 
 delete_volume() {
     echo -n "Deleting volume   ... "
-    ${cli} volume delete ${VolName} -y &> /dev/null
+    ${cli} volume delete ${VolName} ${Owner} -y &> /dev/null
     if [[ $? -eq 0 ]]; then
         echo -e "\033[32mdone\033[0m"
         return

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -775,7 +775,6 @@ func newSimpleView(vol *Vol) *proto.SimpleVolView {
 	return &proto.SimpleVolView{
 		ID:                 vol.ID,
 		Name:               vol.Name,
-		Owner:              vol.Owner,
 		ZoneName:           vol.zoneName,
 		DpReplicaNum:       vol.dpReplicaNum,
 		MpReplicaNum:       vol.mpReplicaNum,

--- a/master/gapi_volume.go
+++ b/master/gapi_volume.go
@@ -56,7 +56,6 @@ func (s *VolumeService) registerObject(schema *schemabuilder.Schema) {
 		return &proto.SimpleVolView{
 			ID:                 vol.ID,
 			Name:               vol.Name,
-			Owner:              vol.Owner,
 			ZoneName:           vol.zoneName,
 			DpReplicaNum:       vol.dpReplicaNum,
 			MpReplicaNum:       vol.mpReplicaNum,

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -466,7 +466,6 @@ func NewMetaPartitionView(partitionID, start, end uint64, status int8) (mpView *
 type SimpleVolView struct {
 	ID                 uint64
 	Name               string
-	Owner              string
 	ZoneName           string
 	DpReplicaNum       uint8
 	MpReplicaNum       uint8

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -128,10 +128,10 @@ func (w *Wrapper) getSimpleVolView() (err error) {
 	w.dpSelectorName = view.DpSelectorName
 	w.dpSelectorParm = view.DpSelectorParm
 
-	log.LogInfof("getSimpleVolView: get volume simple info: ID(%v) name(%v) owner(%v) status(%v) capacity(%v) "+
+	log.LogInfof("getSimpleVolView: get volume simple info: ID(%v) name(%v) status(%v) capacity(%v) "+
 		"metaReplicas(%v) dataReplicas(%v) mpCnt(%v) dpCnt(%v) followerRead(%v) createTime(%v) dpSelectorName(%v) "+
 		"dpSelectorParm(%v)",
-		view.ID, view.Name, view.Owner, view.Status, view.Capacity, view.MpReplicaNum, view.DpReplicaNum, view.MpCnt,
+		view.ID, view.Name, view.Status, view.Capacity, view.MpReplicaNum, view.DpReplicaNum, view.MpCnt,
 		view.DpCnt, view.FollowerRead, view.CreateTime, view.DpSelectorName, view.DpSelectorParm)
 	return nil
 }


### PR DESCRIPTION
Do not expose the 'owner' field in simple volume view response for
the sake of security.

Signed-off-by: Shuoran Liu <shuoranliu@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
