### PR TITLE
build: Workaround for rocksdb compiling errors

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -168,7 +168,8 @@ build_rocksdb() {
         echo "build rocksdb..."
         pushd ${RocksdbBuildPath} >/dev/null
         [ "-$LUA_PATH" != "-" ]  && unset LUA_PATH
-        make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
+        CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move' \
+		make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
         popd >/dev/null
     fi
     cgo_cflags="${cgo_cflags} -I${RocksdbSrcPath}/include"


### PR DESCRIPTION
When compiling cubefs using a newer version gcc (version 10.2.1), it
complains that:

```
./db/version_edit.h:156:33: error: implicitly-declared ‘constexpr rocksdb::FileDescriptor::FileDescriptor(const rocksdb::FileDescriptor&)’ is deprecated [-Werror=deprecated-copy]
   76 | struct FileMetaData {
      |        ^~~~~~~~~~~~

./memtable/inlineskiplist.h:282:11: error: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘struct std::atomic<rocksdb::InlineSkipList<const rocksdb::MemTableRep::KeyComparator&>::Node*>’ with no trivial copy-assignment [-Werror=class-memaccess]
  282 |     memcpy(&next_[0], &height, sizeof(int));
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

./utilities/persistent_cache/persistent_cache_util.h:51:23: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
   51 |     return std::move(t);
      |                       ^
```
The best way to address that is to backport patches or upgrade
rocksdb. However this is a big move for cubefs. So let's just
switch these errors off temporarily to make gcc happy.

Reference: https://github.com/facebook/rocksdb/issues/5303

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>