### PR TITLE
proto: Show name of opcode instead of number

### DIFF
--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -193,7 +193,7 @@ func (s *DataNode) handlePacketToCreateDataPartition(p *repl.Packet) {
 	}
 	request := &proto.CreateDataPartitionRequest{}
 	if task.OpCode != proto.OpCreateDataPartition {
-		err = fmt.Errorf("from master Task(%v) failed,error unavali opcode(%v)", task.ToString(), task.OpCode)
+		err = fmt.Errorf("from master Task(%v) failed,error unavali opcode(%v)", task.ToString(), proto.OpNameOf(task.OpCode))
 		return
 	}
 

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -646,7 +646,7 @@ func (c *Cluster) handleMetaNodeTaskResponse(nodeAddr string, task *proto.AdminT
 		response := task.Response.(*proto.UpdateMetaPartitionResponse)
 		err = c.dealUpdateMetaPartitionResp(task.OperatorAddr, response)
 	default:
-		err := fmt.Errorf("unknown operate code %v", task.OpCode)
+		err := fmt.Errorf("unknown operate code %v", proto.OpNameOf(task.OpCode))
 		log.LogError(err)
 	}
 
@@ -814,7 +814,7 @@ func (c *Cluster) handleDataNodeTaskResponse(nodeAddr string, task *proto.AdminT
 		response := task.Response.(*proto.DataNodeHeartbeatResponse)
 		err = c.handleDataNodeHeartbeatResp(task.OperatorAddr, response)
 	default:
-		err = fmt.Errorf(fmt.Sprintf("unknown operate code %v", task.OpCode))
+		err = fmt.Errorf(fmt.Sprintf("unknown operate code %v", proto.OpNameOf(task.OpCode)))
 		goto errHandler
 	}
 

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -19,13 +19,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/exporter"
 	"github.com/cubefs/cubefs/util/log"
-	"math/rand"
-	"strings"
-	"time"
 )
 
 func newCreateDataPartitionRequest(volName string, ID uint64, members []proto.Peer, dataPartitionSize int, hosts []string, createType int) (req *proto.CreateDataPartitionRequest) {
@@ -94,7 +95,7 @@ func unmarshalTaskResponse(task *proto.AdminTask) (err error) {
 	case proto.OpDecommissionMetaPartition:
 		response = &proto.MetaPartitionDecommissionResponse{}
 	default:
-		log.LogError(fmt.Sprintf("unknown operate code(%v)", task.OpCode))
+		log.LogError(fmt.Sprintf("unknown operate code(%v)", proto.OpNameOf(task.OpCode)))
 	}
 
 	if response == nil {

--- a/proto/admin_task.go
+++ b/proto/admin_task.go
@@ -123,7 +123,7 @@ func NewAdminTask(opCode uint8, opAddr string, request interface{}) (t *AdminTas
 	t.OpCode = opCode
 	t.Request = request
 	t.OperatorAddr = opAddr
-	t.ID = fmt.Sprintf("addr[%v]_op[%v]", t.OperatorAddr, t.OpCode)
+	t.ID = fmt.Sprintf("addr[%v]_op[%v]", t.OperatorAddr, OpNameOf(t.OpCode))
 	t.CreateTime = time.Now().Unix()
 	return
 }

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -392,6 +392,8 @@ func (p *Packet) GetOpMsg() (m string) {
 		m = "OpListMultiparts"
 	case OpBatchDeleteExtent:
 		m = "OpBatchDeleteExtent"
+	default:
+		m = fmt.Sprintf("%v", p.Opcode)
 	}
 	return
 }
@@ -726,4 +728,9 @@ func (p *Packet) ShouldRetry() bool {
 
 func (p *Packet) IsBatchDeleteExtents() bool {
 	return p.Opcode == OpBatchDeleteExtent
+}
+
+func OpNameOf(opcode uint8) string {
+	packet := Packet{Opcode: opcode}
+	return packet.GetOpMsg()
 }


### PR DESCRIPTION
The name of opcode is much straightforward than its value when
checking logs.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>