### PR TITLE
fix: Fix logger.Error format

### DIFF
--- a/vendor/github.com/tiglabs/raft/transport_heartbeat.go
+++ b/vendor/github.com/tiglabs/raft/transport_heartbeat.go
@@ -97,7 +97,7 @@ func (t *heartbeatTransport) handleConn(conn *util.ConnTimeout) {
 				return
 			default:
 				if msg, err := reciveMessage(bufRd); err != nil {
-					logger.Error("[heartbeatTransport] recive message from conn error", err.Error())
+					logger.Error("[heartbeatTransport] recive message from conn error: %v", err)
 					return
 				} else {
 					//logger.Debug(fmt.Sprintf("Recive %v from (%v)", msg.ToString(), conn.RemoteAddr()))


### PR DESCRIPTION
Fix the following error message:

```
2022-02-18 12:35:22,026 transport_heartbeat.go:100: [ERROR] [heartbeatTransport] recive message from conn error
%!(EXTRA string=read tcp 192.168.0.31:17330->192.168.0.34:39830: read: connection reset by peer)
^^^^^^^^
```

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>