### PR TITLE
datanode: Repair broken tiny extents more aggressively

### DIFF
--- a/storage/extent.go
+++ b/storage/extent.go
@@ -49,6 +49,7 @@ type ExtentInfo struct {
 	IsDeleted  bool   `json:"deleted"`
 	ModifyTime int64  `json:"modTime"` // random write not update modify time
 	Source     string `json:"src"`
+	Repairing  int32  `json:"repairing"`
 }
 
 func (ei *ExtentInfo) String() (m string) {
@@ -57,6 +58,14 @@ func (ei *ExtentInfo) String() (m string) {
 		source = "none"
 	}
 	return fmt.Sprintf("%v_%v_%v_%v", ei.FileID, ei.Size, ei.IsDeleted, source)
+}
+
+func (ei *ExtentInfo) SetRepairing() bool {
+	return atomic.CompareAndSwapInt32(&ei.Repairing, 0, 1)
+}
+
+func (ei *ExtentInfo) ClearRepairing() {
+	atomic.StoreInt32(&ei.Repairing, 0)
 }
 
 // Extent is an implementation of Extent for local regular extent file data management.


### PR DESCRIPTION
When repairing a broken tiny extent, only up to ~4G data is transmitted.
If a tiny extent is very large, it takes hours to repair the extent.

This patch tries to repair the broken tiny extent continously until
local extent size is equal to remote extent size.  And an atomic
`Reparing' state is added to ExtentInfo to avoid multiple repair-
goroutines repair the same extent.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>