### PR TITLE
Release docker image for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,40 @@ name: CI
 on:
   push:
     branches: [ master ]
+    tags:
+      - v*
   pull_request:
     branches: [ master ]
 
 jobs:
 
+  Build-Image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u chubaofs -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+             chubaofs/cfs-base:${{ steps.prepare.outputs.tag_name }}
+             chubaofs/cfs-base:latest
   ci-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The following file has been modified:
Modified file .github/workflows/ci.yml to build and push the image for both amd64 and arm64 platforms.

Signed-off-by: odidev odidev@puresoftware.com