### PR TITLE
[RFC] datanode: Stop raft server before close metadata files

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -406,8 +406,8 @@ func (dp *DataPartition) Stop() {
 			close(dp.stopC)
 		}
 		// Close the store and raftstore.
-		dp.extentStore.Close()
 		dp.stopRaft()
+		dp.extentStore.Close()
 		_ = dp.storeAppliedID(atomic.LoadUint64(&dp.appliedID))
 	})
 	return


### PR DESCRIPTION
When killing a datanode, the following panic occurs:

```
2022/03/09 12:20:17 action[interceptSignal] received signal: terminated.
goroutine 75408162 [running]:
runtime/debug.Stack(...)
        /home/bin/go/src/runtime/debug/stack.go:24 +0x9f
runtime/debug.PrintStack()
        /home/bin/go/src/runtime/debug/stack.go:16 +0x25
vendor/github.com/tiglabs/raft/util.HandleCrash(...)
        vendor/github.com/tiglabs/raft/util/runtime.go:27 +0x51
panic(...)
        /home/bin/go/src/runtime/panic.go:965 +0x1b9
datanode.(*DataPartition).ApplyRandomWrite.func1(...)
        datanode/partition_op_by_raft.go:225 +0x325
datanode.(*DataPartition).ApplyRandomWrite(...)
        datanode/partition_op_by_raft.go:255 +0x7b0
datanode.(*DataPartition).Apply(...)
        datanode/partition_raftfsm.go:37 +0x57
vendor/github.com/tiglabs/raft.(*raft).runApply(...)
        vendor/github.com/tiglabs/raft/raft.go:232 +0x1e6
vendor/github.com/tiglabs/raft/util.RunWorker.func1(...)
        vendor/github.com/tiglabs/raft/util/runtime.go:51 +0x6c
created by vendor/github.com/tiglabs/raft/util.RunWorker
        vendor/github.com/tiglabs/raft/util/runtime.go:48 +0x5d
```

And the following error messages could be found in log files:

* dataNode_error.log
```
2022/03/09 12:20:17.758881 [ERROR] partition_op_by_raft.go:252: [ApplyRandomWrite] ApplyID(564774) Partition(3646)_Extent(31)_ExtentOffset(32247808)_Size(16384) apply err(write /disk/sda/datapartition_3646_128849018880/31: file already closed) retry(19)
```

* ump_datanode_business.log
```
{"time":"20220309122017000","key":"xxx_dataNode_warning","hostname":"A.B.C.D","type":"0","value":"0","detail":"[ApplyRandomWrite] ApplyID(564774) Partition(3646)_Extent(31)_ExtentOffset(32247808)_Size(16384) apply err(write /disk/sda/datapartition_3646_128849018880/31: file already closed) retry[20]"}
```

which means `ApplyRandomWrite` tries to write an already closed extent
file 20 times. And the write should have not failed.

When shutting down a datanode, its raft server should be closed first
to prevent newer raft requests froming being applied. After that, all
metadata files could be closed safely.

Reported-by: wanglei469 <wanglei469@ke.com>
Signed-off-by: Sheng Yong <shengyong2021@gmail.com>