### PR TITLE
test: change s3-tests from single bucket to double buckets

### DIFF
--- a/docker/s3tests/env.py
+++ b/docker/s3tests/env.py
@@ -14,10 +14,12 @@
 
 # -*- coding: utf-8 -*-
 
+import os
+
 MASTER = 'http://master.chubao.io'
 ENDPOINT = 'http://object.chubao.io'
 ACCESS_KEY = '39bEF4RrAQgMj6RV'
 SECRET_KEY = 'TRL6o3JL16YOqvZGIohBDFTHZDEcFsyd'
-BUCKET = 'ltptest'
+BUCKET = os.environ.get('BUCKET')
 USE_SSL = False
 REGION = 'chubaofs01'


### PR DESCRIPTION
We found a bug when multi bucket were operated.
The s3-tests case now only support single bucket tests.
So I add a bucket named 's3test'.

Signed-off-by: wanglei469 <wanglei469@ke.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
