### PR TITLE
metanode: Fix extra response to connection

### DIFF
--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -1374,24 +1374,23 @@ func (m *metadataManager) opGetMultipart(conn net.Conn, p *Packet, remote string
 }
 
 func (m *metadataManager) opAppendMultipart(conn net.Conn, p *Packet, remote string) (err error) {
-	defer func() {
-		if err != nil {
-			p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
-		}
-		_ = m.respondToClient(conn, p)
-	}()
 	req := &proto.AddMultipartPartRequest{}
 	if err = json.Unmarshal(p.Data, req); err != nil {
+		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		m.respondToClient(conn, p)
 		return
 	}
 	mp, err := m.getPartition(req.PartitionId)
 	if err != nil {
+		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
+		m.respondToClient(conn, p)
 		return
 	}
 	if !m.serveProxy(conn, mp, p) {
 		return
 	}
 	err = mp.AppendMultipart(req, p)
+	_ = m.respondToClient(conn, p)
 	return
 }
 


### PR DESCRIPTION
If current metanode is not the leader, `serveProxy` is called and
conntion is responsed in serveProxy. So caller should not response
again. Otherwise, we may get the following error:

```
2022/02/23 07:03:25.491884 [ERROR] conn.go:139: send: the response packet mismatch with request: conn(A.B.C.D:49774 to E.F.G.H:17210) req(ReqID(529314752)Op(OpMetaLookup)PartitionID(152)ResultCode(Unknown ResultCode(0))) resp(ReqID(529314745)Op(OpAddMultipartPart)PartitionID(150)ResultCode(Ok))
```

Reported-by: wanglei469 <wanglei469@ke.com>
Signed-off-by: Sheng Yong <shengyong2021@gmail.com>