### PR TITLE
metanode: Show metapartition id correctly

### DIFF
--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -347,10 +347,11 @@ func (m *metadataManager) loadPartitions() (err error) {
 				}
 
 				partitionConfig := &MetaPartitionConfig{
-					NodeId:    m.nodeId,
-					RaftStore: m.raftStore,
-					RootDir:   path.Join(m.rootDir, fileName),
-					ConnPool:  m.connPool,
+					PartitionId: id,
+					NodeId:      m.nodeId,
+					RaftStore:   m.raftStore,
+					RootDir:     path.Join(m.rootDir, fileName),
+					ConnPool:    m.connPool,
 				}
 				partitionConfig.AfterStop = func() {
 					m.detachPartition(id)


### PR DESCRIPTION
When loading an mp, initialize `MetaPartitionConfig.PartitionID`
correctly. Otherwise, if something goes wrong in `mp.onStart`,
we can only get "id=0".

Signed-off-by: Sheng Yong <shengyong2021@gmail.com>