### PR TITLE
unin test: Add WaitGroup before goroutine starts

### DIFF
--- a/util/synclist/synclist_test.go
+++ b/util/synclist/synclist_test.go
@@ -25,8 +25,8 @@ func TestListPushBach(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	for j := 0; j < 50; j += 1 {
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			for i := 0; i < 1000; i += 1 {
 				println("pushback: ", i)
 				l.PushBack(i)
@@ -35,8 +35,8 @@ func TestListPushBach(t *testing.T) {
 		}()
 	}
 	for j := 0; j < 60; j += 1 {
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			for i := 0; i < 1000; i += 1 {
 				if f := l.Front(); f != nil {
 					println("remove: ", f.Value)
@@ -55,8 +55,8 @@ func TestSyncPushBach(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	for j := 0; j < 50; j += 1 {
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			for i := 0; i < 1000; i += 1 {
 				println("pushback: ", i)
 				l.PushBack(i)
@@ -65,8 +65,8 @@ func TestSyncPushBach(t *testing.T) {
 		}()
 	}
 	for j := 0; j < 60; j += 1 {
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			for i := 0; i < 1000; i += 1 {
 				if f := l.Front(); f != nil {
 					println("remove: ", f.Value)


### PR DESCRIPTION
If the `wg.Add(1)` is called inside a goroutine, there is no guarantee
that `wg.Wait` is called before all `wg.Add(1)`. So `wg.Add(1)` should
be called before goroutine starts. Otherwise, the following error
occurs:

```
panic: sync: WaitGroup is reused before previous Wait has returned [recovered]
	panic: sync: WaitGroup is reused before previous Wait has returned

goroutine 18 [running]:
testing.tRunner.func1.2(0x51cac0, 0x56ebb0)
	/usr/local/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc00009e300)
	/usr/local/go/src/testing/testing.go:1146 +0x4b6
panic(0x51cac0, 0x56ebb0)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
sync.(*WaitGroup).Wait(0xc000098080)
	/usr/local/go/src/sync/waitgroup.go:132 +0xae
github.com/cubefs/cubefs/util/synclist.TestSyncPushBach(0xc00009e300)
	/root/tmp/cfs/go/src/github.com/cubefs/cubefs/util/synclist/synclist_test.go:79 +0xf3
testing.tRunner(0xc00009e300, 0x54f988)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3
```

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>