### PR TITLE
enhance: add cfg diskRdonlySpace for datanode

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -418,9 +418,9 @@ func (dp *DataPartition) Disk() *Disk {
 	return dp.disk
 }
 
-func (dp *DataPartition) IsRejectWrite() bool {
-	return dp.Disk().RejectWrite
-}
+// func (dp *DataPartition) IsRejectWrite() bool {
+// 	return dp.Disk().RejectWrite
+// }
 
 // Status returns the partition status.
 func (dp *DataPartition) Status() int {

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -88,6 +88,7 @@ const (
 	 */
 	CfgMetricsDegrade = "metricsDegrade" // int
 
+	CfgDiskRdonlySpace = "diskRdonlySpace" // int
 	// smux Config
 	ConfigKeyEnableSmuxClient  = "enableSmuxConnPool" //bool
 	ConfigKeySmuxPortShift     = "smuxPortShift"      //int
@@ -271,6 +272,13 @@ func (s *DataNode) startSpaceManager(cfg *config.Config) (err error) {
 	s.space.SetNodeID(s.nodeID)
 	s.space.SetClusterID(s.clusterID)
 
+	diskRdonlySpace := uint64(cfg.GetInt64(CfgDiskRdonlySpace))
+	if diskRdonlySpace < DefaultDiskRetainMin {
+		diskRdonlySpace = DefaultDiskRetainMin
+	}
+
+	log.LogInfof("startSpaceManager preReserveSpace %d", diskRdonlySpace)
+
 	var wg sync.WaitGroup
 	for _, d := range cfg.GetSlice(ConfigKeyDisks) {
 		log.LogDebugf("action[startSpaceManager] load disk raw config(%v).", d)
@@ -300,7 +308,7 @@ func (s *DataNode) startSpaceManager(cfg *config.Config) (err error) {
 		wg.Add(1)
 		go func(wg *sync.WaitGroup, path string, reservedSpace uint64) {
 			defer wg.Done()
-			s.space.LoadDisk(path, reservedSpace, DefaultDiskMaxErr)
+			s.space.LoadDisk(path, reservedSpace, diskRdonlySpace, DefaultDiskMaxErr)
 		}(&wg, path, reservedSpace)
 	}
 	wg.Wait()

--- a/datanode/server_handler.go
+++ b/datanode/server_handler.go
@@ -42,6 +42,7 @@ func (s *DataNode) getDiskAPI(w http.ResponseWriter, r *http.Request) {
 			Allocated   uint64 `json:"allocated"`
 			Status      int    `json:"status"`
 			RestSize    uint64 `json:"restSize"`
+			DiskRdoSize uint64 `json:"diskRdoSize"`
 			Partitions  int    `json:"partitions"`
 		}{
 			Path:        diskItem.Path,
@@ -52,6 +53,7 @@ func (s *DataNode) getDiskAPI(w http.ResponseWriter, r *http.Request) {
 			Allocated:   diskItem.Allocated,
 			Status:      diskItem.Status,
 			RestSize:    diskItem.ReservedSpace,
+			DiskRdoSize: diskItem.DiskRdonlySpace,
 			Partitions:  diskItem.PartitionCount(),
 		}
 		disks = append(disks, disk)

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -162,7 +162,7 @@ func (s *DataNode) handlePacketToCreateExtent(p *repl.Packet) {
 		}
 	}()
 	partition := p.Object.(*DataPartition)
-	if partition.Available() <= 0 || partition.disk.Status == proto.ReadOnly || partition.IsRejectWrite() {
+	if partition.Available() <= 0 || !partition.disk.CanWrite() {
 		err = storage.NoSpaceError
 		return
 	} else if partition.disk.Status == proto.Unavailable {
@@ -425,7 +425,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 	if !shallDegrade {
 		metricPartitionIOLabels = GetIoMetricLabels(partition, "write")
 	}
-	if partition.Available() <= 0 || partition.disk.Status == proto.ReadOnly || partition.IsRejectWrite() {
+	if partition.Available() <= 0 || !partition.disk.CanWrite() {
 		err = storage.NoSpaceError
 		return
 	} else if partition.disk.Status == proto.Unavailable {

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -39,7 +39,7 @@ func (partition *DataPartition) checkStatus(clusterName string, needLog bool, dp
 	switch len(liveReplicas) {
 	case (int)(partition.ReplicaNum):
 		partition.Status = proto.ReadOnly
-		if partition.checkReplicaStatusOnLiveNode(liveReplicas) == true && partition.canWrite() {
+		if partition.checkReplicaStatusOnLiveNode(liveReplicas) && partition.canWrite() {
 			partition.Status = proto.ReadWrite
 		}
 	default:


### PR DESCRIPTION
preReserveSpace is used to avoid writeOp failed when disk is rdonly:
eg: client try to write data on a rw dp, when request arrive datanode server and
find disk is already rdonly, which will cause writeOp failed and have to retry other dp,
once many disks are going to be rdonly(cluster used factor is too bigger), which will casue
a lot retry in clients, make writeOp become slow.

diskRdonlySpace is bigger than reservedSpace,
if reservedSpace < freeSpace < diskRdonlySpace, writeOp is ok, but disk or dp will be rdonly,
if freeSpace < reservedSpace, writeOp will also failed.

Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

