### PR TITLE
[RFC] Refactor btree in metanode

### DIFF
--- a/cli/cmd/compatibility.go
+++ b/cli/cmd/compatibility.go
@@ -102,7 +102,9 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 	if err != nil {
 		return
 	}
-	mp.CloneDentryTree().Ascend(func(d metanode.BtreeItem) bool {
+
+	cnt := 0
+	handler := func(d metanode.BtreeItem) bool {
 		dentry, ok := d.(*metanode.Dentry)
 		if !ok {
 			stdout("item type is not *metanode.Dentry \n")
@@ -121,10 +123,13 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 			err = fmt.Errorf("dentry %v is not equal with old version,dentry[%v],oldDentry[%v]", key, dentry, oldDentry)
 			return false
 		}
+		cnt++
 		return true
-	})
+	}
+	mp.WalkDentryTree(handler)
+
 	if err == nil {
-		stdout("The number of dentry is %v, all dentry are consistent \n", mp.CloneDentryTree().Len())
+		stdout("The number of dentry is %v, all dentry are consistent\n", cnt)
 	}
 	return
 }
@@ -134,9 +139,10 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 	if err != nil {
 		return
 	}
-	var localInode *api.Inode
-	mp.CloneInodeTree().Ascend(func(d metanode.BtreeItem) bool {
-		inode, ok := d.(*metanode.Inode)
+
+	cnt := 0
+	handler := func(i metanode.BtreeItem) bool {
+		inode, ok := i.(*metanode.Inode)
 		if !ok {
 			stdout("item type is not *metanode.Inode \n")
 			err = fmt.Errorf("item type is not *metanode.Inode")
@@ -148,7 +154,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 			err = fmt.Errorf("inode %v is not in old version", inode.Inode)
 			return false
 		}
-		localInode = &api.Inode{
+		localInode := &api.Inode{
 			Inode:      inode.Inode,
 			Type:       inode.Type,
 			Uid:        inode.Uid,
@@ -173,10 +179,13 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 			err = fmt.Errorf("inode %v is not equal with old version,inode[%v],oldInode[%v]\n", inode.Inode, inode, oldInode)
 			return false
 		}
+		cnt++
 		return true
-	})
+	}
+	mp.WalkInodeTree(handler)
+
 	if err == nil {
-		stdout("The number of inodes is %v, all inodes are consistent \n", mp.CloneInodeTree().Len())
+		stdout("The number of inodes is %v, all inodes are consistent\n", cnt)
 	}
 	return
 }

--- a/cli/cmd/compatibility.go
+++ b/cli/cmd/compatibility.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cubefs/cubefs/cli/api"
 	"github.com/cubefs/cubefs/metanode"
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/btree"
 	"github.com/spf13/cobra"
 )
 
@@ -104,7 +105,7 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 	}
 
 	cnt := 0
