### PR TITLE
sdk: reduce file fragmentation

### DIFF
--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -429,10 +429,6 @@ func (s *Streamer) doWrite(data []byte, offset, size int, direct bool) (total in
 		if s.handler == nil {
 			s.handler = NewExtentHandler(s, offset, storeMode, 0)
 			s.dirty = false
-		} else if s.handler.storeMode != storeMode {
-			// store mode changed, so close open handler and start a new one
-			s.closeOpenHandler()
-			continue
 		}
 
 		ek, err = s.handler.write(data, offset, size, direct)


### PR DESCRIPTION
if ExtentHandle is exist, keep use it, don't need storeMode.
write data to old ExtentHandle. if we change it, Increases file
 fragmentation

Signed-off-by: 李艳坤 <liyankun01@58.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
