### PR TITLE
metanode: Adjust the usage of Btree.GetTree

### DIFF
--- a/cli/cmd/compatibility.go
+++ b/cli/cmd/compatibility.go
@@ -102,7 +102,9 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 	if err != nil {
 		return
 	}
-	mp.CloneDentryTree().Ascend(func(d metanode.BtreeItem) bool {
+
+	cnt := 0
+	handler := func(d metanode.BtreeItem) bool {
 		dentry, ok := d.(*metanode.Dentry)
 		if !ok {
 			stdout("item type is not *metanode.Dentry \n")
@@ -121,10 +123,13 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 			err = fmt.Errorf("dentry %v is not equal with old version,dentry[%v],oldDentry[%v]", key, dentry, oldDentry)
 			return false
 		}
+		cnt++
 		return true
-	})
+	}
+	mp.WalkDentryTree(handler)
+
 	if err == nil {
-		stdout("The number of dentry is %v, all dentry are consistent \n", mp.CloneDentryTree().Len())
+		stdout("The number of dentry is %v, all dentry are consistent\n", cnt)
 	}
 	return
 }
@@ -134,9 +139,10 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 	if err != nil {
 		return
 	}
-	var localInode *api.Inode
-	mp.CloneInodeTree().Ascend(func(d metanode.BtreeItem) bool {
-		inode, ok := d.(*metanode.Inode)
+
+	cnt := 0
+	handler := func(i metanode.BtreeItem) bool {
+		inode, ok := i.(*metanode.Inode)
 		if !ok {
 			stdout("item type is not *metanode.Inode \n")
 			err = fmt.Errorf("item type is not *metanode.Inode")
@@ -148,7 +154,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 			err = fmt.Errorf("inode %v is not in old version", inode.Inode)
 			return false
 		}
-		localInode = &api.Inode{
+		localInode := &api.Inode{
 			Inode:      inode.Inode,
 			Type:       inode.Type,
 			Uid:        inode.Uid,
@@ -173,10 +179,13 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 			err = fmt.Errorf("inode %v is not equal with old version,inode[%v],oldInode[%v]\n", inode.Inode, inode, oldInode)
 			return false
 		}
+		cnt++
 		return true
-	})
+	}
+	mp.WalkInodeTree(handler)
+
 	if err == nil {
-		stdout("The number of inodes is %v, all inodes are consistent \n", mp.CloneInodeTree().Len())
+		stdout("The number of inodes is %v, all inodes are consistent\n", cnt)
 	}
 	return
 }

--- a/cli/cmd/compatibility.go
+++ b/cli/cmd/compatibility.go
@@ -16,12 +16,13 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+
 	"github.com/cubefs/cubefs/cli/api"
 	"github.com/cubefs/cubefs/metanode"
 	"github.com/cubefs/cubefs/proto"
 	"github.com/spf13/cobra"
