### PR TITLE
[RFC] metanode: Load snapshot file with multiple goroutines

### DIFF
--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -73,6 +73,7 @@ const (
 	CliFlagDelWorkerSleepMs   = "delete-worker-sleep-ms"
 	CliFlagMarkDelRate        = "mark-delete-rate"
 	CliFlagCrossZone          = "crossZone"
+	CliFlagMetaFileBlock      = "mf-blksize"
 
 	//CliFlagSetDataPartitionCount	= "count" use dp-count instead
 

--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -94,6 +94,7 @@ const (
 	cmdVolDefaultFollowerReader = true
 	cmdVolDefaultZoneName       = ""
 	cmdVolDefaultCrossZone      = false
+	cmdVolDefaultMetaFileBlock  = 0 // MB
 )
 
 func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
@@ -105,6 +106,7 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 	var optYes bool
 	var optCrossZone bool
 	var optZoneName string
+	var optMetaFileBlock uint64
 	var cmd = &cobra.Command{
 		Use:   cmdVolCreateUse,
 		Short: cmdVolCreateShort,
@@ -129,7 +131,8 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 				stdout("  Replicas            : %v\n", optReplicas)
 				stdout("  Allow follower read : %v\n", formatEnabledDisabled(optFollowerRead))
 				stdout("  ZoneName            : %v\n", optZoneName)
-				stdout("  CrossZone            : %v\n", optCrossZone)
+				stdout("  CrossZone           : %v\n", optCrossZone)
+				stdout("  Metafile block size : %v MB\n", optMetaFileBlock)
 				stdout("\nConfirm (yes/no)[yes]: ")
 				var userConfirm string
 				_, _ = fmt.Scanln(&userConfirm)
@@ -141,7 +144,8 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 
 			err = client.AdminAPI().CreateVolume(
 				volumeName, userID, optMPCount, optDPSize,
-				optCapacity, optReplicas, optFollowerRead, optZoneName, optCrossZone)
+				optCapacity, optReplicas, optFollowerRead, optZoneName,
+				optCrossZone, optMetaFileBlock)
 			if err != nil {
 				err = fmt.Errorf("Create volume failed case:\n%v\n", err)
 				return
@@ -158,6 +162,7 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optZoneName, CliFlagZoneName, cmdVolDefaultZoneName, "Specify volume zone name")
 	cmd.Flags().BoolVarP(&optYes, "yes", "y", false, "Answer yes for all questions")
 	cmd.Flags().BoolVar(&optCrossZone, CliFlagCrossZone, cmdVolDefaultCrossZone, "Disable cross zone")
+	cmd.Flags().Uint64Var(&optMetaFileBlock, CliFlagMetaFileBlock, cmdVolDefaultMetaFileBlock, "Meta file block size")
 
 	return cmd
 }

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -102,7 +102,7 @@ func createDefaultMasterServerForTest() *Server {
 	testServer.cluster.checkMetaNodeHeartbeat()
 	time.Sleep(5 * time.Second)
 	testServer.cluster.scheduleToUpdateStatInfo()
-	vol, err := testServer.cluster.createVol(commonVolName, "cfs", testZone2, "", 3, 3, 3, 100, false, false, false, false)
+	vol, err := testServer.cluster.createVol(commonVolName, "cfs", testZone2, "", 3, 3, 3, 100, 0, false, false, false, false)
 	if err != nil {
 		panic(err)
 	}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1727,7 +1727,7 @@ func (c *Cluster) checkVolInfo(name string, crossZone bool, zoneName string) (ne
 // Create a new volume.
 // By default we create 3 meta partitions and 10 data partitions during initialization.
 func (c *Cluster) createVol(name, owner, zoneName, description string,
-	mpCount, dpReplicaNum, size, capacity int,
+	mpCount, dpReplicaNum, size, capacity, metaFileBlock int,
 	followerRead, authenticate, crossZone, defaultPriority bool) (vol *Vol, err error) {
 	var (
 		dataPartitionSize       uint64
@@ -1750,9 +1750,8 @@ func (c *Cluster) createVol(name, owner, zoneName, description string,
 	}
 	zoneName = newZoneName
 	if vol, err = c.doCreateVol(name, owner, zoneName, description,
-		dataPartitionSize, uint64(capacity), dpReplicaNum,
-		followerRead, authenticate, crossZone,
-		defaultPriority); err != nil {
+		dataPartitionSize, uint64(capacity), dpReplicaNum, uint32(metaFileBlock),
+		followerRead, authenticate, crossZone, defaultPriority); err != nil {
 		goto errHandler
 	}
 	if err = vol.initMetaPartitions(c, mpCount); err != nil {
@@ -1782,9 +1781,8 @@ errHandler:
 }
 
 func (c *Cluster) doCreateVol(name, owner, zoneName, description string,
-	dpSize, capacity uint64, dpReplicaNum int,
-	followerRead, authenticate, crossZone,
-	defaultPriority bool) (vol *Vol, err error) {
+	dpSize, capacity uint64, dpReplicaNum int, metaFileBlock uint32,
+	followerRead, authenticate, crossZone, defaultPriority bool) (vol *Vol, err error) {
 	var id uint64
 	c.createVolMutex.Lock()
 	defer c.createVolMutex.Unlock()
@@ -1798,9 +1796,9 @@ func (c *Cluster) doCreateVol(name, owner, zoneName, description string,
 		goto errHandler
 	}
 	vol = newVol(id, name, owner, zoneName, dpSize,
-		capacity, uint8(dpReplicaNum), defaultReplicaNum,
-		followerRead, authenticate, crossZone,
-		defaultPriority, createTime, description)
+		capacity, uint8(dpReplicaNum), defaultReplicaNum, metaFileBlock,
+		followerRead, authenticate, crossZone, defaultPriority,
+		createTime, description)
 	// refresh oss secure
 	vol.refreshOSSSecure()
 	if err = c.syncAddVol(vol); err != nil {

--- a/master/cluster_test.go
+++ b/master/cluster_test.go
@@ -2,9 +2,10 @@ package master
 
 import (
 	"fmt"
-	"github.com/chubaofs/chubaofs/proto"
 	"testing"
 	"time"
+
+	"github.com/chubaofs/chubaofs/proto"
 )
 
 func buildPanicCluster() *Cluster {
@@ -21,7 +22,7 @@ func buildPanicVol() *Vol {
 	}
 	var createTime = time.Now().Unix() // record create time of this volume
 	vol := newVol(id, commonVol.Name, commonVol.Owner, "", commonVol.dataPartitionSize, commonVol.Capacity,
-		defaultReplicaNum, defaultReplicaNum, false, false, false, false, createTime, "")
+		defaultReplicaNum, defaultReplicaNum, 0, false, false, false, false, createTime, "")
 	vol.dataPartitions = nil
 	return vol
 }
@@ -74,7 +75,7 @@ func TestPanicCheckMetaPartitions(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	mp := newMetaPartition(partitionID, 1, defaultMaxMetaPartitionInodeID, vol.mpReplicaNum, vol.Name, vol.ID)
+	mp := newMetaPartition(partitionID, 1, defaultMaxMetaPartitionInodeID, vol.mpReplicaNum, vol.Name, vol.ID, 0)
 	vol.addMetaPartition(mp)
 	mp = nil
 	c.checkMetaPartitions()
@@ -187,7 +188,7 @@ func TestPanicCheckBadMetaPartitionRecovery(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	dp := newMetaPartition(partitionID, 0, defaultMaxMetaPartitionInodeID, vol.mpReplicaNum, vol.Name, vol.ID)
+	dp := newMetaPartition(partitionID, 0, defaultMaxMetaPartitionInodeID, vol.mpReplicaNum, vol.Name, vol.ID, 0)
 	c.BadMetaPartitionIds.Store(fmt.Sprintf("%v", dp.PartitionID), dp)
 	c.scheduleToCheckMetaPartitionRecoveryProgress()
 }

--- a/master/const.go
+++ b/master/const.go
@@ -34,6 +34,7 @@ const (
 	dataPartitionSizeKey    = "size"
 	metaPartitionCountKey   = "mpCount"
 	volCapacityKey          = "capacity"
+	metaFileBlockKey        = "metaFileBlock"
 	volOwnerKey             = "owner"
 	volAuthKey              = "authKey"
 	replicaNumKey           = "replicaNum"

--- a/master/gapi_volume.go
+++ b/master/gapi_volume.go
@@ -173,9 +173,9 @@ func (s *VolumeService) volPermission(ctx context.Context, args struct {
 }
 
 func (s *VolumeService) createVolume(ctx context.Context, args struct {
-	Name, Owner, ZoneName, Description                     string
-	Capacity, DataPartitionSize, MpCount, DpReplicaNum     uint64
-	FollowerRead, Authenticate, CrossZone, DefaultPriority bool
+	Name, Owner, ZoneName, Description                                string
+	Capacity, DataPartitionSize, MpCount, DpReplicaNum, MetaFileBlock uint64
+	FollowerRead, Authenticate, CrossZone, DefaultPriority            bool
 }) (*Vol, error) {
 	uid, per, err := permissions(ctx, ADMIN|USER)
 	if err != nil {
@@ -191,7 +191,7 @@ func (s *VolumeService) createVolume(ctx context.Context, args struct {
 	}
 
 	vol, err := s.cluster.createVol(args.Name, args.Owner, args.ZoneName, args.Description, int(args.MpCount),
-		int(args.DpReplicaNum), int(args.DataPartitionSize), int(args.Capacity),
+		int(args.DpReplicaNum), int(args.DataPartitionSize), int(args.Capacity), int(args.MetaFileBlock),
 		args.FollowerRead, args.Authenticate, args.CrossZone, args.DefaultPriority)
 	if err != nil {
 		return nil, err

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -68,6 +68,7 @@ type metaPartitionValue struct {
 	OfflinePeerID uint64
 	Peers         []bsProto.Peer
 	IsRecover     bool
+	MetaFileBlock uint32
 }
 
 func newMetaPartitionValue(mp *MetaPartition) (mpv *metaPartitionValue) {
@@ -83,6 +84,7 @@ func newMetaPartitionValue(mp *MetaPartition) (mpv *metaPartitionValue) {
 		Peers:         mp.Peers,
 		OfflinePeerID: mp.OfflinePeerID,
 		IsRecover:     mp.IsRecover,
+		MetaFileBlock: mp.MetaFileBlock,
 	}
 	return
 }
@@ -133,6 +135,7 @@ type volValue struct {
 	Status            uint8
 	DataPartitionSize uint64
 	Capacity          uint64
+	MetaFileBlock     uint32
 	Owner             string
 	FollowerRead      bool
 	Authenticate      bool
@@ -162,6 +165,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		Status:            vol.Status,
 		DataPartitionSize: vol.dataPartitionSize,
 		Capacity:          vol.Capacity,
+		MetaFileBlock:     vol.MetaFileBlock,
 		Owner:             vol.Owner,
 		FollowerRead:      vol.FollowerRead,
 		Authenticate:      vol.authenticate,
@@ -824,7 +828,7 @@ func (c *Cluster) loadMetaPartitions() (err error) {
 				mpv.Peers[i].ID = mn.(*MetaNode).ID
 			}
 		}
-		mp := newMetaPartition(mpv.PartitionID, mpv.Start, mpv.End, vol.mpReplicaNum, vol.Name, mpv.VolID)
+		mp := newMetaPartition(mpv.PartitionID, mpv.Start, mpv.End, vol.mpReplicaNum, vol.Name, mpv.VolID, vol.MetaFileBlock)
 		mp.setHosts(strings.Split(mpv.Hosts, underlineSeparator))
 		mp.setPeers(mpv.Peers)
 		mp.OfflinePeerID = mpv.OfflinePeerID

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -19,13 +19,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/exporter"
 	"github.com/chubaofs/chubaofs/util/log"
-	"math/rand"
-	"strings"
-	"time"
 )
 
 func newCreateDataPartitionRequest(volName string, ID uint64, members []proto.Peer, dataPartitionSize int, hosts []string, createType int) (req *proto.CreateDataPartitionRequest) {
@@ -172,6 +173,10 @@ func WarnBySpecialKey(key, msg string) {
 
 func keyNotFound(name string) (err error) {
 	return errors.NewErrorf("parameter %v not found", name)
+}
+
+func keyInvalid(name string) (err error) {
+	return errors.NewErrorf("parameter %v invalid", name)
 }
 
 func unmatchedKey(name string) (err error) {

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -2,11 +2,12 @@ package master
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/log"
-	"testing"
-	"time"
 )
 
 func TestAutoCreateDataPartitions(t *testing.T) {
@@ -214,12 +215,12 @@ func TestConcurrentReadWriteDataPartitionMap(t *testing.T) {
 	var volID uint64 = 1
 	var createTime = time.Now().Unix()
 	vol := newVol(volID, name, name, "", util.DefaultDataPartitionSize, 100, defaultReplicaNum,
-		defaultReplicaNum, false, false, false, false, createTime, "")
+		defaultReplicaNum, 0, false, false, false, false, createTime, "")
 	// unavailable mp
-	mp1 := newMetaPartition(1, 1, defaultMaxMetaPartitionInodeID, 3, name, volID)
+	mp1 := newMetaPartition(1, 1, defaultMaxMetaPartitionInodeID, 3, name, volID, 0)
 	vol.addMetaPartition(mp1)
 	//readonly mp
-	mp2 := newMetaPartition(2, 1, defaultMaxMetaPartitionInodeID, 3, name, volID)
+	mp2 := newMetaPartition(2, 1, defaultMaxMetaPartitionInodeID, 3, name, volID, 0)
 	mp2.Status = proto.ReadOnly
 	vol.addMetaPartition(mp2)
 	vol.updateViewCache(server.cluster)

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -404,16 +404,17 @@ func (m *metadataManager) createPartition(request *proto.CreateMetaPartitionRequ
 	partitionId := fmt.Sprintf("%d", request.PartitionID)
 
 	mpc := &MetaPartitionConfig{
-		PartitionId: request.PartitionID,
-		VolName:     request.VolName,
-		Start:       request.Start,
-		End:         request.End,
-		Cursor:      request.Start,
-		Peers:       request.Members,
-		RaftStore:   m.raftStore,
-		NodeId:      m.nodeId,
-		RootDir:     path.Join(m.rootDir, partitionPrefix+partitionId),
-		ConnPool:    m.connPool,
+		PartitionId:   request.PartitionID,
+		VolName:       request.VolName,
+		Start:         request.Start,
+		End:           request.End,
+		Cursor:        request.Start,
+		MetaFileBlock: request.MetaFileBlock,
+		Peers:         request.Members,
+		RaftStore:     m.raftStore,
+		NodeId:        m.nodeId,
+		RootDir:       path.Join(m.rootDir, partitionPrefix+partitionId),
+		ConnPool:      m.connPool,
 	}
 	mpc.AfterStop = func() {
 		m.detachPartition(request.PartitionID)

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -482,21 +482,23 @@ func (mp *metaPartition) store(sm *storeMsg) (err error) {
 		}
 	}()
 	var crcBuffer = bytes.NewBuffer(make([]byte, 0, 16))
-	var storeFuncs = []func(dir string, sm *storeMsg) (uint32, error){
+	var storeFuncs = []func(dir string, sm *storeMsg) ([2]uint32, error){
 		mp.storeInode,
 		mp.storeDentry,
 		mp.storeExtend,
 		mp.storeMultipart,
 	}
 	for _, storeFunc := range storeFuncs {
-		var crc uint32
+		var crc [2]uint32
 		if crc, err = storeFunc(tmpDir, sm); err != nil {
 			return
 		}
-		if crcBuffer.Len() != 0 {
-			crcBuffer.WriteString(" ")
+		for _, v := range crc {
+			if crcBuffer.Len() != 0 {
+				crcBuffer.WriteString(" ")
+			}
+			crcBuffer.WriteString(fmt.Sprintf("%d", v))
 		}
-		crcBuffer.WriteString(fmt.Sprintf("%d", crc))
 	}
 	if err = mp.storeApplyID(tmpDir, sm); err != nil {
 		return

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -651,7 +651,8 @@ func (mp *metaPartition) Reset() (err error) {
 	mp.applyID = 0
 
 	// remove files
-	filenames := []string{applyIDFile, dentryFile, inodeFile, extendFile, multipartFile}
+	filenames := []string{applyIDFile, dentryFileLarge, dentryFileSmall, inodeFileLarge,
+		inodeFileSmall, extendFileLarge, extendFileSmall, multipartFileLarge, multipartFileSmall}
 	for _, filename := range filenames {
 		filepath := path.Join(mp.config.RootDir, filename)
 		if err = os.Remove(filepath); err != nil {

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -460,19 +460,7 @@ func (mp *metaPartition) load() (err error) {
 		return
 	}
 	snapshotPath := path.Join(mp.config.RootDir, snapshotDir)
-	if err = mp.loadInode(snapshotPath); err != nil {
-		return
-	}
-	if err = mp.loadDentry(snapshotPath); err != nil {
-		return
-	}
-	if err = mp.loadExtend(snapshotPath); err != nil {
-		return
-	}
-	if err = mp.loadMultipart(snapshotPath); err != nil {
-		return
-	}
-	err = mp.loadApplyID(snapshotPath)
+	err = mp.LoadSnapshot(snapshotPath)
 	return
 }
 

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -643,68 +643,100 @@ func (mp *metaPartition) storeDentry(rootDir string, sm *storeMsg) (crc [2]uint3
 	return
 }
 
-func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc uint32, err error) {
-	var extendTree = sm.extendTree
-	var fp = path.Join(rootDir, extendFileLarge)
-	var f *os.File
-	f, err = os.OpenFile(fp, os.O_RDWR|os.O_TRUNC|os.O_APPEND|os.O_CREATE, 0755)
-	if err != nil {
+func storeToSnapshot2(fp *os.File, crc hash.Hash32, data []byte, length []byte) (err error) {
+	// set length
+	if _, err = fp.Write(length); err != nil {
 		return
 	}
-	defer func() {
-		closeErr := f.Close()
-		if err == nil && closeErr != nil {
-			err = closeErr
-		}
-	}()
-	var writer = bufio.NewWriterSize(f, 4*1024*1024)
-	var crc32 = crc32.NewIEEE()
-	var varintTmp = make([]byte, binary.MaxVarintLen64)
-	var n int
-	// write number of extends
-	n = binary.PutUvarint(varintTmp, uint64(extendTree.Len()))
-	if _, err = writer.Write(varintTmp[:n]); err != nil {
+	if _, err = crc.Write(length); err != nil {
 		return
 	}
-	if _, err = crc32.Write(varintTmp[:n]); err != nil {
+	// set body
+	if _, err = fp.Write(data); err != nil {
 		return
 	}
-	extendTree.Ascend(func(i BtreeItem) bool {
+	if _, err = crc.Write(data); err != nil {
+		return
+	}
+	return
+}
+
+func storeDummyNum(fp *os.File, crc hash.Hash32) (err error) {
+	// write a dummy extend number to the fileLarge
+	varintTmp := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(varintTmp, 0)
+	if _, err = fp.Write(varintTmp[:n]); err != nil {
+		return
+	}
+	if _, err = crc.Write(varintTmp[:n]); err != nil {
+		return
+	}
+	return
+}
+
+func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc [2]uint32, err error) {
+	var (
+		fpLarge  *os.File
+		fpSmall  *os.File
+		posSmall int64
+		hdr      *SmallFileHeader
+	)
+
+	defer closeSnapshotFiles(fpSmall, fpLarge)
+
+	if fpSmall, fpLarge, err = prepareSnapshotFiles(rootDir, extendFileSmall, extendFileLarge); err != nil {
+		return
+	}
+
+	var data []byte
+	signLarge := crc32.NewIEEE()
+	signSmall := crc32.NewIEEE()
+
+	if err = storeDummyNum(fpLarge, signLarge); err != nil {
+		return
+	}
+	if hdr, err = storeSmallFileHeader(fpSmall, signSmall); err != nil {
+		return
+	}
+	posSmall += smallFileHeaderSize
+
+	varintTmp := make([]byte, binary.MaxVarintLen64)
+	sm.extendTree.Ascend(func(i BtreeItem) bool {
 		e := i.(*Extend)
-		var raw []byte
-		if raw, err = e.Bytes(); err != nil {
+		if data, err = e.Bytes(); err != nil {
 			return false
 		}
-		// write length
-		n = binary.PutUvarint(varintTmp, uint64(len(raw)))
-		if _, err = writer.Write(varintTmp[:n]); err != nil {
+
+		n := binary.PutUvarint(varintTmp, uint64(len(data)))
+		if int64(n)+int64(len(data)) > int64(hdr.blockSize) {
+			if err = storeToSnapshot2(fpLarge, signLarge, data, varintTmp[:n]); err != nil {
+				return false
+			}
+			return true
+		}
+
+		if (posSmall%int64(hdr.blockSize))+int64(n)+int64(len(data)) > int64(hdr.blockSize) {
+			// round up to blockSize alignment
+			posSmall = (posSmall + int64(hdr.blockSize) - 1) / int64(hdr.blockSize) * int64(hdr.blockSize)
+			fpSmall.Seek(posSmall, os.SEEK_SET)
+		}
+		if err = storeToSnapshot2(fpSmall, signSmall, data, varintTmp[:n]); err != nil {
 			return false
 		}
-		if _, err = crc32.Write(varintTmp[:n]); err != nil {
-			return false
-		}
-		// write raw
-		if _, err = writer.Write(raw); err != nil {
-			return false
-		}
-		if _, err = crc32.Write(raw); err != nil {
-			return false
-		}
+
+		posSmall += (int64(n) + int64(len(data)))
 		return true
 	})
 	if err != nil {
 		return
 	}
 
-	if err = writer.Flush(); err != nil {
-		return
-	}
-	if err = f.Sync(); err != nil {
-		return
-	}
-	crc = crc32.Sum32()
+	crc[0] = signLarge.Sum32()
+	crc[1] = signSmall.Sum32()
+
 	log.LogInfof("storeExtend: store complete: partitoinID(%v) volume(%v) numExtends(%v) crc(%v)",
-		mp.config.PartitionId, mp.config.VolName, extendTree.Len(), crc)
+		mp.config.PartitionId, mp.config.VolName, sm.extendTree.Len(), crc)
+
 	return
 }
 

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -188,9 +188,10 @@ func (mp *metaPartition) loadMetadata() (err error) {
 	mp.config.End = mConf.End
 	mp.config.Peers = mConf.Peers
 	mp.config.Cursor = mp.config.Start
+	mp.config.MetaFileBlock = mConf.MetaFileBlock
 
-	log.LogInfof("loadMetadata: load complete: partitionID(%v) volume(%v) range(%v,%v) cursor(%v)",
-		mp.config.PartitionId, mp.config.VolName, mp.config.Start, mp.config.End, mp.config.Cursor)
+	log.LogInfof("loadMetadata: load complete: partitionID(%v) volume(%v) range(%v,%v) cursor(%v) metaFileBlock(%v)",
+		mp.config.PartitionId, mp.config.VolName, mp.config.Start, mp.config.End, mp.config.Cursor, mp.config.MetaFileBlock)
 	return
 }
 

--- a/proto/meta_proto.go
+++ b/proto/meta_proto.go
@@ -14,6 +14,8 @@
 
 package proto
 
+const DefaultMetaFileBlockMax = 4096
+
 // CreateNameSpaceRequest defines the request to create a name space.
 type CreateNameSpaceRequest struct {
 	Name string
@@ -33,12 +35,13 @@ type Peer struct {
 
 // CreateMetaPartitionRequest defines the request to create a meta partition.
 type CreateMetaPartitionRequest struct {
-	MetaId      string
-	VolName     string
-	Start       uint64
-	End         uint64
-	PartitionID uint64
-	Members     []Peer
+	MetaId        string
+	VolName       string
+	Start         uint64
+	End           uint64
+	PartitionID   uint64
+	MetaFileBlock uint32
+	Members       []Peer
 }
 
 // CreateMetaPartitionResponse defines the response to the request of creating a meta partition.

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -246,7 +246,8 @@ func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey string) 
 }
 
 func (api *AdminAPI) CreateVolume(volName, owner string, mpCount int,
-	dpSize uint64, capacity uint64, replicas int, followerRead bool, zoneName string, crossZone bool) (err error) {
+	dpSize uint64, capacity uint64, replicas int, followerRead bool, zoneName string,
+	crossZone bool, metaFileBlock uint64) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminCreateVol)
 	request.addParam("name", volName)
 	request.addParam("owner", owner)
@@ -256,6 +257,7 @@ func (api *AdminAPI) CreateVolume(volName, owner string, mpCount int,
 	request.addParam("followerRead", strconv.FormatBool(followerRead))
 	request.addParam("zoneName", zoneName)
 	request.addParam("crossZone", strconv.FormatBool(crossZone))
+	request.addParam("metaFileBlock", strconv.FormatUint(metaFileBlock, 10))
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}


### PR DESCRIPTION
This patchset introduces a new format of snapshot files in metanode.
In order to distinguish between the new and old format, the new one
is called small file while the old one is called large file.

Small file is composed of fixed-size blocks, in which continous
entries are saved. If an entry is larger than a block, the entry is
saved to large file.

When metanode loads snapshot file during booting, multiple routines
load blocks of small file concurrency to reduce boot time.

cfs-cli is also adjusted to enable small file when creating a new
volume. Otherwise, small file is disabled by default.

The performance is tested with a large snapshot/inode file, which
has 133333338 Inode entries.

Without small file:

| snapshot size | read block size | load time |
| ------------- | --------------- | --------- |
| 12G           | 4M              | 1m35.238  |
| 12G           | 32M             | 1m35.470  |
| 12G           | 64M             | 1m32.916  |

With small file:

| snapshot size | read block size | routines | load time |
| --------------| --------------- | -------- | --------- |
| 12G           | 4M              | 128      | 49.574s   |
| 12G           | 4M              | 64       | 47.502s   |
| 12G           | 4M              | 16       | 48.353s   |
| 12G           | 4M              | 32       | 49.772s   |
| 12G           | 32M             | 32       | 49.252s   |
| 12G           | 64M             | 32       | 54.584s   |