### PR TITLE
Simple auth for master administration APIs

### DIFF
--- a/authtool/authtool.go
+++ b/authtool/authtool.go
@@ -444,6 +444,7 @@ func main() {
 	ticketCmd := flag.NewFlagSet("ticket", flag.ExitOnError)
 	apiCmd := flag.NewFlagSet("api", flag.ExitOnError)
 	authkeyCmd := flag.NewFlagSet("authkey", flag.ExitOnError)
+	signCmd := flag.NewFlagSet("sign", flag.ExitOnError)
 
 	switch os.Args[1] {
 	case "ticket":
@@ -515,9 +516,32 @@ func main() {
 			}
 			keyInfo.DumpJSONFile(*output[i])
 		}
+	case "sign":
+		userID := signCmd.String("user", "", "user ID")
+		accessKey := signCmd.String("ak", "", "access key of user")
+		secretKey := signCmd.String("sk", "", "secret key of user")
+		path := signCmd.String("path", "", "API path")
+		signCmd.Parse(os.Args[2:])
+
+		if signCmd.NFlag() != 4 {
+			flag.Usage()
+			signCmd.PrintDefaults()
+			os.Exit(1)
+		}
+
+		user := &proto.AuthUser{*userID, *accessKey, *secretKey}
+		sign, err := user.GenerateSignature(*path)
+		if err != nil {
+			panic(fmt.Errorf("failed to generate signature: %v\n", err))
+		}
+		signature, err := json.Marshal(sign)
+		if err != nil {
+			panic(fmt.Errorf("failed to marshal signature: %v\n", err))
+		}
+		fmt.Println(string(signature))
 
 	default:
-		fmt.Println("expected 'ticket', 'api' or 'authkey'subcommands")
+		fmt.Println("expected 'ticket', 'api', 'authkey' or 'sign' subcommands")
 		os.Exit(1)
 	}
 }