-	"reflect"
-	"strconv"
 )
 
 const (
@@ -101,7 +102,7 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 	if err != nil {
 		return
 	}
-	mp.GetDentryTree().Ascend(func(d metanode.BtreeItem) bool {
+	mp.CloneDentryTree().Ascend(func(d metanode.BtreeItem) bool {
 		dentry, ok := d.(*metanode.Dentry)
 		if !ok {
 			stdout("item type is not *metanode.Dentry \n")
@@ -123,7 +124,7 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 		return true
 	})
 	if err == nil {
-		stdout("The number of dentry is %v, all dentry are consistent \n", mp.GetDentryTree().Len())
+		stdout("The number of dentry is %v, all dentry are consistent \n", mp.CloneDentryTree().Len())
 	}
 	return
 }
@@ -134,7 +135,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 		return
 	}
 	var localInode *api.Inode
-	mp.GetInodeTree().Ascend(func(d metanode.BtreeItem) bool {
+	mp.CloneInodeTree().Ascend(func(d metanode.BtreeItem) bool {
 		inode, ok := d.(*metanode.Inode)
 		if !ok {
 			stdout("item type is not *metanode.Inode \n")
@@ -175,7 +176,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 		return true
 	})
 	if err == nil {
-		stdout("The number of inodes is %v, all inodes are consistent \n", mp.GetInodeTree().Len())
+		stdout("The number of inodes is %v, all inodes are consistent \n", mp.CloneInodeTree().Len())
 	}
 	return
 }

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -181,7 +181,7 @@ func (m *MetaNode) getAllInodesHandler(w http.ResponseWriter, r *http.Request) {
 		return true
 	}
 
-	mp.CloneInodeTree().Ascend(f)
+	mp.(*metaPartition).inodeTree.CloneTree().Ascend(f)
 }
 
 func (m *MetaNode) getInodeHandler(w http.ResponseWriter, r *http.Request) {
@@ -381,7 +381,7 @@ func (m *MetaNode) getAllDentriesHandler(w http.ResponseWriter, r *http.Request)
 		delimiter = []byte{',', '\n'}
 		isFirst   = true
 	)
-	mp.CloneDentryTree().Ascend(func(i BtreeItem) bool {
+	mp.(*metaPartition).dentryTree.CloneTree().Ascend(func(i BtreeItem) bool {
 		if !isFirst {
 			if _, err = w.Write(delimiter); err != nil {
 				return false

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -181,7 +181,7 @@ func (m *MetaNode) getAllInodesHandler(w http.ResponseWriter, r *http.Request) {
 		return true
 	}
 
-	mp.GetInodeTree().Ascend(f)
+	mp.CloneInodeTree().Ascend(f)
 }
 
 func (m *MetaNode) getInodeHandler(w http.ResponseWriter, r *http.Request) {
@@ -381,7 +381,7 @@ func (m *MetaNode) getAllDentriesHandler(w http.ResponseWriter, r *http.Request)
 		delimiter = []byte{',', '\n'}
 		isFirst   = true
 	)
-	mp.GetDentryTree().Ascend(func(i BtreeItem) bool {
+	mp.CloneDentryTree().Ascend(func(i BtreeItem) bool {
 		if !isFirst {
 			if _, err = w.Write(delimiter); err != nil {
 				return false

--- a/metanode/btree.go
+++ b/metanode/btree.go
@@ -15,8 +15,9 @@
 package metanode
 
 import (
-	"github.com/cubefs/cubefs/util/btree"
 	"sync"
+
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 const defaultBTreeDegree = 32
@@ -118,7 +119,7 @@ func (b *BTree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok
 
 // Ascend is the wrapper of the google's btree Ascend.
 // This function scans the entire btree. When the data is huge, it is not recommended to use this function online.
-// Instead, it is recommended to call GetTree to obtain the snapshot of the current btree, and then do the scan on the snapshot.
+// Instead, it is recommended to call CloneTree to obtain the snapshot of the current btree, and then do the scan on the snapshot.
 func (b *BTree) Ascend(fn func(i BtreeItem) bool) {
 	b.RLock()
 	b.tree.Ascend(fn)
@@ -140,7 +141,7 @@ func (b *BTree) AscendGreaterOrEqual(pivot BtreeItem, iterator func(i BtreeItem)
 }
 
 // GetTree returns the snapshot of a btree.
-func (b *BTree) GetTree() *BTree {
+func (b *BTree) CloneTree() *BTree {
 	b.Lock()
 	t := b.tree.Clone()
 	b.Unlock()

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -74,8 +74,8 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 				Status:      proto.ReadWrite,
 				MaxInodeID:  mConf.Cursor,
 				VolName:     mConf.VolName,
-				InodeCnt:    uint64(partition.CloneInodeTree().Len()),
-				DentryCnt:   uint64(partition.CloneDentryTree().Len()),
+				InodeCnt:    uint64(partition.(*metaPartition).inodeTree.Len()),
+				DentryCnt:   uint64(partition.(*metaPartition).dentryTree.Len()),
 			}
 			addr, isLeader := partition.IsLeader()
 			if addr == "" {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -74,8 +74,8 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 				Status:      proto.ReadWrite,
 				MaxInodeID:  mConf.Cursor,
 				VolName:     mConf.VolName,
-				InodeCnt:    uint64(partition.GetInodeTree().Len()),
-				DentryCnt:   uint64(partition.GetDentryTree().Len()),
+				InodeCnt:    uint64(partition.CloneInodeTree().Len()),
+				DentryCnt:   uint64(partition.CloneDentryTree().Len()),
 			}
 			addr, isLeader := partition.IsLeader()
 			if addr == "" {

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -43,10 +43,9 @@ func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
 	labels := map[string]string{
 		"partid": fmt.Sprintf("%d", mp.config.PartitionId),
 	}
-	it := mp.CloneInodeTree()
-	if it != nil {
-		exporter.NewGauge("mpInodeCount").SetWithLabels(float64(it.Len()), labels)
-	}
+
+	cnt := mp.inodeTree.Len()
+	exporter.NewGauge("mpInodeCount").SetWithLabels(float64(cnt), labels)
 }
 
 func (m *MetaNode) collectPartitionMetrics() {

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -43,7 +43,7 @@ func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
 	labels := map[string]string{
 		"partid": fmt.Sprintf("%d", mp.config.PartitionId),
 	}
-	it := mp.GetInodeTree()
+	it := mp.CloneInodeTree()
 	if it != nil {
 		exporter.NewGauge("mpInodeCount").SetWithLabels(float64(it.Len()), labels)
 	}

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -117,7 +117,7 @@ type OpInode interface {
 	EvictInode(req *EvictInodeReq, p *Packet) (err error)
 	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
 	SetAttr(reqData []byte, p *Packet) (err error)
-	GetInodeTree() *BTree
+	CloneInodeTree() *BTree
 	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
 	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
 }
@@ -141,7 +141,7 @@ type OpDentry interface {
 	ReadDirLimit(req *ReadDirLimitReq, p *Packet) (err error)
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
-	GetDentryTree() *BTree
+	CloneDentryTree() *BTree
 }
 
 // OpExtent defines the interface for the extent operations.
@@ -632,8 +632,8 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
-	resp.InodeCount = uint64(mp.getInodeTree().Len())
-	resp.DentryCount = uint64(mp.getDentryTree().Len())
+	resp.InodeCount = uint64(mp.cloneInodeTree().Len())
+	resp.DentryCount = uint64(mp.cloneDentryTree().Len())
 	resp.ApplyID = mp.applyID
 	if err != nil {
 		err = errors.Trace(err,

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -117,7 +117,7 @@ type OpInode interface {
 	EvictInode(req *EvictInodeReq, p *Packet) (err error)
 	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
 	SetAttr(reqData []byte, p *Packet) (err error)
-	CloneInodeTree() *BTree
+	WalkInodeTree(handler func(item BtreeItem) bool)
 	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
 	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
 }
@@ -141,7 +141,7 @@ type OpDentry interface {
 	ReadDirLimit(req *ReadDirLimitReq, p *Packet) (err error)
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
-	CloneDentryTree() *BTree
+	WalkDentryTree(handler func(item BtreeItem) bool)
 }
 
 // OpExtent defines the interface for the extent operations.
@@ -632,8 +632,8 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
-	resp.InodeCount = uint64(mp.cloneInodeTree().Len())
-	resp.DentryCount = uint64(mp.cloneDentryTree().Len())
+	resp.InodeCount = uint64(mp.inodeTree.Len())
+	resp.DentryCount = uint64(mp.dentryTree.Len())
 	resp.ApplyID = mp.applyID
 	if err != nil {
 		err = errors.Trace(err,

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -142,10 +142,10 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		}
 		resp = mp.fsmAppendExtentsWithCheck(ino)
 	case opFSMStoreTick:
-		inodeTree := mp.getInodeTree()
-		dentryTree := mp.getDentryTree()
-		extendTree := mp.extendTree.GetTree()
-		multipartTree := mp.multipartTree.GetTree()
+		inodeTree := mp.cloneInodeTree()
+		dentryTree := mp.cloneDentryTree()
+		extendTree := mp.extendTree.CloneTree()
+		multipartTree := mp.multipartTree.CloneTree()
 		msg := &storeMsg{
 			command:       opFSMStoreTick,
 			applyIndex:    index,

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -142,8 +142,8 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		}
 		resp = mp.fsmAppendExtentsWithCheck(ino)
 	case opFSMStoreTick:
-		inodeTree := mp.cloneInodeTree()
-		dentryTree := mp.cloneDentryTree()
+		inodeTree := mp.inodeTree.CloneTree()
+		dentryTree := mp.dentryTree.CloneTree()
 		extendTree := mp.extendTree.CloneTree()
 		multipartTree := mp.multipartTree.CloneTree()
 		msg := &storeMsg{

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -155,10 +155,6 @@ func (mp *metaPartition) fsmUpdateDentry(dentry *Dentry) (
 	return
 }
 
-func (mp *metaPartition) cloneDentryTree() *BTree {
-	return mp.dentryTree.CloneTree()
-}
-
 func (mp *metaPartition) readDir(req *ReadDirReq) (resp *ReadDirResp) {
 	resp = &ReadDirResp{}
 	begDentry := &Dentry{

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -155,8 +155,8 @@ func (mp *metaPartition) fsmUpdateDentry(dentry *Dentry) (
 	return
 }
 
-func (mp *metaPartition) getDentryTree() *BTree {
-	return mp.dentryTree.GetTree()
+func (mp *metaPartition) cloneDentryTree() *BTree {
+	return mp.dentryTree.CloneTree()
 }
 
 func (mp *metaPartition) readDir(req *ReadDirReq) (resp *ReadDirResp) {

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -98,10 +98,6 @@ func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
 	return
 }
 
-func (mp *metaPartition) cloneInodeTree() *BTree {
-	return mp.inodeTree.CloneTree()
-}
-
 // Ascend is the wrapper of inodeTree.Ascend
 func (mp *metaPartition) Ascend(f func(i BtreeItem) bool) {
 	mp.inodeTree.Ascend(f)

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -98,8 +98,8 @@ func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
 	return
 }
 
-func (mp *metaPartition) getInodeTree() *BTree {
-	return mp.inodeTree.GetTree()
+func (mp *metaPartition) cloneInodeTree() *BTree {
+	return mp.inodeTree.CloneTree()
 }
 
 // Ascend is the wrapper of inodeTree.Ascend

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -144,10 +144,10 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 	si = new(MetaItemIterator)
 	si.fileRootDir = mp.config.RootDir
 	si.applyID = mp.applyID
-	si.inodeTree = mp.inodeTree.GetTree()
-	si.dentryTree = mp.dentryTree.GetTree()
-	si.extendTree = mp.extendTree.GetTree()
-	si.multipartTree = mp.multipartTree.GetTree()
+	si.inodeTree = mp.inodeTree.CloneTree()
+	si.dentryTree = mp.dentryTree.CloneTree()
+	si.extendTree = mp.extendTree.CloneTree()
+	si.multipartTree = mp.multipartTree.CloneTree()
 	si.dataCh = make(chan interface{})
 	si.errorCh = make(chan error, 1)
 	si.closeCh = make(chan struct{})

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -235,7 +235,7 @@ func (mp *metaPartition) Lookup(req *LookupReq, p *Packet) (err error) {
 	return
 }
 
-// CloneDentryTree returns the dentry tree stored in the meta partition.
-func (mp *metaPartition) CloneDentryTree() *BTree {
-	return mp.dentryTree.CloneTree()
+// handler should not modify items
+func (mp *metaPartition) WalkDentryTree(handler func(item BtreeItem) bool) {
+	mp.dentryTree.Ascend(handler)
 }

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -235,7 +235,7 @@ func (mp *metaPartition) Lookup(req *LookupReq, p *Packet) (err error) {
 	return
 }
 
-// GetDentryTree returns the dentry tree stored in the meta partition.
-func (mp *metaPartition) GetDentryTree() *BTree {
-	return mp.dentryTree.GetTree()
+// CloneDentryTree returns the dentry tree stored in the meta partition.
+func (mp *metaPartition) CloneDentryTree() *BTree {
+	return mp.dentryTree.CloneTree()
 }

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -315,9 +315,9 @@ func (mp *metaPartition) SetAttr(reqData []byte, p *Packet) (err error) {
 	return
 }
 
-// GetInodeTree returns the inode tree.
-func (mp *metaPartition) GetInodeTree() *BTree {
-	return mp.inodeTree.GetTree()
+// CloneInodeTree returns the inode tree.
+func (mp *metaPartition) CloneInodeTree() *BTree {
+	return mp.inodeTree.CloneTree()
 }
 
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error) {

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -315,9 +315,9 @@ func (mp *metaPartition) SetAttr(reqData []byte, p *Packet) (err error) {
 	return
 }
 
-// CloneInodeTree returns the inode tree.
-func (mp *metaPartition) CloneInodeTree() *BTree {
-	return mp.inodeTree.CloneTree()
+// handler should not modify item
+func (mp *metaPartition) WalkInodeTree(handler func(item BtreeItem) bool) {
+	mp.inodeTree.Ascend(handler)
 }
 
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error) {


### PR DESCRIPTION
Btree.GetTree() starts a COW clone for a tree. It would be better
not to clone a tree in the following scenarios:
  * when reporting the number of inodes or dentries, clone a tree
    does not help report a more precise value
  * if a tree is already cloned, do not clone it once more to get
    its length

This patch also removes duplicated definitions of getting inode
and dentry trees.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>