-	handler := func(d metanode.BtreeItem) bool {
+	handler := func(d btree.Item) bool {
 		dentry, ok := d.(*metanode.Dentry)
 		if !ok {
 			stdout("item type is not *metanode.Dentry \n")
@@ -141,7 +142,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 	}
 
 	cnt := 0
-	handler := func(i metanode.BtreeItem) bool {
+	handler := func(i btree.Item) bool {
 		inode, ok := i.(*metanode.Inode)
 		if !ok {
 			stdout("item type is not *metanode.Inode \n")

--- a/cli/cmd/compatibility.go
+++ b/cli/cmd/compatibility.go
@@ -16,12 +16,13 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
+
 	"github.com/cubefs/cubefs/cli/api"
 	"github.com/cubefs/cubefs/metanode"
 	"github.com/cubefs/cubefs/proto"
 	"github.com/spf13/cobra"
-	"reflect"
-	"strconv"
 )
 
 const (
@@ -101,7 +102,7 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 	if err != nil {
 		return
 	}
-	mp.GetDentryTree().Ascend(func(d metanode.BtreeItem) bool {
+	mp.CloneDentryTree().Ascend(func(d metanode.BtreeItem) bool {
 		dentry, ok := d.(*metanode.Dentry)
 		if !ok {
 			stdout("item type is not *metanode.Dentry \n")
@@ -123,7 +124,7 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 		return true
 	})
 	if err == nil {
-		stdout("The number of dentry is %v, all dentry are consistent \n", mp.GetDentryTree().Len())
+		stdout("The number of dentry is %v, all dentry are consistent \n", mp.CloneDentryTree().Len())
 	}
 	return
 }
@@ -134,7 +135,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 		return
 	}
 	var localInode *api.Inode
-	mp.GetInodeTree().Ascend(func(d metanode.BtreeItem) bool {
+	mp.CloneInodeTree().Ascend(func(d metanode.BtreeItem) bool {
 		inode, ok := d.(*metanode.Inode)
 		if !ok {
 			stdout("item type is not *metanode.Inode \n")
@@ -175,7 +176,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 		return true
 	})
 	if err == nil {
-		stdout("The number of inodes is %v, all inodes are consistent \n", mp.GetInodeTree().Len())
+		stdout("The number of inodes is %v, all inodes are consistent \n", mp.CloneInodeTree().Len())
 	}
 	return
 }

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -181,7 +181,7 @@ func (m *MetaNode) getAllInodesHandler(w http.ResponseWriter, r *http.Request) {
 		return true
 	}
 
-	mp.CloneInodeTree().Ascend(f)
+	mp.(*metaPartition).inodeTree.CloneTree().Ascend(f)
 }
 
 func (m *MetaNode) getInodeHandler(w http.ResponseWriter, r *http.Request) {
@@ -381,7 +381,7 @@ func (m *MetaNode) getAllDentriesHandler(w http.ResponseWriter, r *http.Request)
 		delimiter = []byte{',', '\n'}
 		isFirst   = true
 	)
-	mp.CloneDentryTree().Ascend(func(i BtreeItem) bool {
+	mp.(*metaPartition).dentryTree.CloneTree().Ascend(func(i BtreeItem) bool {
 		if !isFirst {
 			if _, err = w.Write(delimiter); err != nil {
 				return false

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -181,7 +181,7 @@ func (m *MetaNode) getAllInodesHandler(w http.ResponseWriter, r *http.Request) {
 		return true
 	}
 
-	mp.GetInodeTree().Ascend(f)
+	mp.CloneInodeTree().Ascend(f)
 }
 
 func (m *MetaNode) getInodeHandler(w http.ResponseWriter, r *http.Request) {
@@ -381,7 +381,7 @@ func (m *MetaNode) getAllDentriesHandler(w http.ResponseWriter, r *http.Request)
 		delimiter = []byte{',', '\n'}
 		isFirst   = true
 	)
-	mp.GetDentryTree().Ascend(func(i BtreeItem) bool {
+	mp.CloneDentryTree().Ascend(func(i BtreeItem) bool {
 		if !isFirst {
 			if _, err = w.Write(delimiter); err != nil {
 				return false

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/btree"
 	"github.com/cubefs/cubefs/util/log"
 )
 
@@ -154,7 +155,7 @@ func (m *MetaNode) getAllInodesHandler(w http.ResponseWriter, r *http.Request) {
 
 	var inode *Inode
 
-	f := func(i BtreeItem) bool {
+	f := func(i btree.Item) bool {
 		var (
 			data []byte
 			e    error
@@ -381,7 +382,7 @@ func (m *MetaNode) getAllDentriesHandler(w http.ResponseWriter, r *http.Request)
 		delimiter = []byte{',', '\n'}
 		isFirst   = true
 	)
-	mp.(*metaPartition).dentryTree.CloneTree().Ascend(func(i BtreeItem) bool {
+	mp.(*metaPartition).dentryTree.CloneTree().Ascend(func(i btree.Item) bool {
 		if !isFirst {
 			if _, err = w.Write(delimiter); err != nil {
 				return false

--- a/metanode/btree.go
+++ b/metanode/btree.go
@@ -15,8 +15,9 @@
 package metanode
 
 import (
-	"github.com/cubefs/cubefs/util/btree"
 	"sync"
+
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 const defaultBTreeDegree = 32
@@ -118,7 +119,7 @@ func (b *BTree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok
 
 // Ascend is the wrapper of the google's btree Ascend.
 // This function scans the entire btree. When the data is huge, it is not recommended to use this function online.
-// Instead, it is recommended to call GetTree to obtain the snapshot of the current btree, and then do the scan on the snapshot.
+// Instead, it is recommended to call CloneTree to obtain the snapshot of the current btree, and then do the scan on the snapshot.
 func (b *BTree) Ascend(fn func(i BtreeItem) bool) {
 	b.RLock()
 	b.tree.Ascend(fn)
@@ -140,7 +141,7 @@ func (b *BTree) AscendGreaterOrEqual(pivot BtreeItem, iterator func(i BtreeItem)
 }
 
 // GetTree returns the snapshot of a btree.
-func (b *BTree) GetTree() *BTree {
+func (b *BTree) CloneTree() *BTree {
 	b.Lock()
 	t := b.tree.Clone()
 	b.Unlock()

--- a/metanode/btree.go
+++ b/metanode/btree.go
@@ -22,10 +22,9 @@ import (
 
 const defaultBTreeDegree = 32
 
-type (
-	// BtreeItem type alias google btree Item
-	BtreeItem = btree.Item
-)
+type BtreeItem interface {
+	btree.Item
+}
 
 // Btree is the wrapper of Google's btree.
 type Btree struct {
@@ -41,14 +40,14 @@ func NewBtree() *Btree {
 }
 
 // Get returns the object of the given key in the btree.
-func (b *Btree) Get(key BtreeItem) (item BtreeItem) {
+func (b *Btree) Get(key btree.Item) (item btree.Item) {
 	b.RLock()
 	item = b.tree.Get(key)
 	b.RUnlock()
 	return
 }
 
-func (b *Btree) CopyGet(key BtreeItem) (item BtreeItem) {
+func (b *Btree) CopyGet(key btree.Item) (item btree.Item) {
 	b.Lock()
 	item = b.tree.CopyGet(key)
 	b.Unlock()
@@ -56,7 +55,7 @@ func (b *Btree) CopyGet(key BtreeItem) (item BtreeItem) {
 }
 
 // Find searches for the given key in the btree.
-func (b *Btree) Find(key BtreeItem, fn func(i BtreeItem)) {
+func (b *Btree) Find(key btree.Item, fn func(i btree.Item)) {
 	b.RLock()
 	item := b.tree.Get(key)
 	b.RUnlock()
@@ -66,7 +65,7 @@ func (b *Btree) Find(key BtreeItem, fn func(i BtreeItem)) {
 	fn(item)
 }
 
-func (b *Btree) CopyFind(key BtreeItem, fn func(i BtreeItem)) {
+func (b *Btree) CopyFind(key btree.Item, fn func(i btree.Item)) {
 	b.Lock()
 	item := b.tree.CopyGet(key)
 	fn(item)
@@ -74,7 +73,7 @@ func (b *Btree) CopyFind(key BtreeItem, fn func(i BtreeItem)) {
 }
 
 // Has checks if the key exists in the btree.
-func (b *Btree) Has(key BtreeItem) (ok bool) {
+func (b *Btree) Has(key btree.Item) (ok bool) {
 	b.RLock()
 	ok = b.tree.Has(key)
 	b.RUnlock()
@@ -82,21 +81,21 @@ func (b *Btree) Has(key BtreeItem) (ok bool) {
 }
 
 // Delete deletes the object by the given key.
-func (b *Btree) Delete(key BtreeItem) (item BtreeItem) {
+func (b *Btree) Delete(key btree.Item) (item btree.Item) {
 	b.Lock()
 	item = b.tree.Delete(key)
 	b.Unlock()
 	return
 }
 
-func (b *Btree) Execute(fn func(tree *btree.BTree) interface{}) interface{} {
+func (b *Btree) Execute(fn func(tree *btree.BTree) btree.Item) btree.Item {
 	b.Lock()
 	defer b.Unlock()
 	return fn(b.tree)
 }
 
 // ReplaceOrInsert is the wrapper of google's btree ReplaceOrInsert.
-func (b *Btree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok bool) {
+func (b *Btree) ReplaceOrInsert(key btree.Item, replace bool) (item btree.Item, ok bool) {
 	b.Lock()
 	if replace {
 		item = b.tree.ReplaceOrInsert(key)
@@ -120,21 +119,21 @@ func (b *Btree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok
 // Ascend is the wrapper of the google's btree Ascend.
 // This function scans the entire btree. When the data is huge, it is not recommended to use this function online.
 // Instead, it is recommended to call CloneTree to obtain the snapshot of the current btree, and then do the scan on the snapshot.
-func (b *Btree) Ascend(fn func(i BtreeItem) bool) {
+func (b *Btree) Ascend(fn func(i btree.Item) bool) {
 	b.RLock()
 	b.tree.Ascend(fn)
 	b.RUnlock()
 }
 
 // AscendRange is the wrapper of the google's btree AscendRange.
-func (b *Btree) AscendRange(greaterOrEqual, lessThan BtreeItem, iterator func(i BtreeItem) bool) {
+func (b *Btree) AscendRange(greaterOrEqual, lessThan btree.Item, iterator func(i btree.Item) bool) {
 	b.RLock()
 	b.tree.AscendRange(greaterOrEqual, lessThan, iterator)
 	b.RUnlock()
 }
 
 // AscendGreaterOrEqual is the wrapper of the google's btree AscendGreaterOrEqual
-func (b *Btree) AscendGreaterOrEqual(pivot BtreeItem, iterator func(i BtreeItem) bool) {
+func (b *Btree) AscendGreaterOrEqual(pivot btree.Item, iterator func(i btree.Item) bool) {
 	b.RLock()
 	b.tree.AscendGreaterOrEqual(pivot, iterator)
 	b.RUnlock()
@@ -166,9 +165,9 @@ func (b *Btree) Len() (size int) {
 }
 
 // MaxItem returns the largest item in the btree.
-func (b *Btree) MaxItem() BtreeItem {
+func (b *Btree) MaxItem() (item btree.Item) {
 	b.RLock()
-	item := b.tree.Max()
+	item = b.tree.Max()
 	b.RUnlock()
-	return item
+	return
 }

--- a/metanode/btree.go
+++ b/metanode/btree.go
@@ -27,28 +27,28 @@ type (
 	BtreeItem = btree.Item
 )
 
-// BTree is the wrapper of Google's btree.
-type BTree struct {
+// Btree is the wrapper of Google's btree.
+type Btree struct {
 	sync.RWMutex
 	tree *btree.BTree
 }
 
 // NewBtree creates a new btree.
-func NewBtree() *BTree {
-	return &BTree{
+func NewBtree() *Btree {
+	return &Btree{
 		tree: btree.New(defaultBTreeDegree),
 	}
 }
 
 // Get returns the object of the given key in the btree.
-func (b *BTree) Get(key BtreeItem) (item BtreeItem) {
+func (b *Btree) Get(key BtreeItem) (item BtreeItem) {
 	b.RLock()
 	item = b.tree.Get(key)
 	b.RUnlock()
 	return
 }
 
-func (b *BTree) CopyGet(key BtreeItem) (item BtreeItem) {
+func (b *Btree) CopyGet(key BtreeItem) (item BtreeItem) {
 	b.Lock()
 	item = b.tree.CopyGet(key)
 	b.Unlock()
@@ -56,7 +56,7 @@ func (b *BTree) CopyGet(key BtreeItem) (item BtreeItem) {
 }
 
 // Find searches for the given key in the btree.
-func (b *BTree) Find(key BtreeItem, fn func(i BtreeItem)) {
+func (b *Btree) Find(key BtreeItem, fn func(i BtreeItem)) {
 	b.RLock()
 	item := b.tree.Get(key)
 	b.RUnlock()
@@ -66,7 +66,7 @@ func (b *BTree) Find(key BtreeItem, fn func(i BtreeItem)) {
 	fn(item)
 }
 
-func (b *BTree) CopyFind(key BtreeItem, fn func(i BtreeItem)) {
+func (b *Btree) CopyFind(key BtreeItem, fn func(i BtreeItem)) {
 	b.Lock()
 	item := b.tree.CopyGet(key)
 	fn(item)
@@ -74,7 +74,7 @@ func (b *BTree) CopyFind(key BtreeItem, fn func(i BtreeItem)) {
 }
 
 // Has checks if the key exists in the btree.
-func (b *BTree) Has(key BtreeItem) (ok bool) {
+func (b *Btree) Has(key BtreeItem) (ok bool) {
 	b.RLock()
 	ok = b.tree.Has(key)
 	b.RUnlock()
@@ -82,21 +82,21 @@ func (b *BTree) Has(key BtreeItem) (ok bool) {
 }
 
 // Delete deletes the object by the given key.
-func (b *BTree) Delete(key BtreeItem) (item BtreeItem) {
+func (b *Btree) Delete(key BtreeItem) (item BtreeItem) {
 	b.Lock()
 	item = b.tree.Delete(key)
 	b.Unlock()
 	return
 }
 
-func (b *BTree) Execute(fn func(tree *btree.BTree) interface{}) interface{} {
+func (b *Btree) Execute(fn func(tree *btree.BTree) interface{}) interface{} {
 	b.Lock()
 	defer b.Unlock()
 	return fn(b.tree)
 }
 
 // ReplaceOrInsert is the wrapper of google's btree ReplaceOrInsert.
-func (b *BTree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok bool) {
+func (b *Btree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok bool) {
 	b.Lock()
 	if replace {
 		item = b.tree.ReplaceOrInsert(key)
@@ -120,28 +120,28 @@ func (b *BTree) ReplaceOrInsert(key BtreeItem, replace bool) (item BtreeItem, ok
 // Ascend is the wrapper of the google's btree Ascend.
 // This function scans the entire btree. When the data is huge, it is not recommended to use this function online.
 // Instead, it is recommended to call CloneTree to obtain the snapshot of the current btree, and then do the scan on the snapshot.
-func (b *BTree) Ascend(fn func(i BtreeItem) bool) {
+func (b *Btree) Ascend(fn func(i BtreeItem) bool) {
 	b.RLock()
 	b.tree.Ascend(fn)
 	b.RUnlock()
 }
 
 // AscendRange is the wrapper of the google's btree AscendRange.
-func (b *BTree) AscendRange(greaterOrEqual, lessThan BtreeItem, iterator func(i BtreeItem) bool) {
+func (b *Btree) AscendRange(greaterOrEqual, lessThan BtreeItem, iterator func(i BtreeItem) bool) {
 	b.RLock()
 	b.tree.AscendRange(greaterOrEqual, lessThan, iterator)
 	b.RUnlock()
 }
 
 // AscendGreaterOrEqual is the wrapper of the google's btree AscendGreaterOrEqual
-func (b *BTree) AscendGreaterOrEqual(pivot BtreeItem, iterator func(i BtreeItem) bool) {
+func (b *Btree) AscendGreaterOrEqual(pivot BtreeItem, iterator func(i BtreeItem) bool) {
 	b.RLock()
 	b.tree.AscendGreaterOrEqual(pivot, iterator)
 	b.RUnlock()
 }
 
 // GetTree returns the snapshot of a btree.
-func (b *BTree) CloneTree() *BTree {
+func (b *Btree) CloneTree() *Btree {
 	b.Lock()
 	t := b.tree.Clone()
 	b.Unlock()
@@ -151,14 +151,14 @@ func (b *BTree) CloneTree() *BTree {
 }
 
 // Reset resets the current btree.
-func (b *BTree) Reset() {
+func (b *Btree) Reset() {
 	b.Lock()
 	b.tree.Clear(true)
 	b.Unlock()
 }
 
 // Len returns the total number of items in the btree.
-func (b *BTree) Len() (size int) {
+func (b *Btree) Len() (size int) {
 	b.RLock()
 	size = b.tree.Len()
 	b.RUnlock()
@@ -166,7 +166,7 @@ func (b *BTree) Len() (size int) {
 }
 
 // MaxItem returns the largest item in the btree.
-func (b *BTree) MaxItem() BtreeItem {
+func (b *Btree) MaxItem() BtreeItem {
 	b.RLock()
 	item := b.tree.Max()
 	b.RUnlock()

--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -17,6 +17,8 @@ package metanode
 import (
 	"bytes"
 	"encoding/binary"
+
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 // Dentry wraps necessary properties of the `dentry` information in file system.
@@ -151,13 +153,13 @@ func DentryBatchUnmarshal(raw []byte) (DentryBatch, error) {
 
 // Less tests whether the current dentry is less than the given one.
 // This method is necessary fot B-Tree item implementation.
-func (d *Dentry) Less(than BtreeItem) (less bool) {
+func (d *Dentry) Less(than btree.Item) (less bool) {
 	dentry, ok := than.(*Dentry)
 	less = ok && ((d.ParentId < dentry.ParentId) || ((d.ParentId == dentry.ParentId) && (d.Name < dentry.Name)))
 	return
 }
 
-func (d *Dentry) Copy() BtreeItem {
+func (d *Dentry) Copy() btree.Item {
 	newDentry := *d
 	return &newDentry
 }

--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -45,6 +45,8 @@ type Dentry struct {
 	Name     string // Name of the current dentry.
 	Inode    uint64 // FileID value of the current inode.
 	Type     uint32
+
+	ver uint64 // used only for Btree
 }
 
 type DentryBatch []*Dentry
@@ -162,6 +164,14 @@ func (d *Dentry) Less(than btree.Item) (less bool) {
 func (d *Dentry) Copy() btree.Item {
 	newDentry := *d
 	return &newDentry
+}
+
+func (d *Dentry) GetVersion() uint64 {
+	return d.ver
+}
+
+func (d *Dentry) SetVersion(ver uint64) {
+	d.ver = ver
 }
 
 // MarshalKey is the bytes version of the MarshalKey method which returns the byte slice result.

--- a/metanode/extend.go
+++ b/metanode/extend.go
@@ -26,6 +26,8 @@ type Extend struct {
 	inode   uint64
 	dataMap map[string][]byte
 	mu      sync.RWMutex
+
+	ver uint64 // used only for Btree
 }
 
 func NewExtend(inode uint64) *Extend {
@@ -125,6 +127,14 @@ func (e *Extend) Copy() btree.Item {
 		newExt.dataMap[k] = v
 	}
 	return newExt
+}
+
+func (e *Extend) GetVersion() uint64 {
+	return e.ver
+}
+
+func (e *Extend) SetVersion(ver uint64) {
+	e.ver = ver
 }
 
 func (e *Extend) Bytes() ([]byte, error) {

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -67,6 +67,8 @@ type Inode struct {
 	Reserved   uint64 // reserved space
 	//Extents    *ExtentsTree
 	Extents *SortedExtents
+
+	ver uint64 // used only for Btree
 }
 
 type InodeBatch []*Inode
@@ -144,6 +146,15 @@ func (i *Inode) Copy() btree.Item {
 	newIno.Extents = i.Extents.Clone()
 	i.RUnlock()
 	return newIno
+}
+
+func (i *Inode) GetVersion() uint64 {
+	ver := i.ver
+	return ver
+}
+
+func (i *Inode) SetVersion(ver uint64) {
+	i.ver = ver
 }
 
 // MarshalToJSON is the wrapper of json.Marshal.

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 const (
@@ -117,13 +118,13 @@ func NewInode(ino uint64, t uint32) *Inode {
 
 // Less tests whether the current Inode item is less than the given one.
 // This method is necessary fot B-Tree item implementation.
-func (i *Inode) Less(than BtreeItem) bool {
+func (i *Inode) Less(than btree.Item) bool {
 	ino, ok := than.(*Inode)
 	return ok && i.Inode < ino.Inode
 }
 
 // Copy returns a copy of the inode.
-func (i *Inode) Copy() BtreeItem {
+func (i *Inode) Copy() btree.Item {
 	newIno := NewInode(i.Inode, i.Type)
 	i.RLock()
 	newIno.Uid = i.Uid

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -74,8 +74,8 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 				Status:      proto.ReadWrite,
 				MaxInodeID:  mConf.Cursor,
 				VolName:     mConf.VolName,
-				InodeCnt:    uint64(partition.CloneInodeTree().Len()),
-				DentryCnt:   uint64(partition.CloneDentryTree().Len()),
+				InodeCnt:    uint64(partition.(*metaPartition).inodeTree.Len()),
+				DentryCnt:   uint64(partition.(*metaPartition).dentryTree.Len()),
 			}
 			addr, isLeader := partition.IsLeader()
 			if addr == "" {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -74,8 +74,8 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 				Status:      proto.ReadWrite,
 				MaxInodeID:  mConf.Cursor,
 				VolName:     mConf.VolName,
-				InodeCnt:    uint64(partition.GetInodeTree().Len()),
-				DentryCnt:   uint64(partition.GetDentryTree().Len()),
+				InodeCnt:    uint64(partition.CloneInodeTree().Len()),
+				DentryCnt:   uint64(partition.CloneDentryTree().Len()),
 			}
 			addr, isLeader := partition.IsLeader()
 			if addr == "" {

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -43,10 +43,9 @@ func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
 	labels := map[string]string{
 		"partid": fmt.Sprintf("%d", mp.config.PartitionId),
 	}
-	it := mp.CloneInodeTree()
-	if it != nil {
-		exporter.NewGauge("mpInodeCount").SetWithLabels(float64(it.Len()), labels)
-	}
+
+	cnt := mp.inodeTree.Len()
+	exporter.NewGauge("mpInodeCount").SetWithLabels(float64(cnt), labels)
 }
 
 func (m *MetaNode) collectPartitionMetrics() {

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -43,7 +43,7 @@ func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
 	labels := map[string]string{
 		"partid": fmt.Sprintf("%d", mp.config.PartitionId),
 	}
-	it := mp.GetInodeTree()
+	it := mp.CloneInodeTree()
 	if it != nil {
 		exporter.NewGauge("mpInodeCount").SetWithLabels(float64(it.Len()), labels)
 	}

--- a/metanode/multipart.go
+++ b/metanode/multipart.go
@@ -303,6 +303,8 @@ type Multipart struct {
 	extend   MultipartExtend
 
 	mu sync.RWMutex
+
+	ver uint64 // used only for Btree
 }
 
 func (m *Multipart) Less(than btree.Item) bool {
@@ -318,6 +320,14 @@ func (m *Multipart) Copy() btree.Item {
 		parts:    append(Parts{}, m.parts...),
 		extend:   m.extend,
 	}
+}
+
+func (m *Multipart) GetVersion() uint64 {
+	return m.ver
+}
+
+func (m *Multipart) SetVersion(ver uint64) {
+	m.ver = ver
 }
 
 func (m *Multipart) ID() string {

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/raftstore"
 	"github.com/cubefs/cubefs/util"
+	"github.com/cubefs/cubefs/util/btree"
 	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/log"
 	raftproto "github.com/tiglabs/raft/proto"
@@ -117,7 +118,7 @@ type OpInode interface {
 	EvictInode(req *EvictInodeReq, p *Packet) (err error)
 	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
 	SetAttr(reqData []byte, p *Packet) (err error)
-	WalkInodeTree(handler func(item BtreeItem) bool)
+	WalkInodeTree(handler func(item btree.Item) bool)
 	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
 	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
 }
@@ -141,7 +142,7 @@ type OpDentry interface {
 	ReadDirLimit(req *ReadDirLimitReq, p *Packet) (err error)
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
-	WalkDentryTree(handler func(item BtreeItem) bool)
+	WalkDentryTree(handler func(item btree.Item) bool)
 }
 
 // OpExtent defines the interface for the extent operations.

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -117,7 +117,7 @@ type OpInode interface {
 	EvictInode(req *EvictInodeReq, p *Packet) (err error)
 	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
 	SetAttr(reqData []byte, p *Packet) (err error)
-	GetInodeTree() *BTree
+	CloneInodeTree() *BTree
 	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
 	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
 }
@@ -141,7 +141,7 @@ type OpDentry interface {
 	ReadDirLimit(req *ReadDirLimitReq, p *Packet) (err error)
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
-	GetDentryTree() *BTree
+	CloneDentryTree() *BTree
 }
 
 // OpExtent defines the interface for the extent operations.
@@ -632,8 +632,8 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
-	resp.InodeCount = uint64(mp.getInodeTree().Len())
-	resp.DentryCount = uint64(mp.getDentryTree().Len())
+	resp.InodeCount = uint64(mp.cloneInodeTree().Len())
+	resp.DentryCount = uint64(mp.cloneDentryTree().Len())
 	resp.ApplyID = mp.applyID
 	if err != nil {
 		err = errors.Trace(err,

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -117,7 +117,7 @@ type OpInode interface {
 	EvictInode(req *EvictInodeReq, p *Packet) (err error)
 	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
 	SetAttr(reqData []byte, p *Packet) (err error)
-	CloneInodeTree() *BTree
+	WalkInodeTree(handler func(item BtreeItem) bool)
 	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
 	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
 }
@@ -141,7 +141,7 @@ type OpDentry interface {
 	ReadDirLimit(req *ReadDirLimitReq, p *Packet) (err error)
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
-	CloneDentryTree() *BTree
+	WalkDentryTree(handler func(item BtreeItem) bool)
 }
 
 // OpExtent defines the interface for the extent operations.
@@ -632,8 +632,8 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
-	resp.InodeCount = uint64(mp.cloneInodeTree().Len())
-	resp.DentryCount = uint64(mp.cloneDentryTree().Len())
+	resp.InodeCount = uint64(mp.inodeTree.Len())
+	resp.DentryCount = uint64(mp.dentryTree.Len())
 	resp.ApplyID = mp.applyID
 	if err != nil {
 		err = errors.Trace(err,

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -208,10 +208,10 @@ type metaPartition struct {
 	config                 *MetaPartitionConfig
 	size                   uint64 // For partition all file size
 	applyID                uint64 // Inode/Dentry max applyID, this index will be update after restoring from the dumped data.
-	dentryTree             *BTree
-	inodeTree              *BTree // btree for inodes
-	extendTree             *BTree // btree for inode extend (XAttr) management
-	multipartTree          *BTree // collection for multipart management
+	dentryTree             *Btree
+	inodeTree              *Btree // btree for inodes
+	extendTree             *Btree // btree for inode extend (XAttr) management
+	multipartTree          *Btree // collection for multipart management
 	raftPartition          raftstore.Partition
 	stopC                  chan bool
 	storeChan              chan *storeMsg

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -145,7 +145,7 @@ func (mp *metaPartition) deleteWorker() {
 			}
 
 			//check inode nlink == 0 and deletMarkFlag unset
-			if inode, ok := mp.inodeTree.CopyGet(&Inode{Inode: ino}).(*Inode); ok {
+			if inode, ok := mp.inodeTree.GetForWrite(&Inode{Inode: ino}).(*Inode); ok {
 				if inode.ShouldDelayDelete() {
 					log.LogDebugf("[metaPartition] deleteWorker delay to remove inode: %v as NLink is 0", inode)
 					delayDeleteInos = append(delayDeleteInos, ino)
@@ -232,7 +232,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 	allInodes := make([]*Inode, 0)
 	for _, ino := range inoSlice {
 		ref := &Inode{Inode: ino}
-		inode, ok := mp.inodeTree.CopyGet(ref).(*Inode)
+		inode, ok := mp.inodeTree.GetForWrite(ref).(*Inode)
 		if !ok {
 			continue
 		}

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -142,10 +142,10 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		}
 		resp = mp.fsmAppendExtentsWithCheck(ino)
 	case opFSMStoreTick:
-		inodeTree := mp.getInodeTree()
-		dentryTree := mp.getDentryTree()
-		extendTree := mp.extendTree.GetTree()
-		multipartTree := mp.multipartTree.GetTree()
+		inodeTree := mp.cloneInodeTree()
+		dentryTree := mp.cloneDentryTree()
+		extendTree := mp.extendTree.CloneTree()
+		multipartTree := mp.multipartTree.CloneTree()
 		msg := &storeMsg{
 			command:       opFSMStoreTick,
 			applyIndex:    index,

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -142,8 +142,8 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		}
 		resp = mp.fsmAppendExtentsWithCheck(ino)
 	case opFSMStoreTick:
-		inodeTree := mp.cloneInodeTree()
-		dentryTree := mp.cloneDentryTree()
+		inodeTree := mp.inodeTree.CloneTree()
+		dentryTree := mp.dentryTree.CloneTree()
 		extendTree := mp.extendTree.CloneTree()
 		multipartTree := mp.multipartTree.CloneTree()
 		msg := &storeMsg{

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -36,7 +36,7 @@ func NewDentryResponse() *DentryResponse {
 func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 	forceUpdate bool) (status uint8) {
 	status = proto.OpOk
-	item := mp.inodeTree.CopyGet(NewInode(dentry.ParentId, 0))
+	item := mp.inodeTree.GetForWrite(NewInode(dentry.ParentId, 0))
 	var parIno *Inode
 	if !forceUpdate {
 		if item == nil {
@@ -80,7 +80,7 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 // Query a dentry from the dentry tree with specified dentry info.
 func (mp *metaPartition) getDentry(dentry *Dentry) (*Dentry, uint8) {
 	status := proto.OpOk
-	item := mp.dentryTree.Get(dentry)
+	item := mp.dentryTree.GetForRead(dentry)
 	if item == nil {
 		status = proto.OpNotExistErr
 		return nil, status
@@ -98,7 +98,7 @@ func (mp *metaPartition) fsmDeleteDentry(dentry *Dentry, checkInode bool) (
 	var item interface{}
 	if checkInode {
 		item = mp.dentryTree.Execute(func(tree *btree.BTree) btree.Item {
-			d := tree.CopyGet(dentry)
+			d := tree.Get(dentry)
 			if d == nil {
 				return nil
 			}

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -155,10 +155,6 @@ func (mp *metaPartition) fsmUpdateDentry(dentry *Dentry) (
 	return
 }
 
-func (mp *metaPartition) cloneDentryTree() *BTree {
-	return mp.dentryTree.CloneTree()
-}
-
 func (mp *metaPartition) readDir(req *ReadDirReq) (resp *ReadDirResp) {
 	resp = &ReadDirResp{}
 	begDentry := &Dentry{

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -155,8 +155,8 @@ func (mp *metaPartition) fsmUpdateDentry(dentry *Dentry) (
 	return
 }
 
-func (mp *metaPartition) getDentryTree() *BTree {
-	return mp.dentryTree.GetTree()
+func (mp *metaPartition) cloneDentryTree() *BTree {
+	return mp.dentryTree.CloneTree()
 }
 
 func (mp *metaPartition) readDir(req *ReadDirReq) (resp *ReadDirResp) {

--- a/metanode/partition_fsmop_extend.go
+++ b/metanode/partition_fsmop_extend.go
@@ -20,7 +20,7 @@ type ExtendOpResult struct {
 }
 
 func (mp *metaPartition) fsmSetXAttr(extend *Extend) (err error) {
-	treeItem := mp.extendTree.CopyGet(extend)
+	treeItem := mp.extendTree.GetForWrite(extend)
 	var e *Extend
 	if treeItem == nil {
 		e = NewExtend(extend.inode)
@@ -33,7 +33,7 @@ func (mp *metaPartition) fsmSetXAttr(extend *Extend) (err error) {
 }
 
 func (mp *metaPartition) fsmRemoveXAttr(extend *Extend) (err error) {
-	treeItem := mp.extendTree.CopyGet(extend)
+	treeItem := mp.extendTree.GetForWrite(extend)
 	if treeItem == nil {
 		return
 	}

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -98,10 +98,6 @@ func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
 	return
 }
 
-func (mp *metaPartition) cloneInodeTree() *BTree {
-	return mp.inodeTree.CloneTree()
-}
-
 // Ascend is the wrapper of inodeTree.Ascend
 func (mp *metaPartition) Ascend(f func(i BtreeItem) bool) {
 	mp.inodeTree.Ascend(f)

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/btree"
 	"github.com/cubefs/cubefs/util/log"
 )
 
@@ -99,7 +100,7 @@ func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
 }
 
 // Ascend is the wrapper of inodeTree.Ascend
-func (mp *metaPartition) Ascend(f func(i BtreeItem) bool) {
+func (mp *metaPartition) Ascend(f func(i btree.Item) bool) {
 	mp.inodeTree.Ascend(f)
 }
 

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -98,8 +98,8 @@ func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
 	return
 }
 
-func (mp *metaPartition) getInodeTree() *BTree {
-	return mp.inodeTree.GetTree()
+func (mp *metaPartition) cloneInodeTree() *BTree {
+	return mp.inodeTree.CloneTree()
 }
 
 // Ascend is the wrapper of inodeTree.Ascend

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -47,7 +47,7 @@ func (mp *metaPartition) fsmCreateInode(ino *Inode) (status uint8) {
 func (mp *metaPartition) fsmCreateLinkInode(ino *Inode) (resp *InodeResponse) {
 	resp = NewInodeResponse()
 	resp.Status = proto.OpOk
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		resp.Status = proto.OpNotExistErr
 		return
@@ -65,7 +65,7 @@ func (mp *metaPartition) fsmCreateLinkInode(ino *Inode) (resp *InodeResponse) {
 func (mp *metaPartition) getInode(ino *Inode) (resp *InodeResponse) {
 	resp = NewInodeResponse()
 	resp.Status = proto.OpOk
-	item := mp.inodeTree.Get(ino)
+	item := mp.inodeTree.GetForRead(ino)
 	if item == nil {
 		resp.Status = proto.OpNotExistErr
 		return
@@ -85,7 +85,7 @@ func (mp *metaPartition) getInode(ino *Inode) (resp *InodeResponse) {
 }
 
 func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
-	item := mp.inodeTree.Get(ino)
+	item := mp.inodeTree.GetForRead(ino)
 	if item == nil {
 		ok = false
 		return
@@ -108,7 +108,7 @@ func (mp *metaPartition) Ascend(f func(i btree.Item) bool) {
 func (mp *metaPartition) fsmUnlinkInode(ino *Inode) (resp *InodeResponse) {
 	resp = NewInodeResponse()
 	resp.Status = proto.OpOk
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		resp.Status = proto.OpNotExistErr
 		return
@@ -200,7 +200,7 @@ func (mp *metaPartition) internalDeleteInode(ino *Inode) {
 
 func (mp *metaPartition) fsmAppendExtents(ino *Inode) (status uint8) {
 	status = proto.OpOk
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		status = proto.OpNotExistErr
 		return
@@ -219,7 +219,7 @@ func (mp *metaPartition) fsmAppendExtents(ino *Inode) (status uint8) {
 
 func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode) (status uint8) {
 	status = proto.OpOk
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		status = proto.OpNotExistErr
 		return
@@ -255,7 +255,7 @@ func (mp *metaPartition) fsmExtentsTruncate(ino *Inode) (resp *InodeResponse) {
 	resp = NewInodeResponse()
 
 	resp.Status = proto.OpOk
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		resp.Status = proto.OpNotExistErr
 		return
@@ -282,7 +282,7 @@ func (mp *metaPartition) fsmEvictInode(ino *Inode) (resp *InodeResponse) {
 	resp = NewInodeResponse()
 
 	resp.Status = proto.OpOk
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		resp.Status = proto.OpNotExistErr
 		return
@@ -326,7 +326,7 @@ func (mp *metaPartition) checkAndInsertFreeList(ino *Inode) {
 
 func (mp *metaPartition) fsmSetAttr(req *SetattrRequest) (err error) {
 	ino := NewInode(req.Inode, req.Mode)
-	item := mp.inodeTree.CopyGet(ino)
+	item := mp.inodeTree.GetForWrite(ino)
 	if item == nil {
 		return
 	}

--- a/metanode/partition_fsmop_multipart.go
+++ b/metanode/partition_fsmop_multipart.go
@@ -33,7 +33,7 @@ func (mp *metaPartition) fsmRemoveMultipart(multipart *Multipart) (status uint8)
 }
 
 func (mp *metaPartition) fsmAppendMultipart(multipart *Multipart) (status uint8) {
-	storedItem := mp.multipartTree.CopyGet(multipart)
+	storedItem := mp.multipartTree.GetForWrite(multipart)
 	if storedItem == nil {
 		return proto.OpNotExistErr
 	}

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -125,10 +125,10 @@ type fileData struct {
 type MetaItemIterator struct {
 	fileRootDir   string
 	applyID       uint64
-	inodeTree     *BTree
-	dentryTree    *BTree
-	extendTree    *BTree
-	multipartTree *BTree
+	inodeTree     *Btree
+	dentryTree    *Btree
+	extendTree    *Btree
+	multipartTree *Btree
 
 	filenames []string
 

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 // MetaItem defines the structure of the metadata operations.
@@ -201,28 +203,28 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 		produceItem(si.applyID)
 
 		// process inodes
-		iter.inodeTree.Ascend(func(i BtreeItem) bool {
+		iter.inodeTree.Ascend(func(i btree.Item) bool {
 			return produceItem(i)
 		})
 		if checkClose() {
 			return
 		}
 		// process dentries
-		iter.dentryTree.Ascend(func(i BtreeItem) bool {
+		iter.dentryTree.Ascend(func(i btree.Item) bool {
 			return produceItem(i)
 		})
 		if checkClose() {
 			return
 		}
 		// process extends
-		iter.extendTree.Ascend(func(i BtreeItem) bool {
+		iter.extendTree.Ascend(func(i btree.Item) bool {
 			return produceItem(i)
 		})
 		if checkClose() {
 			return
 		}
 		// process multiparts
-		iter.multipartTree.Ascend(func(i BtreeItem) bool {
+		iter.multipartTree.Ascend(func(i btree.Item) bool {
 			return produceItem(i)
 		})
 		if checkClose() {

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -144,10 +144,10 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 	si = new(MetaItemIterator)
 	si.fileRootDir = mp.config.RootDir
 	si.applyID = mp.applyID
-	si.inodeTree = mp.inodeTree.GetTree()
-	si.dentryTree = mp.dentryTree.GetTree()
-	si.extendTree = mp.extendTree.GetTree()
-	si.multipartTree = mp.multipartTree.GetTree()
+	si.inodeTree = mp.inodeTree.CloneTree()
+	si.dentryTree = mp.dentryTree.CloneTree()
+	si.extendTree = mp.extendTree.CloneTree()
+	si.multipartTree = mp.multipartTree.CloneTree()
 	si.dataCh = make(chan interface{})
 	si.errorCh = make(chan error, 1)
 	si.closeCh = make(chan struct{})

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 // CreateDentry returns a new dentry.
@@ -236,6 +237,6 @@ func (mp *metaPartition) Lookup(req *LookupReq, p *Packet) (err error) {
 }
 
 // handler should not modify items
-func (mp *metaPartition) WalkDentryTree(handler func(item BtreeItem) bool) {
+func (mp *metaPartition) WalkDentryTree(handler func(item btree.Item) bool) {
 	mp.dentryTree.Ascend(handler)
 }

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -235,7 +235,7 @@ func (mp *metaPartition) Lookup(req *LookupReq, p *Packet) (err error) {
 	return
 }
 
-// CloneDentryTree returns the dentry tree stored in the meta partition.
-func (mp *metaPartition) CloneDentryTree() *BTree {
-	return mp.dentryTree.CloneTree()
+// handler should not modify items
+func (mp *metaPartition) WalkDentryTree(handler func(item BtreeItem) bool) {
+	mp.dentryTree.Ascend(handler)
 }

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -235,7 +235,7 @@ func (mp *metaPartition) Lookup(req *LookupReq, p *Packet) (err error) {
 	return
 }
 
-// GetDentryTree returns the dentry tree stored in the meta partition.
-func (mp *metaPartition) GetDentryTree() *BTree {
-	return mp.dentryTree.GetTree()
+// CloneDentryTree returns the dentry tree stored in the meta partition.
+func (mp *metaPartition) CloneDentryTree() *BTree {
+	return mp.dentryTree.CloneTree()
 }

--- a/metanode/partition_op_extend.go
+++ b/metanode/partition_op_extend.go
@@ -30,7 +30,7 @@ func (mp *metaPartition) UpdateSummaryInfo(req *proto.UpdateSummaryInfoRequest, 
 
 	mp.summaryLock.Lock()
 	defer mp.summaryLock.Unlock()
-	treeItem := mp.extendTree.Get(NewExtend(req.Inode))
+	treeItem := mp.extendTree.GetForRead(NewExtend(req.Inode))
 	if treeItem != nil {
 		extend := treeItem.(*Extend)
 		if value, exist := extend.Get([]byte(req.Key)); exist {
@@ -107,7 +107,7 @@ func (mp *metaPartition) GetXAttr(req *proto.GetXAttrRequest, p *Packet) (err er
 		Inode:       req.Inode,
 		Key:         req.Key,
 	}
-	treeItem := mp.extendTree.Get(NewExtend(req.Inode))
+	treeItem := mp.extendTree.GetForRead(NewExtend(req.Inode))
 	if treeItem != nil {
 		extend := treeItem.(*Extend)
 		if value, exist := extend.Get([]byte(req.Key)); exist {
@@ -131,7 +131,7 @@ func (mp *metaPartition) BatchGetXAttr(req *proto.BatchGetXAttrRequest, p *Packe
 		XAttrs:      make([]*proto.XAttrInfo, 0, len(req.Inodes)),
 	}
 	for _, inode := range req.Inodes {
-		treeItem := mp.extendTree.Get(NewExtend(inode))
+		treeItem := mp.extendTree.GetForRead(NewExtend(inode))
 		if treeItem != nil {
 			extend := treeItem.(*Extend)
 			info := &proto.XAttrInfo{
@@ -173,7 +173,7 @@ func (mp *metaPartition) ListXAttr(req *proto.ListXAttrRequest, p *Packet) (err 
 		Inode:       req.Inode,
 		XAttrs:      make([]string, 0),
 	}
-	treeItem := mp.extendTree.Get(NewExtend(req.Inode))
+	treeItem := mp.extendTree.GetForRead(NewExtend(req.Inode))
 	if treeItem != nil {
 		extend := treeItem.(*Extend)
 		extend.Range(func(key, value []byte) bool {

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -315,9 +315,9 @@ func (mp *metaPartition) SetAttr(reqData []byte, p *Packet) (err error) {
 	return
 }
 
-// GetInodeTree returns the inode tree.
-func (mp *metaPartition) GetInodeTree() *BTree {
-	return mp.inodeTree.GetTree()
+// CloneInodeTree returns the inode tree.
+func (mp *metaPartition) CloneInodeTree() *BTree {
+	return mp.inodeTree.CloneTree()
 }
 
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error) {

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -315,9 +315,9 @@ func (mp *metaPartition) SetAttr(reqData []byte, p *Packet) (err error) {
 	return
 }
 
-// CloneInodeTree returns the inode tree.
-func (mp *metaPartition) CloneInodeTree() *BTree {
-	return mp.inodeTree.CloneTree()
+// handler should not modify item
+func (mp *metaPartition) WalkInodeTree(handler func(item BtreeItem) bool) {
+	mp.inodeTree.Ascend(handler)
 }
 
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error) {

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/btree"
 )
 
 func replyInfo(info *proto.InodeInfo, ino *Inode) bool {
@@ -316,7 +317,7 @@ func (mp *metaPartition) SetAttr(reqData []byte, p *Packet) (err error) {
 }
 
 // handler should not modify item
-func (mp *metaPartition) WalkInodeTree(handler func(item BtreeItem) bool) {
+func (mp *metaPartition) WalkInodeTree(handler func(item btree.Item) bool) {
 	mp.inodeTree.Ascend(handler)
 }
 

--- a/metanode/partition_op_multipart.go
+++ b/metanode/partition_op_multipart.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cubefs/cubefs/util"
+	"github.com/cubefs/cubefs/util/btree"
 
 	"github.com/cubefs/cubefs/proto"
 )
@@ -159,7 +160,7 @@ func (mp *metaPartition) ListMultipart(req *proto.ListMultipartRequest, p *Packe
 	multipartIdMarker := req.MultipartIdMarker
 	prefix := req.Prefix
 	var matches = make([]*Multipart, 0, max)
-	var walkTreeFunc = func(i BtreeItem) bool {
+	var walkTreeFunc = func(i btree.Item) bool {
 		multipart := i.(*Multipart)
 		// prefix is enabled
 		if len(prefix) > 0 && !strings.HasPrefix(multipart.key, prefix) {

--- a/metanode/partition_op_multipart.go
+++ b/metanode/partition_op_multipart.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (mp *metaPartition) GetMultipart(req *proto.GetMultipartRequest, p *Packet) (err error) {
-	item := mp.multipartTree.Get(&Multipart{key: req.Path, id: req.MultipartId})
+	item := mp.multipartTree.GetForRead(&Multipart{key: req.Path, id: req.MultipartId})
 	if item == nil {
 		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
 		return
@@ -64,7 +64,7 @@ func (mp *metaPartition) AppendMultipart(req *proto.AddMultipartPartRequest, p *
 		p.PacketOkReply()
 		return
 	}
-	item := mp.multipartTree.Get(&Multipart{key: req.Path, id: req.MultipartId})
+	item := mp.multipartTree.GetForRead(&Multipart{key: req.Path, id: req.MultipartId})
 	if item == nil {
 		p.PacketErrorWithBody(proto.OpNotExistErr, nil)
 		return
@@ -121,7 +121,7 @@ func (mp *metaPartition) CreateMultipart(req *proto.CreateMultipartRequest, p *P
 	)
 	for {
 		multipartId = util.CreateMultipartID(mp.config.PartitionId).String()
-		storedItem := mp.multipartTree.Get(&Multipart{key: req.Path, id: multipartId})
+		storedItem := mp.multipartTree.GetForRead(&Multipart{key: req.Path, id: multipartId})
 		if storedItem == nil {
 			break
 		}

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/cubefs/cubefs/util/btree"
 	"github.com/cubefs/cubefs/util/log"
 
 	"github.com/cubefs/cubefs/proto"
@@ -403,7 +404,7 @@ func (mp *metaPartition) storeInode(rootDir string,
 	var data []byte
 	lenBuf := make([]byte, 4)
 	sign := crc32.NewIEEE()
-	sm.inodeTree.Ascend(func(i BtreeItem) bool {
+	sm.inodeTree.Ascend(func(i btree.Item) bool {
 		ino := i.(*Inode)
 		if data, err = ino.Marshal(); err != nil {
 			return false
@@ -447,7 +448,7 @@ func (mp *metaPartition) storeDentry(rootDir string,
 	var data []byte
 	lenBuf := make([]byte, 4)
 	sign := crc32.NewIEEE()
-	sm.dentryTree.Ascend(func(i BtreeItem) bool {
+	sm.dentryTree.Ascend(func(i btree.Item) bool {
 		dentry := i.(*Dentry)
 		data, err = dentry.Marshal()
 		if err != nil {
@@ -501,7 +502,7 @@ func (mp *metaPartition) storeExtend(rootDir string, sm *storeMsg) (crc uint32, 
 	if _, err = crc32.Write(varintTmp[:n]); err != nil {
 		return
 	}
-	extendTree.Ascend(func(i BtreeItem) bool {
+	extendTree.Ascend(func(i btree.Item) bool {
 		e := i.(*Extend)
 		var raw []byte
 		if raw, err = e.Bytes(); err != nil {
@@ -566,7 +567,7 @@ func (mp *metaPartition) storeMultipart(rootDir string, sm *storeMsg) (crc uint3
 	if _, err = crc32.Write(varintTmp[:n]); err != nil {
 		return
 	}
-	multipartTree.Ascend(func(i BtreeItem) bool {
+	multipartTree.Ascend(func(i btree.Item) bool {
 		m := i.(*Multipart)
 		var raw []byte
 		if raw, err = m.Bytes(); err != nil {

--- a/metanode/partition_store_ticket.go
+++ b/metanode/partition_store_ticket.go
@@ -27,10 +27,10 @@ import (
 type storeMsg struct {
 	command       uint32
 	applyIndex    uint64
-	inodeTree     *BTree
-	dentryTree    *BTree
-	extendTree    *BTree
-	multipartTree *BTree
+	inodeTree     *Btree
+	dentryTree    *Btree
+	extendTree    *Btree
+	multipartTree *Btree
 }
 
 func (mp *metaPartition) startSchedule(curIndex uint64) {


### PR DESCRIPTION
This patchset refactors the usage of btree in metanode:
1. remove unnecessary clone of tree
2. rename helper functions to show its semantic apparently, like renaming GetTree to CloneTree
3. change metanode.BtreeItem to a new interface which inherits from btree.Item
4. avoid modifying the original btree module
5. introduce version to metanode.Btree and implementations of metanode.BtreeItem
6. introduce GetForRead and GetForWrite for metanode.Btree

GetForWrite is responsable for COW. Here is how we do COW:
1. tree.ver = 1, items_in_tree.ver = 1
2. oldTree = CloneTree(tree) => oldTree.ver = 1, tree.ver = 2, they share all items
3. tree.GetForWrite(key)
  3.1 item_in_tree.ver != tree.ver
  3.2 new_item = copy(item_in_tree)
  3.3 new_item.ver = tree.ver
  3.4 ReplaceOrInsert(new_item) => oldTree keeps old item, while tree has new_item
  3.5 return new_item
4. oldTree.GetForRead(key) => item_in_oldTree.ver = 1