--- a/cli/cli-sample.json
+++ b/cli/cli-sample.json
@@ -1,5 +1,13 @@
 {
   "masterAddr": [
     "master.chubao.io"
+  ],
+  "timeout": 60,
+  "users": [
+    {
+      "userID": "user ID",
+      "accessKey": "user's access key value",
+      "secretKey": "user's secret key value"
+    }
   ]
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -46,6 +46,7 @@ func runCLI() (err error) {
 func setupCommands(cfg *cmd.Config) *cobra.Command {
 	var mc = master.NewMasterClient(cfg.MasterAddr, false)
 	mc.SetTimeout(cfg.Timeout)
+	mc.SetUsers(cfg.AuthUsers)
 	cfsRootCmd := cmd.NewRootCmd(mc)
 	var completionCmd = &cobra.Command{
 		Use:   "completion",

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -29,6 +29,7 @@ func formatClusterView(cv *proto.ClusterView) string {
 	sb.WriteString(fmt.Sprintf("  Cluster name       : %v\n", cv.Name))
 	sb.WriteString(fmt.Sprintf("  Master leader      : %v\n", cv.LeaderAddr))
 	sb.WriteString(fmt.Sprintf("  Auto allocate      : %v\n", formatEnabledDisabled(!cv.DisableAutoAlloc)))
+	sb.WriteString(fmt.Sprintf("  Simple Auth        : %v\n", formatEnabledDisabled(cv.EnableSimpleAuth)))
 	sb.WriteString(fmt.Sprintf("  MetaNode count     : %v\n", len(cv.MetaNodes)))
 	sb.WriteString(fmt.Sprintf("  MetaNode used      : %v GB\n", cv.MetaNodeStatInfo.UsedGB))
 	sb.WriteString(fmt.Sprintf("  MetaNode total     : %v GB\n", cv.MetaNodeStatInfo.TotalGB))

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -376,6 +376,11 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 func checkPermission(opt *proto.MountOptions) (err error) {
 	var mc = master.NewMasterClientFromString(opt.Master, false)
 
+	user := &proto.AuthUser{opt.Owner, opt.AccessKey, opt.SecretKey}
+	users := make([]*proto.AuthUser, 0)
+	users = append(users, user)
+	mc.SetUsers(users)
+
 	// Check user access policy is enabled
 	if opt.AccessKey != "" {
 		var userInfo *proto.UserInfo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,11 @@ RUN  mkdir -p /tmp/ltp /opt/ltp && cd /tmp/ltp \
 RUN apt-get install -y sudo python3 python3-pip
 RUN pip3 install boto3 unittest2 requests
 
+# install ssh server for master to allow login
+RUN apt-get install -y openssh-server
+
+# install tools
+RUN apt-get install -y jq fuse
+
 # cleanup environment
-RUN apt-get install -y jq fuse \
-        && rm -rf /var/lib/apt/lists/* \
-        && apt-get clean
+RUN rm -rf /var/lib/apt/lists/* && apt-get clean

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 RootPath=$(cd $(dirname $0) ; pwd)
-CfsBase="ghcr.io/chubaofs/cbfs-base:1.0"
+CfsBase="ghcr.io/chubaofs/cbfs-base:1.1"
 
 docker build -t ${CfsBase} -f ${RootPath}/Dockerfile ${RootPath}

--- a/docker/conf/master1.json
+++ b/docker/conf/master1.json
@@ -13,5 +13,6 @@
   "logDir": "/cfs/log",
   "walDir": "/cfs/data/wal",
   "storeDir": "/cfs/data/store",
-  "metaNodeReservedMem": "67108864"
+  "metaNodeReservedMem": "67108864",
+  "enableSimpleAuth": false
 }

--- a/docker/conf/master2.json
+++ b/docker/conf/master2.json
@@ -13,5 +13,6 @@
   "logDir": "/cfs/log",
   "walDir": "/cfs/data/wal",
   "storeDir": "/cfs/data/store",
-  "metaNodeReservedMem": "67108864"
+  "metaNodeReservedMem": "67108864",
+  "enableSimpleAuth": false
 }

--- a/docker/conf/master3.json
+++ b/docker/conf/master3.json
@@ -13,5 +13,6 @@
   "logDir": "/cfs/log",
   "walDir": "/cfs/data/wal",
   "storeDir": "/cfs/data/store",
-  "metaNodeReservedMem": "67108864"
+  "metaNodeReservedMem": "67108864",
+  "enableSimpleAuth": false
 }

--- a/docker/conf/objectnode.json
+++ b/docker/conf/objectnode.json
@@ -25,5 +25,8 @@
     "action:oss:CreateBucket",
     "action:oss:DeleteBucket"
   ],
-  "strict": true
+  "strict": true,
+  "user": "root",
+  "accessKey": "root's access key value",
+  "secretKey": "root's secret key value"
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 
 services:
     monitor:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         depends_on:
             - consul
             - prometheus
@@ -18,7 +18,7 @@ services:
             extnetwork:
 
     servers:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         depends_on:
             - master1
             - master2
@@ -40,7 +40,7 @@ services:
             extnetwork:
 
     master1:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "5901"
             - "5902"
@@ -48,10 +48,11 @@ services:
             - "17020"
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/authorized_keys:/root/authorized_keys:ro
             - ${DiskPath:-./docker_data}/master1/data:/cfs/data
             - ./bin:/cfs/bin:ro
             - ${DiskPath:-./docker_data}/master1/log:/cfs/log
-            - ./conf/master1.json:/cfs/conf/master.json
+            - ./conf/master1.json:/root/master.json:ro
             - ./script/start_master.sh:/cfs/script/start.sh
         command: /bin/sh /cfs/script/start.sh
         restart: on-failure
@@ -61,7 +62,7 @@ services:
                 ipv4_address: 192.168.0.11
 
     master2:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "5901"
             - "5902"
@@ -69,10 +70,11 @@ services:
             - "17020"
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/authorized_keys:/root/authorized_keys:ro
             - ${DiskPath:-./docker_data}/master2/data:/cfs/data
             - ./bin:/cfs/bin:ro
             - ${DiskPath:-./docker_data}/master2/log:/cfs/log
-            - ./conf/master2.json:/cfs/conf/master.json
+            - ./conf/master2.json:/root/master.json:ro
             - ./script/start_master.sh:/cfs/script/start.sh
         command: /bin/sh /cfs/script/start.sh
         restart: on-failure
@@ -81,7 +83,7 @@ services:
             extnetwork:
                 ipv4_address: 192.168.0.12
     master3:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "5901"
             - "5902"
@@ -89,10 +91,11 @@ services:
             - "17020"
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/authorized_keys:/root/authorized_keys:ro
             - ${DiskPath:-./docker_data}/master3/data:/cfs/data
             - ./bin:/cfs/bin:ro
             - ${DiskPath:-./docker_data}/master3/log:/cfs/log
-            - ./conf/master3.json:/cfs/conf/master.json
+            - ./conf/master3.json:/root/master.json:ro
             - ./script/start_master.sh:/cfs/script/start.sh
         command: /bin/sh /cfs/script/start.sh
         restart: on-failure
@@ -102,7 +105,7 @@ services:
                 ipv4_address: 192.168.0.13
 
     metanode1:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17210"
             - "17220"
@@ -123,7 +126,7 @@ services:
                 ipv4_address: 192.168.0.21
 
     metanode2:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17210"
             - "17220"
@@ -144,7 +147,7 @@ services:
                 ipv4_address: 192.168.0.22
 
     metanode3:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17210"
             - "17220"
@@ -165,7 +168,7 @@ services:
                 ipv4_address: 192.168.0.23
 
     metanode4:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17210"
             - "17220"
@@ -186,7 +189,7 @@ services:
                 ipv4_address: 192.168.0.24
 
     datanode1:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17310"
             - "17320"
@@ -207,7 +210,7 @@ services:
                 ipv4_address: 192.168.0.31
 
     datanode2:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17310"
             - "17320"
@@ -228,7 +231,7 @@ services:
                 ipv4_address: 192.168.0.32
 
     datanode3:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17310"
             - "17320"
@@ -249,7 +252,7 @@ services:
                 ipv4_address: 192.168.0.33
 
     datanode4:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "17310"
             - "17320"
@@ -270,16 +273,17 @@ services:
                 ipv4_address: 192.168.0.34
 
     objectnode1:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "80"
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/id_rsa:/root/id_rsa:ro
             - ./bin:/cfs/bin:ro
             - ${DiskPath:-./docker_data}/objectnode1/log:/cfs/log
-            - ./conf/objectnode.json:/cfs/conf/objectnode.json
+            - ./conf/objectnode.json:/root/objectnode.json:ro
             - ./script/start_objectnode.sh:/cfs/script/start.sh
-        command: /bin/sh /cfs/script/start.sh
+        command: /bin/bash /cfs/script/start.sh
         restart: on-failure
         privileged: true
         environment:
@@ -289,16 +293,17 @@ services:
                 ipv4_address: 192.168.0.41
 
     objectnode2:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "80"
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/id_rsa:/root/id_rsa:ro
             - ./bin:/cfs/bin:ro
             - ${DiskPath:-./docker_data}/objectnode2/log:/cfs/log
-            - ./conf/objectnode.json:/cfs/conf/objectnode.json
+            - ./conf/objectnode.json:/root/objectnode.json:ro
             - ./script/start_objectnode.sh:/cfs/script/start.sh
-        command: /bin/sh /cfs/script/start.sh
+        command: /bin/bash /cfs/script/start.sh
         restart: on-failure
         privileged: true
         environment:
@@ -308,16 +313,17 @@ services:
                 ipv4_address: 192.168.0.42
 
     objectnode3:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - "80"
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/id_rsa:/root/id_rsa:ro
             - ./bin:/cfs/bin:ro
             - ${DiskPath:-./docker_data}/objectnode3/log:/cfs/log
-            - ./conf/objectnode.json:/cfs/conf/objectnode.json
+            - ./conf/objectnode.json:/root/objectnode.json:ro
             - ./script/start_objectnode.sh:/cfs/script/start.sh
-        command: /bin/sh /cfs/script/start.sh
+        command: /bin/bash /cfs/script/start.sh
         restart: on-failure
         privileged: true
         environment:
@@ -328,7 +334,7 @@ services:
 
 
     console1:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
           - "80"
         volumes:
@@ -344,10 +350,11 @@ services:
             ipv4_address: 192.168.0.50
 
     client:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         ports:
             - 9500
         volumes:
+            - ${DiskPath:-./docker_data}/ssh-key/id_rsa:/root/id_rsa:ro
             - ./bin:/cfs/bin:ro
             - ./conf/hosts:/etc/hosts:ro
             - ./conf/client.json:/cfs/conf/client.json
@@ -417,7 +424,7 @@ services:
                 ipv4_address: 192.168.0.104
 
     build:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         volumes:
             - ../:/go/src/github.com/chubaofs/chubaofs
         command:
@@ -426,7 +433,7 @@ services:
             extnetwork:
 
     unit_test:
-        image: ghcr.io/chubaofs/cbfs-base:1.0
+        image: ghcr.io/chubaofs/cbfs-base:1.1
         volumes:
             - ../:/go/src/github.com/chubaofs/chubaofs
         command:

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -23,6 +23,20 @@ EOF
     exit 0
 }
 
+generate_ssh_key() {
+    KeyPath=$DiskPath/ssh-key
+    if [ ! -f $KeyPath/id_rsa ] || [ ! -f $KeyPath/authorized_keys ]; then
+        rm -rf $KeyPath
+        mkdir -p $KeyPath
+        ssh-keygen -t rsa -q -C chubaofs -f $KeyPath/id_rsa -N ''
+        mv $KeyPath/id_rsa.pub $KeyPath/authorized_keys
+        if [ -f $KeyPath/id_rsa ] && [ -f $KeyPath/authorized_keys ]; then
+            echo "Generate ssh key in $KeyPath SUCC"
+        else
+            echo "error: Generate ssh key in $KeyPath failed"
+        fi
+    fi
+}
 
 clean() {
     docker-compose -f ${RootPath}/docker/docker-compose.yml down
@@ -40,6 +54,7 @@ build() {
 
 # start server
 start_servers() {
+    generate_ssh_key
     isDiskAvailable $DiskPath
     mkdir -p ${DiskPath}/disk/{1..4}
     docker-compose -f ${RootPath}/docker/docker-compose.yml up -d servers
@@ -59,6 +74,7 @@ start_ltptest() {
 
 run_ltptest() {
     build
+    generate_ssh_key
     start_servers
     start_ltptest
     clean
@@ -66,6 +82,7 @@ run_ltptest() {
 
 run() {
     build
+    generate_ssh_key
     start_monitor
     start_servers
     start_client

--- a/docker/script/start_client.sh
+++ b/docker/script/start_client.sh
@@ -35,6 +35,7 @@ init_cli() {
     echo -n "Installing ChubaoFS cli tool  ... "
     echo -e "\033[32mdone\033[0m"
 }
+
 check_cluster() {
     echo -n "Checking cluster  ... "
     for i in $(seq 1 300) ; do
@@ -48,6 +49,51 @@ check_cluster() {
     done
     echo -e "\033[31mfail\033[0m"
     exit 1
+}
+
+set_root_user() {
+    local masters=("192.168.0.11" "192.168.0.12" "192.168.0.13")
+    local port=17011
+    local found=0
+
+    mkdir -m 700 /root/.ssh
+    cat /root/id_rsa > /root/.ssh/id_rsa
+    chown root:root /root/.ssh/id_rsa
+    chmod 600 /root/.ssh/id_rsa
+
+    for retry in {1..10}; do
+        for addr in ${masters[@]} ; do
+            echo "Access master $addr ... "
+            local values=`ssh -o StrictHostKeyChecking=no root@$addr \
+                "curl -s localhost:$port/admin/getRoot" | \
+                jq -r '.code,.data.access_key,.data.secret_key'`
+            local code=`echo $values | awk '{print $1}'`
+            local ak=`echo $values | awk '{print $2}'`
+            local sk=`echo $values | awk '{print $3}'`
+            if [ $code -ne 0 ] || [ x"$ak" = x"null" ] || [ x"$ak" = x"" ] || \
+               [ x"$sk" = x"null" ] || [ x"$sk" = x"" ]; then
+                continue
+            fi
+            echo "Get AccessKey and SecretKey at $addr"
+            local found=1
+            break
+        done
+        if [ $found -eq 1 ]; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    if [ $found -eq 0 ]; then
+        echo -e "Setting root user ... \033[31mfail\033[0m"
+        exit 1
+    fi
+
+    sed -i "s/user ID/root/" ~/.cfs-cli.json
+    sed -i "s/user's access key value/$ak/" ~/.cfs-cli.json
+    sed -i "s/user's secret key value/$sk/" ~/.cfs-cli.json
+    cp ~/.cfs-cli.json /cfs/log/cfs-cli.json
+    echo -e "client: Setting root user ... \033[32mdone\033[0m"
 }
 
 create_cluster_user() {
@@ -137,6 +183,7 @@ start_client() {
 
 init_cli
 check_cluster
+set_root_user
 create_cluster_user
 ensure_node_writable "metanode"
 ensure_node_writable "datanode"

--- a/docker/script/start_master.sh
+++ b/docker/script/start_master.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
+
+mkdir -m 700 /root/.ssh
+cat /root/authorized_keys > /root/.ssh/authorized_keys
+chown root:root /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+
+service ssh start
+
+mkdir -p /cfs/conf
+cp /root/master.json /cfs/conf/master.json
+sed -i 's/\"enableSimpleAuth\": false/\"enableSimpleAuth\": true/' /cfs/conf/master.json
+
 mkdir -p /cfs/log /cfs/data/wal /cfs/data/store /cfs/bin
-echo "start master"
+echo "start master with simple auth enabled"
 /cfs/bin/cfs-server -f -c /cfs/conf/master.json
 

--- a/docker/script/start_objectnode.sh
+++ b/docker/script/start_objectnode.sh
@@ -1,6 +1,52 @@
-#!/bin/sh
-mkdir -p /cfs/bin /cfs/log
+#!/bin/bash
+
+set_root_user() {
+    local masters=("192.168.0.11" "192.168.0.12" "192.168.0.13")
+    local port=17011
+    local found=0
+
+    mkdir -m 700 /root/.ssh
+    cat /root/id_rsa > /root/.ssh/id_rsa
+    chown root:root /root/.ssh/id_rsa
+    chmod 600 /root/.ssh/id_rsa
+
+    for retry in {1..10}; do
+        for addr in ${masters[@]} ; do
+            echo "Access master $addr ... "
+            local values=`ssh -o StrictHostKeyChecking=no root@$addr \
+                "curl -s localhost:$port/admin/getRoot" | \
+                jq -r '.code,.data.access_key,.data.secret_key'`
+            local code=`echo $values | awk '{print $1}'`
+            local ak=`echo $values | awk '{print $2}'`
+            local sk=`echo $values | awk '{print $3}'`
+            if [ $code -ne 0 ] || [ x"$ak" = x"null" ] || [ x"$ak" = x"" ] || \
+               [ x"$sk" = x"null" ] || [ x"$sk" = x"" ]; then
+                continue
+            fi
+            echo "Get AccessKey and SecretKey at $addr"
+            local found=1
+            break
+        done
+        if [ $found -eq 1 ]; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    if [ $found -eq 0 ]; then
+        echo -e "Setting root user ... \033[31mfail\033[0m"
+        exit 1
+    fi
+
+    cp /root/objectnode.json /cfs/conf/objectnode.json
+    sed -i "s/root's access key value/$ak/" /cfs/conf/objectnode.json
+    sed -i "s/root's secret key value/$sk/" /cfs/conf/objectnode.json
+    cp /cfs/conf/objectnode.json /cfs/log/
+    echo -e "Setting root user ... \033[32mdone\033[0m"
+}
 
 echo "start objectnode"
+mkdir -p /cfs/bin /cfs/log /cfs/conf
+set_root_user
 /cfs/bin/cfs-server -f -c /cfs/conf/objectnode.json
 

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -216,6 +216,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 		VolStatInfo:         make([]*proto.VolStatInfo, 0),
 		BadPartitionIDs:     make([]proto.BadPartitionView, 0),
 		BadMetaPartitionIDs: make([]proto.BadPartitionView, 0),
+		EnableSimpleAuth:    m.config.enableSimpleAuth,
 	}
 
 	vols := m.cluster.allVolNames()

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -550,11 +550,23 @@ func (m *Server) markDeleteVol(w http.ResponseWriter, r *http.Request) {
 		authKey string
 		err     error
 		msg     string
+		signs   []*proto.AuthSignature
 	)
 
 	if name, authKey, err = parseRequestToDeleteVol(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), name, AuthOwnerPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	if err = m.cluster.markDeleteVol(name, authKey); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
@@ -584,6 +596,7 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 		dpSelectorName string
 		dpSelectorParm string
 		vol            *Vol
+		signs          []*proto.AuthSignature
 	)
 
 	if name, authKey, description, err = parseRequestToUpdateVol(r); err != nil {
@@ -608,6 +621,17 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 	if followerRead, authenticate, err = parseBoolFieldToUpdateVol(r, vol); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), name, AuthOwnerPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 
 	newArgs := getVolVarargs(vol)
@@ -636,10 +660,22 @@ func (m *Server) volExpand(w http.ResponseWriter, r *http.Request) {
 		msg      string
 		capacity int
 		vol      *Vol
+		signs    []*proto.AuthSignature
 	)
 	if name, authKey, capacity, err = parseRequestToSetVolCapacity(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), name, AuthOwnerPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	if vol, err = m.cluster.getVol(name); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeVolNotExists, Msg: err.Error()})
@@ -670,10 +706,22 @@ func (m *Server) volShrink(w http.ResponseWriter, r *http.Request) {
 		msg      string
 		capacity int
 		vol      *Vol
+		signs    []*proto.AuthSignature
 	)
 	if name, authKey, capacity, err = parseRequestToSetVolCapacity(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), name, AuthOwnerPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	if vol, err = m.cluster.getVol(name); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeVolNotExists, Msg: err.Error()})
@@ -713,6 +761,7 @@ func (m *Server) createVol(w http.ResponseWriter, r *http.Request) {
 		defaultPriority bool
 		zoneName        string
 		description     string
+		signs           []*proto.AuthSignature
 	)
 
 	if name, owner, zoneName, description,
@@ -728,6 +777,18 @@ func (m *Server) createVol(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), owner, AuthAccessorPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
+	}
+
 	if vol, err = m.cluster.createVol(name, owner, zoneName, description,
 		mpCount, dpReplicaNum, size, capacity,
 		followerRead, authenticate, crossZone,

--- a/master/api_service_user.go
+++ b/master/api_service_user.go
@@ -14,6 +14,7 @@ import (
 func (m *Server) createUser(w http.ResponseWriter, r *http.Request) {
 	var (
 		userInfo *proto.UserInfo
+		signs    []*proto.AuthSignature
 		err      error
 	)
 	var bytes []byte
@@ -25,6 +26,16 @@ func (m *Server) createUser(w http.ResponseWriter, r *http.Request) {
 	if err = json.Unmarshal(bytes, &param); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthRootPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	if !ownerRegexp.MatchString(param.ID) {
 		sendErrReply(w, r, newErrHTTPReply(proto.ErrInvalidUserID))
@@ -44,11 +55,22 @@ func (m *Server) createUser(w http.ResponseWriter, r *http.Request) {
 func (m *Server) deleteUser(w http.ResponseWriter, r *http.Request) {
 	var (
 		userID string
+		signs  []*proto.AuthSignature
 		err    error
 	)
 	if userID, err = parseUser(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthRootPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	if err = m.user.deleteKey(userID); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
@@ -62,12 +84,23 @@ func (m *Server) deleteUser(w http.ResponseWriter, r *http.Request) {
 func (m *Server) updateUser(w http.ResponseWriter, r *http.Request) {
 	var (
 		userInfo *proto.UserInfo
+		signs    []*proto.AuthSignature
 		err      error
 	)
 	var bytes []byte
 	if bytes, err = ioutil.ReadAll(r.Body); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthRootPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	var param = proto.UserUpdateParam{}
 	if err = json.Unmarshal(bytes, &param); err != nil {
@@ -89,15 +122,34 @@ func (m *Server) getUserAKInfo(w http.ResponseWriter, r *http.Request) {
 	var (
 		ak       string
 		userInfo *proto.UserInfo
+		signs    []*proto.AuthSignature
 		err      error
 	)
 	if ak, err = parseAccessKey(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthAccessorPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
+	}
 	if userInfo, err = m.user.getKeyInfo(ak); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
+	}
+	if m.enableSimpleAuth() {
+		var retVal interface{}
+		if retVal, err = m.filterBySignatures(signs, userFilter, userModify, userInfo); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		userInfo = retVal.(*proto.UserInfo)
 	}
 	sendOkReply(w, r, newSuccessHTTPReply(userInfo))
 }
@@ -106,15 +158,35 @@ func (m *Server) getUserInfo(w http.ResponseWriter, r *http.Request) {
 	var (
 		userID   string
 		userInfo *proto.UserInfo
+		signs    []*proto.AuthSignature
 		err      error
 	)
 	if userID, err = parseUser(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthAccessorPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
+	}
 	if userInfo, err = m.user.getUserInfo(userID); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
+	}
+	if m.enableSimpleAuth() {
+		var retVal interface{}
+		if retVal, err = m.filterBySignatures(signs, userFilter, userModify, userInfo); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		userInfo = retVal.(*proto.UserInfo)
 	}
 	sendOkReply(w, r, newSuccessHTTPReply(userInfo))
 }
@@ -122,12 +194,23 @@ func (m *Server) getUserInfo(w http.ResponseWriter, r *http.Request) {
 func (m *Server) updateUserPolicy(w http.ResponseWriter, r *http.Request) {
 	var (
 		userInfo *proto.UserInfo
+		signs    []*proto.AuthSignature
 		bytes    []byte
 		err      error
 	)
 	if bytes, err = ioutil.ReadAll(r.Body); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthRootPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	var param = proto.UserPermUpdateParam{}
 	if err = json.Unmarshal(bytes, &param); err != nil {
@@ -148,12 +231,23 @@ func (m *Server) updateUserPolicy(w http.ResponseWriter, r *http.Request) {
 func (m *Server) removeUserPolicy(w http.ResponseWriter, r *http.Request) {
 	var (
 		userInfo *proto.UserInfo
+		signs    []*proto.AuthSignature
 		bytes    []byte
 		err      error
 	)
 	if bytes, err = ioutil.ReadAll(r.Body); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthRootPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	var param = proto.UserPermRemoveParam{}
 	if err = json.Unmarshal(bytes, &param); err != nil {
@@ -173,12 +267,23 @@ func (m *Server) removeUserPolicy(w http.ResponseWriter, r *http.Request) {
 
 func (m *Server) deleteUserVolPolicy(w http.ResponseWriter, r *http.Request) {
 	var (
-		vol string
-		err error
+		vol   string
+		signs []*proto.AuthSignature
+		err   error
 	)
 	if vol, err = parseVolName(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
+	}
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthRootPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
 	}
 	if err = m.user.deleteVolPolicy(vol); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
@@ -228,17 +333,64 @@ func (m *Server) transferUserVol(w http.ResponseWriter, r *http.Request) {
 	sendOkReply(w, r, newSuccessHTTPReply(userInfo))
 }
 
+func userFilter(signs []*proto.AuthSignature, item interface{}) (how AuthHandle) {
+	userInfo := item.(*proto.UserInfo)
+	for _, sign := range signs {
+		if sign.IsRoot() {
+			return AuthKeepItem
+		}
+	}
+
+	for _, sign := range signs {
+		if sign.UserID == userInfo.UserID {
+			return AuthKeepItem
+		}
+	}
+
+	return AuthModifyItem
+}
+
+func userModify(item interface{}) interface{} {
+	userInfo := item.(*proto.UserInfo)
+	newUserInfo := proto.UserInfo{}
+	// shallow copy is enough
+	newUserInfo = *userInfo
+	newUserInfo.AccessKey = "*"
+	newUserInfo.SecretKey = "*"
+	return &newUserInfo
+}
+
 func (m *Server) getAllUsers(w http.ResponseWriter, r *http.Request) {
 	var (
 		keywords string
 		users    []*proto.UserInfo
+		signs    []*proto.AuthSignature
 		err      error
 	)
 	if keywords, err = parseKeywords(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+
+	if m.enableSimpleAuth() {
+		if signs, err = m.parseSignatures(r); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		if err = m.verifySignatures(signs, r.URL.EscapedPath(), "", AuthAccessorPermission); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNoPermission, Msg: err.Error()})
+			return
+		}
+	}
 	users = m.user.getAllUserInfo(keywords)
+	if m.enableSimpleAuth() {
+		var retVal interface{}
+		if retVal, err = m.filterBySignatures(signs, userFilter, userModify, users); err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+			return
+		}
+		users = retVal.([]*proto.UserInfo)
+	}
 	sendOkReply(w, r, newSuccessHTTPReply(users))
 }
 

--- a/master/auth.go
+++ b/master/auth.go
@@ -1,0 +1,226 @@
+package master
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+
+	"github.com/chubaofs/chubaofs/proto"
+	"github.com/chubaofs/chubaofs/util/errors"
+	"github.com/chubaofs/chubaofs/util/log"
+)
+
+type AuthHandle int
+
+const (
+	AuthKeepItem AuthHandle = iota
+	AuthRemoveItem
+	AuthModifyItem
+)
+
+type AuthPermission int
+
+const (
+	AuthAccessorPermission = iota // lowest permission
+	AuthOwnerPermission
+	AuthRootPermission // highest permission
+)
+
+type FilterFunc func(signs []*proto.AuthSignature, item interface{}) AuthHandle
+type ModifyFunc func(item interface{}) interface{}
+
+func (m *Server) parseSignatures(r *http.Request) (signs []*proto.AuthSignature, err error) {
+	if err = r.ParseForm(); err != nil {
+		return
+	}
+
+	signature := r.FormValue(signatureKey)
+	if signature == "" {
+		return
+	}
+
+	if err = json.Unmarshal([]byte(signature), &signs); err != nil {
+		return
+	}
+	return
+}
+
+func (m *Server) verifySignatures(
+	signs []*proto.AuthSignature, path string,
+	param string, permReq AuthPermission,
+) (err error) {
+	var (
+		verifySign *proto.AuthSignature
+		userInfo   *proto.UserInfo
+		hasRoot    bool
+	)
+
+	if len(signs) == 0 {
+		log.LogErrorf("Path(%s) verify signature fail: signs is empty", path)
+		return proto.ErrNoPermission
+	}
+
+	for _, sign := range signs {
+		if userInfo, err = m.user.getUserInfo(sign.UserID); err != nil {
+			return err
+		}
+
+		authUser := &proto.AuthUser{userInfo.UserID, userInfo.AccessKey, userInfo.SecretKey}
+
+		if verifySign, err = authUser.GenerateSignature(path); err != nil {
+			return err
+		}
+
+		if err = verifySign.Compare(sign); err != nil {
+			log.LogErrorf("Path(%s) verify signature of user %v fail: %v",
+				path, sign.UserID, err)
+			return proto.ErrNoPermission
+		}
+
+		if sign.UserID == "root" {
+			sign.SetRoot()
+			hasRoot = true
+		}
+	}
+
+	switch permReq {
+	case AuthRootPermission:
+		if !hasRoot {
+			log.LogErrorf("Path(%s) requires root permission", path)
+			return proto.ErrNoPermission
+		}
+	case AuthOwnerPermission:
+		var vol *Vol
+		// param is volName that wants to be accessed
+		if vol, err = m.cluster.getVol(param); err != nil {
+			log.LogErrorf("Path(%s) cannot get volume of vol(%s)", path, param)
+			return err
+		}
+		for _, sign := range signs {
+			if sign.UserID == vol.Owner || sign.IsRoot() {
+				return
+			}
+			log.LogErrorf("Path(%s) requires owner permission", path)
+			return proto.ErrNoPermission
+		}
+	case AuthAccessorPermission:
+		if path == proto.AdminCreateVol {
+			// param is vol owner which should be one of signatures
+			for _, sign := range signs {
+				if sign.UserID == param || sign.IsRoot() {
+					return
+				}
+			}
+			log.LogErrorf("Path(%s) can only create vol for your own", path)
+			return proto.ErrNoPermission
+		}
+	default:
+		log.LogErrorf("Path(%s) invalid permission request(%v)", path, permReq)
+		return proto.ErrParamError
+	}
+
+	return
+}
+
+func handleItem(
+	signs []*proto.AuthSignature,
+	filter FilterFunc, modify ModifyFunc,
+	item reflect.Value,
+) (reflect.Value, error) {
+	var err error
+
+	if !item.IsValid() {
+		err = errors.New("[handleItem] invalid item")
+		return reflect.ValueOf(nil), err
+	}
+
+	if filter == nil {
+		return item, nil
+	}
+
+	how := filter(signs, item.Interface())
+	switch how {
+	case AuthRemoveItem:
+		// return an invalid Value
+		return reflect.Zero(item.Type()), nil
+	case AuthModifyItem:
+		if modify != nil {
+			ret := modify(item.Interface())
+			if ret == item.Interface() {
+				panic("ModifyFunc must modify a new copy!")
+			}
+			item = reflect.ValueOf(ret)
+		} else {
+			err = errors.New("[handleItem] item needs modified but no modify function specified")
+		}
+	case AuthKeepItem:
+		// nothing to do
+	default:
+		err = errors.NewErrorf("[handleItem] invalid return value %v from filter", how)
+		return reflect.Zero(item.Type()), err
+	}
+
+	return item, err
+}
+
+func handleSlice(
+	signs []*proto.AuthSignature,
+	filter FilterFunc, modify ModifyFunc,
+	data interface{},
+) (retVal interface{}, err error) {
+	dataType := reflect.TypeOf(data)
+	newSlice := reflect.MakeSlice(dataType, 0, 0)
+	set := reflect.ValueOf(data)
+	for i := 0; i < set.Len(); i++ {
+		var ret reflect.Value
+
+		item := set.Index(i)
+		if ret, err = handleItem(signs, filter, modify, item); err != nil {
+			return
+		}
+		if ret.IsNil() {
+			continue
+		}
+		newSlice = reflect.Append(newSlice, ret)
+	}
+
+	retVal = newSlice.Interface()
+	return
+}
+
+func handleElement(
+	signs []*proto.AuthSignature,
+	filter FilterFunc, modify ModifyFunc,
+	data interface{},
+) (interface{}, error) {
+	var (
+		ret reflect.Value
+		err error
+	)
+
+	item := reflect.ValueOf(data)
+	if ret, err = handleItem(signs, filter, modify, item); err != nil {
+		return ret.Interface(), proto.ErrNoPermission
+	}
+	if ret.IsNil() {
+		return ret.Interface(), proto.ErrNoPermission
+	}
+	return ret.Interface(), nil
+}
+
+func (m *Server) filterBySignatures(
+	signs []*proto.AuthSignature,
+	filter FilterFunc, modify ModifyFunc,
+	data interface{},
+) (interface{}, error) {
+	switch reflect.TypeOf(data).Kind() {
+	case reflect.Slice:
+		return handleSlice(signs, filter, modify, data)
+	case reflect.Ptr:
+		return handleElement(signs, filter, modify, data)
+	default:
+		err := errors.NewErrorf("[filterBySignatures] unsupported type %v", reflect.TypeOf(data))
+		return nil, err
+	}
+	return nil, nil
+}

--- a/master/config.go
+++ b/master/config.go
@@ -103,6 +103,7 @@ type clusterConfig struct {
 	DomainNodeGrpBatchCnt               int
 	DomainBuildAsPossible               bool
 	DataPartitionUsageThreshold         float64
+	enableSimpleAuth                    bool
 }
 
 func newClusterConfig() (cfg *clusterConfig) {

--- a/master/const.go
+++ b/master/const.go
@@ -55,6 +55,7 @@ const (
 	dpSelectorParmKey       = "dpSelectorParm"
 	nodeTypeKey             = "nodeType"
 	ratio                   = "ratio"
+	signatureKey            = "signature"
 )
 
 const (

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -18,20 +18,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/samsarahq/thunder/graphql"
-	"github.com/samsarahq/thunder/graphql/introspection"
 	"net/http"
 	"net/http/httputil"
+	"strconv"
+
+	"github.com/samsarahq/thunder/graphql"
+	"github.com/samsarahq/thunder/graphql/introspection"
 
 	"github.com/gorilla/mux"
 
 	"github.com/chubaofs/chubaofs/proto"
 	"github.com/chubaofs/chubaofs/util/config"
+	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/exporter"
 	"github.com/chubaofs/chubaofs/util/log"
 )
 
 func (m *Server) startHTTPService(modulename string, cfg *config.Config) {
+	var err error
 	router := mux.NewRouter().SkipClean(true)
 	m.registerAPIRoutes(router)
 	m.registerAPIMiddleware(router)
@@ -41,12 +45,53 @@ func (m *Server) startHTTPService(modulename string, cfg *config.Config) {
 		Handler: router,
 	}
 	var serveAPI = func() {
-		if err := server.ListenAndServe(); err != nil {
+		if err = server.ListenAndServe(); err != nil {
 			log.LogErrorf("serveAPI: serve http server failed: err(%v)", err)
 			return
 		}
 	}
+	var localAPI = func() {
+		var getRootUserInfo = func(w http.ResponseWriter, r *http.Request) {
+			var rootInfo *proto.UserInfo
+			if !m.partition.IsRaftLeader() {
+				log.LogWarnf("I'm not raft leader")
+				err := errors.NewErrorf("not leader")
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+
+			if !m.metaReady {
+				log.LogWarnf("leader is not ready")
+				err := errors.NewErrorf("leader not ready")
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+
+			if rootInfo, err = m.user.getUserInfo("root"); err != nil {
+				log.LogErrorf("get root user info failed: err(%v)", err)
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+			sendOkReply(w, r, newSuccessHTTPReply(rootInfo))
+		}
+
+		var switchSimpleAuth = func(w http.ResponseWriter, r *http.Request) {
+			m.config.enableSimpleAuth = !m.config.enableSimpleAuth
+			msg := fmt.Sprintf("switch enableSimpleAuth to %v", m.config.enableSimpleAuth)
+			sendOkReply(w, r, newSuccessHTTPReply(msg))
+		}
+
+		http.HandleFunc("/admin/getRoot", getRootUserInfo)
+		http.HandleFunc("/admin/switchSimpleAuth", switchSimpleAuth)
+		newPort, _ := strconv.ParseInt(m.port, 0, 64)
+		newPort++
+		if err = http.ListenAndServe(fmt.Sprintf("127.0.0.1:%v", newPort), nil); err != nil {
+			log.LogErrorf("localAPI: local http server failed: err(%v)", err)
+			return
+		}
+	}
 	go serveAPI()
+	go localAPI()
 	m.apiServer = server
 	return
 }

--- a/master/server.go
+++ b/master/server.go
@@ -50,6 +50,7 @@ const (
 	cfgRaftRecvBufSize = "raftRecvBufSize"
 	cfgElectionTick    = "electionTick"
 	SecretKey          = "masterServiceKey"
+	EnableSimpleAuth   = "enableSimpleAuth"
 )
 
 var (
@@ -90,6 +91,10 @@ type Server struct {
 // NewServer creates a new server
 func NewServer() *Server {
 	return &Server{}
+}
+
+func (m *Server) enableSimpleAuth() bool {
+	return m.config.enableSimpleAuth
 }
 
 // Start starts a server
@@ -158,6 +163,8 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 	if m.id, err = strconv.ParseUint(cfg.GetString(ID), 10, 64); err != nil {
 		return fmt.Errorf("%v,err:%v", proto.ErrInvalidCfg, err.Error())
 	}
+	m.config.enableSimpleAuth = cfg.GetBoolWithDefault(EnableSimpleAuth, false)
+	syslog.Println("enableSimpleAuth=", m.config.enableSimpleAuth)
 	m.config.faultDomain = cfg.GetBoolWithDefault(faultDomain, false)
 	m.config.heartbeatPort = cfg.GetInt64(heartbeatPortKey)
 	m.config.replicaPort = cfg.GetInt64(replicaPortKey)

--- a/objectnode/fs_store_user.go
+++ b/objectnode/fs_store_user.go
@@ -73,8 +73,9 @@ func (s *CacheUserInfoStore) LoadUser(accessKey string) (*proto.UserInfo, error)
 	return s.selectLoader(accessKey).LoadUser(accessKey)
 }
 
-func NewUserInfoStore(masters []string, strict bool) UserInfoStore {
+func NewUserInfoStore(masters []string, strict bool, users []*proto.AuthUser) UserInfoStore {
 	mc := master.NewMasterClient(masters, false)
+	mc.SetUsers(users)
 	if strict {
 		return &StrictUserInfoStore{
 			mc: mc,

--- a/objectnode/server.go
+++ b/objectnode/server.go
@@ -79,6 +79,10 @@ const (
 
 	disabledActions               = "disabledActions"
 	configSignatureIgnoredActions = "signatureIgnoredActions"
+
+	configUser      = "user"
+	configAccessKey = "accessKey"
+	configSecretKey = "secretKey"
 )
 
 // Default of configuration value
@@ -176,9 +180,18 @@ func (o *ObjectNode) loadConfig(cfg *config.Config) (err error) {
 	strict := cfg.GetBool(configStrict)
 	log.LogInfof("loadConfig: strict: %v", strict)
 
+	// parse auth user
+	userID := cfg.GetString(configUser)
+	accessKey := cfg.GetString(configAccessKey)
+	secretKey := cfg.GetString(configSecretKey)
+	user := &proto.AuthUser{userID, accessKey, secretKey}
+	users := make([]*proto.AuthUser, 0)
+	users = append(users, user)
+
 	o.mc = master.NewMasterClient(masters, false)
+	//o.mc.SetUsers(users)
 	o.vm = NewVolumeManager(masters, strict)
-	o.userStore = NewUserInfoStore(masters, strict)
+	o.userStore = NewUserInfoStore(masters, strict, users)
 
 	return
 }

--- a/proto/admin_auth.go
+++ b/proto/admin_auth.go
@@ -1,0 +1,7 @@
+package proto
+
+type AuthUser struct {
+	UserID    string `json:"userID"`
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
+}

--- a/proto/admin_auth.go
+++ b/proto/admin_auth.go
@@ -15,6 +15,25 @@ type AuthUser struct {
 type AuthSignature struct {
 	UserID    string
 	Signature string
+	isRoot    bool
+}
+
+func (sign *AuthSignature) SetRoot() {
+	sign.isRoot = true
+}
+
+func (sign *AuthSignature) IsRoot() bool {
+	return sign.isRoot
+}
+
+func (verifySign *AuthSignature) Compare(sign *AuthSignature) (err error) {
+	if verifySign.UserID != sign.UserID {
+		return ErrInvalidUserID
+	}
+	if verifySign.Signature != sign.Signature {
+		return ErrInvalidSignature
+	}
+	return
 }
 
 func (user *AuthUser) GenerateSignature(path string) (*AuthSignature, error) {

--- a/proto/admin_auth.go
+++ b/proto/admin_auth.go
@@ -1,7 +1,41 @@
 package proto
 
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
 type AuthUser struct {
 	UserID    string `json:"userID"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`
+}
+
+type AuthSignature struct {
+	UserID    string
+	Signature string
+}
+
+func (user *AuthUser) GenerateSignature(path string) (*AuthSignature, error) {
+	var (
+		sign *AuthSignature
+		err  error
+	)
+
+	sign = &AuthSignature{UserID: user.UserID}
+
+	dataHMAC := hmac.New(sha256.New, []byte(user.AccessKey))
+	if _, err = dataHMAC.Write([]byte(path)); err != nil {
+		return nil, err
+	}
+
+	keyHMAC := hmac.New(sha256.New, []byte(user.SecretKey))
+	if _, err = keyHMAC.Write(dataHMAC.Sum(nil)); err != nil {
+		return nil, err
+	}
+
+	sign.Signature = hex.EncodeToString(keyHMAC.Sum(nil))
+
+	return sign, nil
 }

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -116,6 +116,7 @@ const (
 	ParamAuthorized = "_authorization"
 	UserKey         = "_user_key"
 	UserInfoKey     = "_user_info_key"
+	UserSign        = "_user_sign"
 )
 
 const TimeFormat = "2006-01-02 15:04:05"

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -82,6 +82,7 @@ var (
 	ErrInvalidSecretKey                = errors.New("invalid secret key")
 	ErrIsOwner                         = errors.New("user owns the volume")
 	ErrZoneNum                         = errors.New("zone num not qualified")
+	ErrInvalidSignature                = errors.New("invalid signature")
 )
 
 // http response error code and error message definitions

--- a/proto/model.go
+++ b/proto/model.go
@@ -102,6 +102,7 @@ type ClusterView struct {
 	MaxDataPartitionID  uint64
 	MaxMetaNodeID       uint64
 	MaxMetaPartitionID  uint64
+	EnableSimpleAuth    bool
 	DataNodeStatInfo    *NodeStatInfo
 	MetaNodeStatInfo    *NodeStatInfo
 	VolStatInfo         []*VolStatInfo

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -201,6 +201,9 @@ func (api *AdminAPI) DeleteVolume(volName, authKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminDeleteVol)
 	request.addParam("name", volName)
 	request.addParam("authKey", authKey)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -216,6 +219,9 @@ func (api *AdminAPI) UpdateVolume(volName string, capacity uint64, replicas int,
 	request.addParam("followerRead", strconv.FormatBool(followerRead))
 	request.addParam("authenticate", strconv.FormatBool(authenticate))
 	request.addParam("zoneName", zoneName)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -227,6 +233,9 @@ func (api *AdminAPI) VolShrink(volName string, capacity uint64, authKey string) 
 	request.addParam("name", volName)
 	request.addParam("authKey", authKey)
 	request.addParam("capacity", strconv.FormatUint(capacity, 10))
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -238,6 +247,9 @@ func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey string) 
 	request.addParam("name", volName)
 	request.addParam("authKey", authKey)
 	request.addParam("capacity", strconv.FormatUint(capacity, 10))
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -255,6 +267,9 @@ func (api *AdminAPI) CreateVolume(volName, owner string, mpCount int,
 	request.addParam("followerRead", strconv.FormatBool(followerRead))
 	request.addParam("zoneName", zoneName)
 	request.addParam("crossZone", strconv.FormatBool(crossZone))
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -266,6 +281,9 @@ func (api *AdminAPI) CreateDefaultVolume(volName, owner string) (err error) {
 	request.addParam("name", volName)
 	request.addParam("owner", owner)
 	request.addParam("capacity", "10")
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}

--- a/sdk/master/api_user.go
+++ b/sdk/master/api_user.go
@@ -18,6 +18,9 @@ func (api *UserAPI) CreateUser(param *proto.UserCreateParam) (userInfo *proto.Us
 		return
 	}
 	request.addBody(reqBody)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -32,6 +35,9 @@ func (api *UserAPI) CreateUser(param *proto.UserCreateParam) (userInfo *proto.Us
 func (api *UserAPI) DeleteUser(userID string) (err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserDelete)
 	request.addParam("user", userID)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -45,6 +51,9 @@ func (api *UserAPI) UpdateUser(param *proto.UserUpdateParam) (userInfo *proto.Us
 		return
 	}
 	request.addBody(reqBody)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -59,6 +68,9 @@ func (api *UserAPI) UpdateUser(param *proto.UserUpdateParam) (userInfo *proto.Us
 func (api *UserAPI) GetAKInfo(accesskey string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.UserGetAKInfo)
 	request.addParam("ak", accesskey)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -73,6 +85,9 @@ func (api *UserAPI) GetAKInfo(accesskey string) (userInfo *proto.UserInfo, err e
 func (api *UserAPI) GetUserInfo(userID string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.UserGetInfo)
 	request.addParam("user", userID)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -91,6 +106,9 @@ func (api *UserAPI) UpdatePolicy(param *proto.UserPermUpdateParam) (userInfo *pr
 		return
 	}
 	request.addBody(reqBody)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -109,6 +127,9 @@ func (api *UserAPI) RemovePolicy(param *proto.UserPermRemoveParam) (userInfo *pr
 		return
 	}
 	request.addBody(reqBody)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -123,6 +144,9 @@ func (api *UserAPI) RemovePolicy(param *proto.UserPermRemoveParam) (userInfo *pr
 func (api *UserAPI) DeleteVolPolicy(vol string) (err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserDeleteVolPolicy)
 	request.addParam("name", vol)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -150,6 +174,9 @@ func (api *UserAPI) TransferVol(param *proto.UserTransferVolParam) (userInfo *pr
 func (api *UserAPI) ListUsers(keywords string) (users []*proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.UserList)
 	request.addParam("keywords", keywords)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return

--- a/sdk/master/api_user.go
+++ b/sdk/master/api_user.go
@@ -160,6 +160,9 @@ func (api *UserAPI) TransferVol(param *proto.UserTransferVolParam) (userInfo *pr
 		return
 	}
 	request.addBody(reqBody)
+	if err = api.mc.generateSignature(request); err != nil {
+		return
+	}
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return

--- a/test/lib/libTestAuth.sh
+++ b/test/lib/libTestAuth.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+#master address
+masterAddr="http://192.168.0.11:17010"
+mastersAddr="192.168.0.11:17010,192.168.0.12:17010,192.168.0.13:17010"
+
+if [ x"$1" == x"" ] || [ x"$2" == x"" ]; then
+    echo "Usage: $0 <root's access key> <root's secret key>"
+    exit 1
+fi
+
+declare -A users
+users["root"]="$1,$2"
+
+function gen_sign()
+{
+    local uid=$1
+    local val=${users["$uid"]}
+    local ak=`echo $val | cut -d ',' -f 1`
+    local sk=`echo $val | cut -d ',' -f 2`
+    local path=`echo $2 | cut -d '?' -f 1`
+    local sign=""
+
+    if [ x"$val" != x"" ]; then
+        local sign=`$cfs_authtool sign --user $uid --ak $ak --sk $sk --path $path`
+    fi
+
+    echo $sign
+}
+
+function add_dict_user()
+{
+    local userID=$1
+    local sign=`gen_sign root /user/info`
+    local operation="/user/info?user=$userID&signature=[$sign]"
+    curl -g -s "${masterAddr}${operation}" | jq > return_Info.json
+
+    local accesskey=`jq -r '.data.access_key' return_Info.json`
+    local secretkey=`jq -r '.data.secret_key' return_Info.json`
+
+    users["$userID"]=$accesskey","$secretkey
+
+    #for key in "${!users[@]}"; do
+    #    echo $key ${users[$key]}
+    #done
+}
+
+#1.according to the input operation, send the corresponding curl request
+#2.store curl result in return_Info.json
+function test_operation()
+{
+    local operation=$1
+    local user=$2
+    if [ x"$user" != x"" ]; then
+        local sign=`gen_sign $user $operation`
+        local url="${masterAddr}${operation}&signature=[$sign]"
+    else
+        local url="${masterAddr}${operation}"
+    fi
+
+    curl -g -s $url | jq > return_Info.json
+}
+
+#check if msg exists in return_Info.json
+#  $1: msg need to be checked, if exist, it means succ
+#  $2: testcase number
+#  $3: stage number of testcase
+function check_msg()
+{
+    local message=$1
+    local test=$2
+    local stage=$3
+    grep "$message" return_Info.json > /dev/null
+    if [ $? -eq 0 ];
+    then
+        echo "test $test stage $stage SUCCESS"
+    else
+        echo "test $test stage $stage FAILED"
+	cat return_Info.json
+	exit 1
+    fi
+}
+
+#check if msg does not exist in return_Info.json
+#  $1: msg need to be checked, if not exist, it means succ
+#  $2: testcase number
+#  $3: stage number of testcase
+function check_no_msg()
+{
+    local message=$1
+    local test=$2
+    local stage=$3
+    grep "$message" return_Info.json > /dev/null
+    if [ $? -ne 0 ];
+    then
+        echo "test $test stage $stage SUCCESS"
+    else
+        echo "test $test stage $stage FAILED"
+	cat return_Info.json
+	exit 1
+    fi
+}
+
+#global variable store accesskey & secretkey
+accesskey=0
+secretkey=0
+#get user keys by user id
+function get_keys_by_ID()
+{
+    local userID=$1
+    test_operation "/user/info?user=$userID" root
+    accesskey=`jq -r '.data.access_key' return_Info.json`
+    secretkey=`jq -r '.data.secret_key' return_Info.json`
+}
+
+#global variable to store md5
+md5=0
+#calculate the MD5 value of the corresponding string
+function cal_md5()
+{
+    local owner=$1
+    md5=`echo -n $owner | md5sum | awk '{print $1}'`
+}
+
+#prepare ltptest user
+function prepare_ltptest_user()
+{
+    get_keys_by_ID ltptest
+    local msg=`jq -r '.msg' return_Info.json`
+    if [ x"$msg" != x"success" ]; then
+        local pwd=ChubaoFSUser
+        local ak=39bEF4RrAQgMj6RV
+        local sk=TRL6o3JL16YOqvZGIohBDFTHZDEcFsyd
+        local sign=`gen_sign root /user/create`
+        curl -g -s -H "Content-Type:application/json" -X POST \
+             --data '{"id":"ltptest","pwd":"'$pwd'","ak":"'$ak'","sk":"'$sk'","type":3}' \
+             "$masterAddr/user/create?signature=[$sign]" | jq > return_Info.json
+        local msg=`jq -r '.msg' return_Info.json`
+        if [ x"$msg" != x"success" ]; then
+            echo "Failed to create ltptest user"
+            exit 1
+        fi
+    fi
+    add_dict_user ltptest
+}

--- a/test/userTestAuth.sh
+++ b/test/userTestAuth.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+#testcases for user interfaces of CFS resource management with simple auth enabled
+
+. ./lib/libTestAuth.sh
+
+cp ../build/bin/cfs-authtool ./
+cfs_authtool=./cfs-authtool
+
+#create user
+function test_create()
+{
+    local sign=`gen_sign $4 /user/create`
+    curl -g -s -H "Content-Type:application/json" -X POST \
+         --data '{"id":"'$1'","pwd":"'$2'","type":'$3'}' \
+         "$masterAddr/user/create?signature=[$sign]" | jq > return_Info.json
+    grep "success" return_Info.json > /dev/null
+}
+
+#update user
+function test_update()
+{
+    local user_id=$1
+    local access_key=$2
+    local secret_key=$3
+    local type=$4
+    local sign=`gen_sign $5 /user/update`
+    curl -g -s -H "Content-Type:application/json" -X POST \
+         --data '{"user_id":'\"$user_id\"',"access_key":'\"$access_key\"',"secret_key":'\"$secret_key\"',"type":'$4'}' \
+         "$masterAddr/user/update?signature=[$sign]" | jq > return_Info.json
+}
+
+#remove policy
+function test_rmpolicy()
+{
+    local user_id=$1
+    local vol_name=$2
+    local sign=`gen_sign $3 /user/removePolicy`
+    curl -g -s -H "Content-Type:application/json" -X POST \
+         --data '{"user_id":'\"$user_id\"',"volume":'\"$vol_name\"'}' \
+         "$masterAddr/user/removePolicy?signature=[$sign]" | jq > return_Info.json
+}
+
+#transfer vol
+function test_transfer()
+{
+    local vol_name=$1
+    local user_src=$2
+    local user_dst=$3
+    local bool=$4
+    local sign=`gen_sign $5 /user/transferVol`
+    curl -g -s -H "Content-Type:application/json" -X POST --data '{"volume":'\"$vol_name\"',"user_src":'\"$user_src\"',"user_dst":'\"$user_dst\"',"force":'$bool'}' "$masterAddr/user/transferVol?signature=[$sign]" |jq >return_Info.json
+}
+
+#grant vol permission to a user
+function test_perm()
+{
+    local user_id=$1
+    local volume=$2
+    local policy=$3
+    local sign=`gen_sign $4 /user/updatePolicy`
+    curl -g -s -H "Content-Type:application/json" -X POST \
+         --data '{"user_id":'\"$user_id\"',"volume":'\"$volume\"',"policy":['\"$policy\"']}' \
+         "$masterAddr/user/updatePolicy?signature=[$sign]" | jq > return_Info.json
+}
+
+prepare_ltptest_user
+
+#test01 create a correct user
+test_create "userc" "123" "3" ltptest
+check_msg "no permission" 1 1
+test_create "userc" "123" "3" root
+check_msg "success" 1 2
+add_dict_user userc
+
+#test02 seek user by id
+test_operation "/user/info?user=userc"
+check_msg "no permission" 2 1
+test_operation "/user/info?user=userc" ltptest
+check_msg "success" 2 2
+check_msg "\*" 2 3
+test_operation "/user/info?user=userc" userc
+check_msg "success" 2 4
+check_no_msg "\*" 2 5
+test_operation "/user/info?user=userc" root
+check_msg "success" 2 6
+check_no_msg "\*" 2 7
+
+#test03 delete the user
+test_operation "/user/delete?user=userc" ltptest
+check_msg "no permission" 3 1
+test_operation "/user/delete?user=userc" userc
+check_msg "no permission" 3 2
+test_operation "/user/delete?user=userc" root
+check_msg "success" 3 3
+
+#test04 creat vol
+test_create "user1" "123" "3" root
+check_msg "success" 4 1
+test_operation "/user/info?user=user1" root
+check_msg "success" 4 2
+add_dict_user user1
+test_operation "/admin/createVol?name=test1&capacity=1&owner=user1&mpCount=3" ltptest
+check_msg "no permission" 4 3
+test_operation "/admin/createVol?name=test1&capacity=1&owner=user1&mpCount=3" root
+check_msg "success" 4 4
+
+#test05 seek vol
+cal_md5 "ltptest"
+test_operation "/client/vol?name=test1&authKey=$md5"
+check_msg "client and server auth key do not match" 5 1
+cal_md5 "user1"
+test_operation "/client/vol?name=test1&authKey=$md5"
+check_msg "success" 5 2
+
+#test06 del vol
+cal_md5 "user1"
+test_operation "/vol/delete?name=test1&authKey=$md5" ltptest
+check_msg "no permission" 6 1
+test_operation "/vol/delete?name=test1&authKey=$md5" root
+check_msg "success" 6 2
+
+#test07 query the user by correct ak
+get_keys_by_ID "user1"
+test_operation "/user/akInfo?ak=$accesskey" user1
+check_msg "success" 7 1
+check_msg "user1" 7 2
+check_msg "$secretkey" 7 3
+test_operation "/user/akInfo?ak=$accesskey" ltptest
+check_msg "success" 7 4
+check_msg "user1"  7 5
+check_msg "\*" 7 6
+
+#test08 query the user list by keyword=user1
+get_keys_by_ID "user1"
+test_operation "/user/list?keywords=user" root
+check_msg "success" 8 1
+check_msg "user1" 8 2
+check_msg "$secretkey" 8 3
+check_no_msg "\*" 8 4
+test_operation "/user/list?keywords=user" ltptest
+check_msg "success" 8 5
+check_msg "user1" 8 6
+check_msg "\*" 8 7
+test_operation "/user/list?keywords=user" user1
+check_msg "success" 8 8
+check_msg "user1" 8 9
+check_msg "$secretkey" 8 10
+test_operation "/user/list?keywords=user"
+check_msg "no permission" 8 11
+
+#test09 update exsists user
+test_update "user1" "KkiiVYCFcvu0c6Rd" "222wlCchJeeuGSnmFW72J2oDqLlSqvA5" "2" user1
+check_msg "no permission" 9 1
+test_update "user1" "KkiiVYCFcvu0c6Rd" "222wlCchJeeuGSnmFW72J2oDqLlSqvA5" "2" root
+check_msg "success" 9 2
+test_operation "/user/info?user=user1" root
+check_msg "success" 9 3
+check_msg "\"user_id\": \"user1\"," 9 4
+check_msg "\"access_key\": \"KkiiVYCFcvu0c6Rd\"," 9 5
+check_msg "\"secret_key\": \"222wlCchJeeuGSnmFW72J2oDqLlSqvA5\"," 9 6
+check_msg "\"user_type\": 2," 9 7
+add_dict_user user1
+
+#test10 authorize a user with ReadOnly policy
+test_operation "/admin/createVol?name=test10&capacity=1&owner=ltptest&mpCount=3" root
+check_msg "success" 10 1
+test_perm "user1" "test10" "perm:builtin:ReadOnly" ltptest
+check_msg "no permission" 10 2
+test_perm "user1" "test10" "perm:builtin:ReadOnly" root
+check_msg "success" 10 3
+check_msg "\"test10\": \[" 10 4
+check_msg "\"perm:builtin:ReadOnly\"" 10 5
+
+#test11 transfer
+test_transfer "test10" "ltptest" "user1" "false" user1
+check_msg "no permission" 11 1
+test_transfer "test10" "ltptest" "user1" "false" user1
+check_msg "no permission" 11 2
+test_transfer "test10" "ltptest" "user1" "false" root
+check_msg "success" 11 3
+check_msg "user1" 11 4
+check_msg "test10" 11 5
+test_operation "/user/info?user=ltptest" ltptest
+check_msg "success" 11 6
+check_msg "\"own_vols\": \[\]," 11 7
+
+# cleanup
+cal_md5 'user1'
+test_operation "/vol/delete?name=test10&authKey=$md5" root
+check_msg "success" 12 1
+test_operation "/user/delete?user=user1" root
+check_msg "success" 12 2
+
+rm return_Info.json
+rm $cfs_authtool

--- a/test/volumeTest/volTestAuth.sh
+++ b/test/volumeTest/volTestAuth.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#testcases for vol interfaces of CFS resource management with simple auth enabled
+
+. ../lib/libTestAuth.sh
+
+cp ../../build/bin/cfs-authtool ./
+cfs_authtool=./cfs-authtool
+
+prepare_ltptest_user
+
+#test01 create vol
+test_operation "/admin/createVol?name=test1&capacity=1&owner=newuser&mpCount=3" ltptest
+check_msg "no permission" 1 1
+test_operation "/admin/createVol?name=test1&capacity=1&owner=root&mpCount=3" ltptest
+check_msg "no permission" 1 2
+test_operation "/admin/createVol?name=test1&capacity=1&owner=ltptest&mpCount=3" ltptest
+check_msg "success" 1 3
+test_operation "/admin/createVol?name=test2&capacity=1&owner=newuser&mpCount=3" root
+check_msg "success" 1 4
+test_operation "/user/info?user=newuser" root
+check_msg "success" 1 5
+add_dict_user newuser
+
+#test02 list vol
+test_operation "/vol/list?keywords="
+check_msg "success" 2 2
+check_msg "test1" 2 3
+check_msg "test2" 2 4
+
+#test03 stat vol
+test_operation "/client/volStat?name=test1"
+check_msg "success" 3 1
+check_msg "test1" 3 2
+test_operation "/client/volStat?name=test2"
+check_msg "success" 3 3
+check_msg "test2" 3 4
+
+#test04 get vol
+cal_md5 ltptest
+test_operation "/client/vol?name=test1&authKey=$md5"
+check_msg "success" 4 1
+check_msg "PartitionID" 4 2
+check_msg "Status" 4 3
+test_operation "/client/vol?name=test2&authKey=$md5"
+check_msg "client and server auth key do not match" 4 4
+cal_md5 newuser
+test_operation "/client/vol?name=test2&authKey=$md5"
+check_msg "success" 4 5
+check_msg "PartitionID" 4 6
+check_msg "Status" 4 7
+
+#test05 update vol
+cal_md5 ltptest
+test_operation "/vol/update?name=test1&capacity=2&authKey=$md5" newuser
+check_msg "no permission" 5 1
+test_operation "/vol/update?name=test1&capacity=2&authKey=$md5" ltptest
+check_msg "success" 5 2
+test_operation "/vol/update?name=test1&capacity=1&authKey=$md5" root
+check_msg "success" 5 3
+
+#test06 delete vol
+cal_md5 ltptest
+test_operation "/vol/delete?name=test1&authKey=$md5" newuser
+check_msg "no permission" 6 1
+test_operation "/vol/delete?name=test1&authKey=$md5" root
+check_msg "success" 6 2
+cal_md5 newuser
+test_operation "/vol/delete?name=test2&authKey=$md5" newuser
+check_msg "success" 6 3
+test_operation "/user/delete?user=newuser" root
+check_msg "success" 6 4
+
+rm return_Info.json
+rm $cfs_authtool


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patchse add simple auth for master administration APIs. For such
API request, client needs to generate a signature based on
        `signature = HMAC( HMAC("request path", AK), SK )`
and pass it as a parameter to the master. Master parses signature and
verify it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
