### PR TITLE
Fix meta resp and make fuse ReadDir compatible

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -55,6 +55,8 @@ type Super struct {
 	enableXattr   bool
 	rootIno       uint64
 	sc            *SummaryCache
+
+	noReaddirLimit bool
 }
 
 // Functions that Super needs to implement

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -200,8 +200,7 @@ func (m *metadataManager) HandleMetadataOperation(conn net.Conn, p *Packet, remo
 	case proto.OpGetMultipart:
 		err = m.opGetMultipart(conn, p, remoteAddr)
 	default:
-		err = fmt.Errorf("%s unknown Opcode: %d, reqId: %d", remoteAddr,
-			p.Opcode, p.GetReqID())
+		err = m.opUnknownOpCode(conn, p, remoteAddr)
 	}
 	if err != nil {
 		err = errors.NewErrorf("%s [%s] req: %d - %s", remoteAddr, p.GetOpMsg(),

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 
 	"github.com/chubaofs/chubaofs/proto"
+	"github.com/chubaofs/chubaofs/repl"
 	"github.com/chubaofs/chubaofs/util"
 	"github.com/chubaofs/chubaofs/util/errors"
 	"github.com/chubaofs/chubaofs/util/log"
@@ -1383,5 +1384,12 @@ func (m *metadataManager) opListMultipart(conn net.Conn, p *Packet, remote strin
 	}
 	err = mp.ListMultipart(req, p)
 	_ = m.respondToClient(conn, p)
+	return
+}
+
+func (m *metadataManager) opUnknownOpCode(conn net.Conn, p *Packet, remote string) (err error) {
+	err = fmt.Errorf("%s unknown Opcode: %d, reqId: %d", remote, p.Opcode, p.GetReqID())
+	p.PacketErrorWithBody(proto.OpIntraGroupNetErr, ([]byte)(repl.ErrorUnknownOp.Error()))
+	m.respondToClient(conn, p)
 	return
 }

--- a/sdk/meta/meta.go
+++ b/sdk/meta/meta.go
@@ -47,6 +47,7 @@ const (
 	statusInval
 	statusNotPerm
 	statusConflictExtents
+	statusMissmatchVer
 )
 
 const (
@@ -265,6 +266,8 @@ func parseStatus(result uint8) (status int) {
 		status = statusNotPerm
 	case proto.OpConflictExtentsErr:
 		status = statusConflictExtents
+	case proto.OpIntraGroupNetErr:
+		status = statusMissmatchVer
 	default:
 		status = statusError
 	}
@@ -292,6 +295,8 @@ func statusToErrno(status int) error {
 		return syscall.EAGAIN
 	case statusConflictExtents:
 		return syscall.ENOTSUP
+	case statusMissmatchVer:
+		return syscall.ENOSYS
 	default:
 	}
 	return syscall.EIO


### PR DESCRIPTION
1. metanode should give a response to client if any error occurs.
2. For old version metanode, ReadDirLimit may not implemented. ReadDir
   should have the capability to detect and rollback to ReadDirAll.