### PR TITLE
cli: Fix failure of unmarshal Inode.Extents

### DIFF
--- a/cli/api/metaapi.go
+++ b/cli/api/metaapi.go
@@ -25,10 +25,11 @@ import (
 	"time"
 
 	"bufio"
+	"io"
+
 	"github.com/cubefs/cubefs/metanode"
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util/log"
-	"io"
 )
 
 const (
@@ -49,8 +50,8 @@ type Inode struct {
 	LinkTarget []byte // SymLink target name
 	NLink      uint32 // NodeLink counts
 	Flag       int32
-	Reserved   uint64 // reserved space
-	Extents    []proto.ExtentKey
+	Reserved   uint64            // reserved space
+	Extents    []proto.ExtentKey `json:"-"`
 }
 
 // String returns the string format of the inode.

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -65,7 +65,7 @@ type Inode struct {
 	Flag       int32
 	Reserved   uint64 // reserved space
 	//Extents    *ExtentsTree
-	Extents *SortedExtents
+	Extents *SortedExtents `json:"-"`
 }
 
 type InodeBatch []*Inode


### PR DESCRIPTION
When executing:
	cfs-cli compatibility meta ./ 192.168.0.22:17220 147

The following error returned:
```
[Meta partition is 147, verify result]
The number of dentry is 0, all dentry are consistent
Error: json: cannot unmarshal object into Go struct field Inode.Extents of type []proto.ExtentKey
```

The reason is that the definitions of `Extents' of `Inode' in cli and
metanode are different. The former is defined as a slice, while the
latter is defined as a non-exportable pointer. So ignore the key in
both marshal and unmarshal sides.

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>