### PR TITLE
s3test: fix s3test mtime asserting when copying object

### DIFF
--- a/docker/s3tests/test_copy_object.py
+++ b/docker/s3tests/test_copy_object.py
@@ -94,7 +94,7 @@ class CopyObjectTest(S3TestCase):
         self.assertNotEqual(target_response["ETag"], "")
         self.assertEqual(target_response["ETag"], source_response["ETag"])
         self.assertEqual(target_response["ContentLength"], source_response["ContentLength"])
-        self.assertGreater(target_response["LastModified"], source_response["LastModified"])
+        self.assertGreaterEqual(target_response["LastModified"], source_response["LastModified"])
         if is_dir:
             self.assertEqual(target_response["ContentLength"], 0)
         if contain_mete_data:


### PR DESCRIPTION
In s3test, it will assert time LastModified after object copying.
If the object copy operation completes in 1s, the s3test will probably not pass.
Because it checks if target's mtime is greater than src instead of not less.

Signed-off-by: wanglei469 <wanglei469@ke.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
