### PR TITLE
metanode: Fix variable scope in migrateMetaNode

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1743,7 +1743,7 @@ func (c *Cluster) migrateMetaNode(srcAddr, targetAddr string, limit int) (err er
 
 	partitions := c.getAllMetaPartitionByMetaNode(srcAddr)
 	if targetAddr != "" {
-		toBeOfflineMps := make([]*MetaPartition, 0)
+		toBeOfflineMps = make([]*MetaPartition, 0)
 		for _, mp := range partitions {
 			if contains(mp.Hosts, targetAddr) {
 				continue


### PR DESCRIPTION
Fixes: 740743119d865 ("master: Remove condition check that is always false")
Signed-off-by: Sheng Yong <shengyong2021@gmail.com>