### PR TITLE
update. support two replicas(data) volume and enable set old 3replica volume to 2replicas to reduce cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release v2.5.0 - 2022/01/06
 
 ### **UPGRAGDE NOTICE**
-If your ChubaoFS version is v2.3.x or before, please refer to the UPGRADE NOTICE in v2.4.0 for upgrading steps. And also please make sure that your fuse client or objectnode version is equal to or older than the servers, i.e. master, metanode and datanode. In another word, newer versioned client can not be used in a cluster with older versioned servers.
+If your CubeFS version is v2.3.x or before, please refer to the UPGRADE NOTICE in v2.4.0 for upgrading steps. And also please make sure that your fuse client or objectnode version is equal to or older than the servers, i.e. master, metanode and datanode. In another word, newer versioned client can not be used in a cluster with older versioned servers.
 
 ### **Main Feature**
 * `fuse client`:support auto push data to push gateway
@@ -159,7 +159,7 @@ The parent directory stores the files, directories and total file size of the cu
 
 ### _**UPGRAGDE NOTICE**_
 
-If your ChubaoFS version is v2.3.x or before, please refer to the UPGRADE NOTICE in v2.4.0 for upgrading steps. And also please make sure that your fuse client or objectnode version is equal to or older than the servers, i.e. master, metanode and datanode. In another word, newer versioned client can not be used in a cluster with older versioned servers.
+If your CubeFS version is v2.3.x or before, please refer to the UPGRADE NOTICE in v2.4.0 for upgrading steps. And also please make sure that your fuse client or objectnode version is equal to or older than the servers, i.e. master, metanode and datanode. In another word, newer versioned client can not be used in a cluster with older versioned servers.
 
 ### Feature
 
@@ -182,7 +182,7 @@ If your ChubaoFS version is v2.3.x or before, please refer to the UPGRADE NOTICE
 
 ### _**UPGRAGDE NOTICE**_
 
-If your ChuBaoFS version is v2.3.x or before, and need to upgrade to v2.4.x , please follow the following upgrade steps:
+If your CubeFS version is v2.3.x or before, and need to upgrade to v2.4.x , please follow the following upgrade steps:
 
 1. first of all, firewall open two more port (17710 & 17810) in your machine to support tcp multiplexing；
 
@@ -251,7 +251,7 @@ Note that when upgrading from versions prior to `v2.3.0` to version `v2.3.0` or 
 
 ### Feature
 * `client`: support multiple subdir permissions for an individual user. [#1051](https://github.com/cubefs/cubefs/pull/1051)
-* `sdk`: introducing libsdk so applications can embed the use of chubaofs to a single binary and no additional process is required at runtime. [#1082](https://github.com/cubefs/cubefs/pull/1082)
+* `sdk`: introducing libsdk so applications can embed the use of cubefs to a single binary and no additional process is required at runtime. [#1082](https://github.com/cubefs/cubefs/pull/1082)
 
 ### Enhancement
 
@@ -326,9 +326,9 @@ Note that when upgrading from versions prior to `v2.3.0` to version `v2.3.0` or 
 ## Release v2.1.0 - 2020/07/09
 
 ### Feature
-* `console`: ChubaoFS **Console** is a web application, which provides management for volume, file, s3, user, node, monitoring, and alarm. 
-The ChubaoFS **Console** makes it much easier to access services provided by ChubaoFS. [#728](https://github.com/cubefs/cubefs/pull/728)  
-Please refer to [https://chubaofs.readthedocs.io/en/latest/user-guide/console.html](https://chubaofs.readthedocs.io/en/latest/user-guide/console.html) to start the **Console**.
+* `console`: CubeFS **Console** is a web application, which provides management for volume, file, s3, user, node, monitoring, and alarm. 
+The CubeFS **Console** makes it much easier to access services provided by CubeFS. [#728](https://github.com/cubefs/cubefs/pull/728)  
+Please refer to [https://cubefs.readthedocs.io/en/latest/user-guide/console.html](https://cubefs.readthedocs.io/en/latest/user-guide/console.html) to start the **Console**.
 * `metanode`: Provide compatibility verification tool for meta partition. [#684](https://github.com/cubefs/cubefs/pull/684)
 * `object`: CORS access control. [#507](https://github.com/cubefs/cubefs/pull/507)
 * `fuse`: Introduce **fsyncOnClose** mount option. Choose if closing system call shall trigger fsync. [#494](https://github.com/cubefs/cubefs/pull/494)
@@ -351,7 +351,7 @@ Release2.1.0 did a lot of work to optimize memory usage.
 * `datanode`: Prioritize healthy data node when sending message to data partition. [#562](https://github.com/cubefs/cubefs/pull/562)
 * `metanode` `datanode`: Check expired partition before loading. [#624](https://github.com/cubefs/cubefs/pull/624)
 * `object`: Implemented several conditional parameters in **GetObject** action. [#471](https://github.com/cubefs/cubefs/pull/471)
-* `object`: Making S3 credential compatible with earlier version of ChubaoFS. [#508](https://github.com/cubefs/cubefs/pull/508)
+* `object`: Making S3 credential compatible with earlier version of CubeFS. [#508](https://github.com/cubefs/cubefs/pull/508)
 * `object`: Totally support presigned url; Partial support user-defined metadata; Making ETag versioned. [#540](https://github.com/cubefs/cubefs/pull/540)   
 * `object`: **CopyObject** across volumes; Support coping directory; Support coping **xattr**. [#563](https://github.com/cubefs/cubefs/pull/563)
 * `object`: Parallel downloading. [#548](https://github.com/cubefs/cubefs/pull/548)
@@ -432,7 +432,7 @@ Release2.1.0 did a lot of work to optimize memory usage.
 * Filter target meta partitions in batch iget. [#472](https://github.com/cubefs/cubefs/pull/472)
 
 #### Others
-* Yum tool for deploying ChubaoFS cluster. [#385](https://github.com/cubefs/cubefs/pull/385)
+* Yum tool for deploying CubeFS cluster. [#385](https://github.com/cubefs/cubefs/pull/385)
 
 ### Bug fix
 * Fix the signature algorithm issues. [#369](https://github.com/cubefs/cubefs/pull/369) [#476](https://github.com/cubefs/cubefs/pull/476)
@@ -446,7 +446,7 @@ Release2.1.0 did a lot of work to optimize memory usage.
 * Fix offline strategy for raft peers of `data partition` and `meta partition`. [#467](https://github.com/cubefs/cubefs/pull/467)
 
 ### Document
-* Add guide for running ChubaoFS by yum tools. [#386](https://github.com/cubefs/cubefs/pull/386)
+* Add guide for running CubeFS by yum tools. [#386](https://github.com/cubefs/cubefs/pull/386)
 * Update FUSE client mount options. [#439](https://github.com/cubefs/cubefs/pull/439)
 * Add documentation for client token. [#449](https://github.com/cubefs/cubefs/pull/449)
 
@@ -466,17 +466,17 @@ Release2.1.0 did a lot of work to optimize memory usage.
 * Unified the configuration of master address and listening port in documentation. [#362](https://github.com/cubefs/cubefs/pull/362)
 
 ### Document
-* Added benchmark data and guidelines for deploying ChubaoFS cluster with Helm in README file. [#350](https://github.com/cubefs/cubefs/pull/350)
+* Added benchmark data and guidelines for deploying CubeFS cluster with Helm in README file. [#350](https://github.com/cubefs/cubefs/pull/350)
 
 ## Release v1.5.0 - 2020/01/08
 
 ### Feature
-* Add a general Authentication & Authorization framework for ChubaoFS. [commit](https://github.com/cubefs/cubefs/commit/60a4977980e093d746d88e848dc3d1f87e17dfb5)
+* Add a general Authentication & Authorization framework for CubeFS. [commit](https://github.com/cubefs/cubefs/commit/60a4977980e093d746d88e848dc3d1f87e17dfb5)
 * Object storage interface. Add ObjectNode to provide S3-compatible APIs. [commit](https://github.com/cubefs/cubefs/commit/d609fedb5c031e27f79dce9c004fdbb101070ac1)
 
 ### Enhancement
 * Check disk path size in run-docker script. [commit](https://github.com/cubefs/cubefs/commit/ba6f2e068f40515491066cfe349d0266f92d9d5c)
-* Support building ChubaoFS docker image that contains cfs-server and cfs-client. [commit](https://github.com/cubefs/cubefs/commit/e1483f5ec531882d193c3ae8237012789f018831)
+* Support building CubeFS docker image that contains cfs-server and cfs-client. [commit](https://github.com/cubefs/cubefs/commit/e1483f5ec531882d193c3ae8237012789f018831)
 * Add go test in docker-compose. [commit](https://github.com/cubefs/cubefs/commit/7ec1e318be0601e2130d2279201541268a29a28b)
 * Add authorization to master api getVol. [commit](https://github.com/cubefs/cubefs/commit/df6ff2a3285c2f77d90baa76ef352d3ec3f38bc4)
 * Support building under the Darwin(Apple MacOS) and Microsoft Windows operating system environment. [commit](https://github.com/cubefs/cubefs/commit/03718f1ed5ed096b3a3f2b810abeffcaec743159)
@@ -756,7 +756,7 @@ Release2.1.0 did a lot of work to optimize memory usage.
 
 * Client: enable support to fifo and socket file types. [commit](https://github.com/cubefs/cubefs/pull/80/commits/a1b118423334c075b0fbdc0b059b7225e8c2173f)
 * Clientv2: use jacobsa fuse package instead of bazil. [commit](https://github.com/cubefs/cubefs/pull/68)
-* Docker: introduce docker compose to create a local testing ChubaoFS cluster. [commit](https://github.com/cubefs/cubefs/pull/79)
+* Docker: introduce docker compose to create a local testing CubeFS cluster. [commit](https://github.com/cubefs/cubefs/pull/79)
 
 
 ### Bugfix
@@ -784,7 +784,7 @@ Release2.1.0 did a lot of work to optimize memory usage.
 
 ### Change / Refactoring
 
-* Rename the repository from cfs to chubaofs.
+* Rename the repository from cfs to cubefs.
 * Use own errors module instead of juju errors due to license incompatibility.
 * Metanode: Change not raft leader error to tryOtherAddr error.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,2 @@
 ## Community Code of Conduct
-ChubaoFS adopts the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+CubeFS adopts the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ChubaoFS
+# Contributing to CubeFS
 
 ## Bug Reports
 
@@ -8,16 +8,16 @@ Please make sure the bug is not already reported by [searching the repository](h
 
 Recommend the standard GitHub flow based on forking and pull requests.
 
-The following diagram and practice steps show the basic process of contributing code to ChubaoFS:
+The following diagram and practice steps show the basic process of contributing code to CubeFS:
 
-<img src="https://user-images.githubusercontent.com/5708406/87878246-9ddf4300-ca15-11ea-97a4-cffd1febffa1.png" height="520" alt="How to make contributing to ChubaoFS"></img>
+<img src="https://user-images.githubusercontent.com/5708406/87878246-9ddf4300-ca15-11ea-97a4-cffd1febffa1.png" height="520" alt="How to make contributing to CubeFS"></img>
 
-1. Fork ChubaoFS to your repository.
-2. Add remote for your forked repository.<br>(Example: `$ git remote add me https://github.com/your/chubaofs`)
+1. Fork CubeFS to your repository.
+2. Add remote for your forked repository.<br>(Example: `$ git remote add me https://github.com/your/cubefs`)
 3. Make sure your local master branch synchronized with the master branch of main repository. <br>(Example: `$ git checkout master && git pull`)
 4. Create local new branch from your up-to-dated local master branch, then checkout to it and leaves your changes. <br>(Example: `$ git branch your-branch && git checkout your-branch`)
 5. Commit and push to your forked remote repository.<br>(Example: `$ git commit -s && git push me`)
-6. Make a pull request that request merging your own branch on your forked repository into the master branch of the main repository.<br>(Example: merge `your/chubaofs:your-branch` into `cubefs/cubefs:master`)
+6. Make a pull request that request merging your own branch on your forked repository into the master branch of the main repository.<br>(Example: merge `your/cubefs:your-branch` into `cubefs/cubefs:master`)
 
 **Note 1:**<br>
 The [DOC Check](https://github.com/apps/dco) is enabled and required. Please make sign your commit by using `-s` argument to add a valid `Signed-off-by` line at bottom of your commit message.<br>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,23 +1,23 @@
-# ChubaoFS Governance
+# CubeFS Governance
 
 ## Principles
 
-The ChubaoFS community adheres to the following principles:
+The CubeFS community adheres to the following principles:
 
-- Open: ChubaoFS is open source.
+- Open: CubeFS is open source.
 - Welcoming and respectful: See [Code of Conduct](CODE_OF_CONDUCT.md).
-- Transparent and accessible: Changes to the ChubaoFS organization, ChubaoFS code repositories, and CNCF related activities (e.g. level, involvement, etc) are done in public.
+- Transparent and accessible: Changes to the CubeFS organization, CubeFS code repositories, and CNCF related activities (e.g. level, involvement, etc) are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
 
 ## Project Lead
 
-The ChubaoFS project has a project lead.
+The CubeFS project has a project lead.
 
-A project lead in ChubaoFS is a single person that has a final say in any decision concerning the ChubaoFS project.
+A project lead in CubeFS is a single person that has a final say in any decision concerning the CubeFS project.
 
 The term of the project lead is one year, with no term limit restriction.
 
-The project lead is elected by ChubaoFS maintainers according to an individual's technical merit to ChubaoFS project.
+The project lead is elected by CubeFS maintainers according to an individual's technical merit to CubeFS project.
 
 The current project lead is identified in the top level [MAINTAINERS](MAINTAINERS) file with the string
 `project lead` and the term behind the name.
@@ -39,23 +39,23 @@ file.
 ## Becoming a Maintainer
 
 On successful merge of a significant pull request any current maintainer can reach
-to the author behind the pull request and ask them if they are willing to become a ChubaoFS
-maintainer. The email of the new maintainer invitation should be cc'ed to `chubaofs-maintainers@groups.io`
+to the author behind the pull request and ask them if they are willing to become a CubeFS
+maintainer. The email of the new maintainer invitation should be cc'ed to `cubefs-maintainers@groups.io`
 as part of the process.
 
 ## Changes in Maintainership
 
 If a Maintainer feels she/he can not fulfill the "Expectations from Maintainers", they are free to step down.
 
-The ChubaoFS organization will never forcefully remove a current Maintainer, unless a maintainer
-fails to meet the principles of ChubaoFS community,
+The CubeFS organization will never forcefully remove a current Maintainer, unless a maintainer
+fails to meet the principles of CubeFS community,
 or adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Changes in Project Lead
 
 Changes in project lead or term is initiated by opening a github PR.
 
-Anyone from ChubaoFS community can vote on the PR with either +1 or -1.
+Anyone from CubeFS community can vote on the PR with either +1 or -1.
 
 Only the following votes are binding:
 1) Any maintainer that has been listed in the top-level [MAINTAINERS](MAINTAINERS.md) file before the PR is opened.
@@ -81,7 +81,7 @@ voting process as in `Changes in Project Lead`.
 
 Decisions are build on consensus between maintainers.
 Proposals and ideas can either be submitted for agreement via a github issue or PR,
-or by sending an email to `chubaofs-maintainers@groups.io`.
+or by sending an email to `cubefs-maintainers@groups.io`.
 
 In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved.
 If a dispute cannot be decided independently, get a third-party maintainer (e.g. a mutual contact with some background
@@ -89,46 +89,46 @@ on the issue, but not involved in the conflict) to intercede.
 If a dispute still cannot be decided, the project lead has the final say to decide an issue.
 
 Decision making process should be transparent to adhere to
-the principles of ChubaoFS project.
+the principles of CubeFS project.
 
 All proposals, ideas, and decisions by maintainers or the project lead
-should either be part of a github issue or PR, or be sent to `chubaofs-maintainers@groups.io`.
+should either be part of a github issue or PR, or be sent to `cubefs-maintainers@groups.io`.
 
 ## Github Project Administration
 
-The __chubaofs__ GitHub project maintainers team reflects the list of Maintainers.
+The __cubefs__ GitHub project maintainers team reflects the list of Maintainers.
 
 ## Other Projects
 
-The ChubaoFS organization is open to receive new sub-projects under its umbrella. To accept a project
-into the __ChubaoFS__ organization, it has to meet the following criteria:
+The CubeFS organization is open to receive new sub-projects under its umbrella. To accept a project
+into the __CubeFS__ organization, it has to meet the following criteria:
 
 - Must be licensed under the terms of the Apache License v2.0
-- Must be related to one or more scopes of the ChubaoFS ecosystem:
-  - ChubaoFS project artifacts (website, deployments, CI, etc)
+- Must be related to one or more scopes of the CubeFS ecosystem:
+  - CubeFS project artifacts (website, deployments, CI, etc)
   - External plugins
   - Other storage related topics
 - Must be supported by a Maintainer not associated or affiliated with the author(s) of the sub-projects
 
 The submission process starts as a Pull Request or Issue on the
 [cubefs/cubefs](https://github.com/cubefs/cubefs) repository with the required information
-mentioned above. Once a project is accepted, it's considered a __sub-project under the umbrella of ChubaoFS__.
+mentioned above. Once a project is accepted, it's considered a __sub-project under the umbrella of CubeFS__.
 
 ## New Plugins
 
-The ChubaoFS is open to receive new plugins as part of the ChubaoFS repo. The submission process is the same as a Pull Request submission. Unlike small Pull Requests though, a new plugin submission should only be approved by a maintainer not associated or affiliated with the author(s) of the plugin.
+The CubeFS is open to receive new plugins as part of the CubeFS repo. The submission process is the same as a Pull Request submission. Unlike small Pull Requests though, a new plugin submission should only be approved by a maintainer not associated or affiliated with the author(s) of the plugin.
 
-## ChubaoFS and CNCF
+## CubeFS and CNCF
 
-ChubaoFS might be involved in CNCF (or other CNCF projects) related
-marketing, events, or activities. Any maintainer could help driving the ChubaoFS involvement, as long as
-she/he sends email to `chubaofs-maintainers@groups.io` (or create a GitHub Pull Request) to call for participation
+CubeFS might be involved in CNCF (or other CNCF projects) related
+marketing, events, or activities. Any maintainer could help driving the CubeFS involvement, as long as
+she/he sends email to `cubefs-maintainers@groups.io` (or create a GitHub Pull Request) to call for participation
 from other maintainers. The `Call for Participation` should be kept open for no less than a week if time
 permits, or a _reasonable_ time frame to allow maintainers to have a chance to volunteer.
 
 ## Code of Conduct
 
-The [ChubaoFS Code of Conduct](CODE_OF_CONDUCT.md) is aligned with the CNCF Code of Conduct.
+The [CubeFS Code of Conduct](CODE_OF_CONDUCT.md) is aligned with the CNCF Code of Conduct.
 
 ## Credits
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-This page listed the ChubaoFS main maintainers and their reponsibilities.
+This page listed the CubeFS main maintainers and their reponsibilities.
 
 Name | Email | Duty | Organization
 --------|---|---|---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Language](https://img.shields.io/badge/Language-Go-blue.svg)](https://golang.org/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cubefs/cubefs)](https://goreportcard.com/report/github.com/cubefs/cubefs)
 [![Docs](https://readthedocs.org/projects/cubefs/badge/?version=latest)](https://cubefs.readthedocs.io/en/latest/?badge=latest)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fchubaofs%2Fcfs.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fchubaofs%2Fcfs?ref=badge_shield)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2761/badge)](https://bestpractices.coreinfrastructure.org/projects/2761)
 
 |<img src="https://user-images.githubusercontent.com/5708406/91202310-31eaab80-e734-11ea-84fc-c1b1882ae71c.png" height="24"/>&nbsp;Community Meeting|
@@ -324,4 +323,4 @@ For a list of users and success stories see [ADOPTERS.md](ADOPTERS.md).
 CubeFS is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 For detail see [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fchubaofs%2Fcfs.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fchubaofs%2Fcfs?ref=badge_large)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fcubefs%2Fcfs.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fcubefs%2Fcfs?ref=badge_large)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Here we draft the engineering roadmap of ChubaoFS. 
+Here we draft the engineering roadmap of CubeFS. 
 
 ## Interfaces
 
@@ -15,13 +15,13 @@ Here we draft the engineering roadmap of ChubaoFS.
 
 * Multi version of data storage such as snapshot and history (May 2022)
 
-* Memory chubaofs built on distributed unused memory (May 2022)
+* Memory cubefs built on distributed unused memory (May 2022)
 
 * Audit function on Data operation flow (May 2022)
 
 ## Ecosystem
 
-* ChubaoSpark, a ChubaoFS-based shuffle manager for Apache Spark (WIP)
+* ChubaoSpark, a CubeFS-based shuffle manager for Apache Spark (WIP)
 
-* ChubaoDB, a ChubaoFS-based document store & search (WIP)
+* ChubaoDB, a CubeFS-based document store & search (WIP)
 

--- a/security/README.md
+++ b/security/README.md
@@ -1,22 +1,22 @@
 # Security Announcements
 
-Join the [chubaofs-users@groups.io](mailto:chubaofs-users@groups.io) group for emails about security and major announcements.
+Join the [cubefs-users@groups.io](mailto:cubefs-users@groups.io) group for emails about security and major announcements.
 
 ## Report a Vulnerability
 
-We’re extremely grateful for security researchers and users that report vulnerabilities to the ChubaoFS Open Source Community. All reports are thoroughly investigated by a dedicated committee of community volunteers called [Product Security Committee](security-release-process.md#product-security-committee).
+We’re extremely grateful for security researchers and users that report vulnerabilities to the CubeFS Open Source Community. All reports are thoroughly investigated by a dedicated committee of community volunteers called [Product Security Committee](security-release-process.md#product-security-committee).
 
-To make a report, please email the private [chubaofs-users@groups.io](mailto:chubaofs-users@groups.io) list with the security details and the details expected for [all ChubaoFS bug reports](https://github.com/cubefs/cubefs/blob/master/CONTRIBUTING.md#bug-reports).
+To make a report, please email the private [cubefs-users@groups.io](mailto:cubefs-users@groups.io) list with the security details and the details expected for [all CubeFS bug reports](https://github.com/cubefs/cubefs/blob/master/CONTRIBUTING.md#bug-reports).
 
 ### When Should I Report a Vulnerability?
 
-- When discovered a potential security vulnerability in ChubaoFS 
-- When unsure how a vulnerability affects ChubaoFS
-- When discovered a vulnerability in another project that ChubaoFS depends on
+- When discovered a potential security vulnerability in CubeFS 
+- When unsure how a vulnerability affects CubeFS
+- When discovered a vulnerability in another project that CubeFS depends on
 
 ### When Should I NOT Report a Vulnerability?
 
-- Need help tuning ChubaoFS for security
+- Need help tuning CubeFS for security
 - Need help applying security related updates
 - When an issue is not security related
 
@@ -24,10 +24,10 @@ To make a report, please email the private [chubaofs-users@groups.io](mailto:chu
 
 Each report is acknowledged and analyzed by Product Security Committee members within 3 working days. This will set off the [Security Release Process](security-release-process.md).
 
-Any vulnerability information shared with Product Security Committee stays within ChubaoFS project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+Any vulnerability information shared with Product Security Committee stays within CubeFS project and will not be disseminated to other projects unless it is necessary to get the issue fixed.
 
 As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
 
 ## Public Disclosure Timing
 
-A public disclosure date is negotiated by the ChubaoFS Product Security Committee and the bug reporter. We prefer to fully disclose the bug as soon as possible once user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. As a basic default, we expect report date to disclosure date to be on the order of 7 days. The ChubaoFS Product Security Committee holds the final say when setting a disclosure date.
+A public disclosure date is negotiated by the CubeFS Product Security Committee and the bug reporter. We prefer to fully disclose the bug as soon as possible once user mitigation is available. It is reasonable to delay disclosure when the bug or the fix is not yet fully understood, the solution is not well-tested, or for vendor coordination. The timeframe for disclosure is from immediate (especially if it's already publicly known) to a few weeks. As a basic default, we expect report date to disclosure date to be on the order of 7 days. The CubeFS Product Security Committee holds the final say when setting a disclosure date.

--- a/security/email-templates.md
+++ b/security/email-templates.md
@@ -1,17 +1,17 @@
-# ChubaoFS Security Process Email Templates
+# CubeFS Security Process Email Templates
 
 This is a collection of email templates to handle various situations the security team encounters.
 
 ## Upcoming security release
 
 ```
-Subject: Upcoming security release of ChubaoFS $VERSION
-To: chubaofs-users@groups.io
+Subject: Upcoming security release of CubeFS $VERSION
+To: cubefs-users@groups.io
 
-Hello ChubaoFS Community,
+Hello CubeFS Community,
 
-The ChubaoFS Product Security Committee and maintainers would like to announce the forthcoming release
-of ChubaoFS $VERSION.
+The CubeFS Product Security Committee and maintainers would like to announce the forthcoming release
+of CubeFS $VERSION.
 
 This release will be made available on the $ORDINALDAY of $MONTH $YEAR at
 $PDTHOUR PDT ($GMTHOUR GMT). This release will fix $NUMDEFECTS security
@@ -25,18 +25,18 @@ Thanks to $REPORTER, $DEVELOPERS, and the $RELEASELEADS for the coordination is 
 
 Thanks,
 
-$PERSON on behalf of the ChubaoFS Product Security Committee and maintainers
+$PERSON on behalf of the CubeFS Product Security Committee and maintainers
 ```
 
 ## Security Fix Announcement
 
 ```
-Subject: Security release of ChubaoFS $VERSION is now available
-To: chubaofs-users@groups.io
+Subject: Security release of CubeFS $VERSION is now available
+To: cubefs-users@groups.io
 
-Hello ChubaoFS Community,
+Hello CubeFS Community,
 
-The Product Security Committee and maintainers would like to announce the availability of ChubaoFS $VERSION.
+The Product Security Committee and maintainers would like to announce the availability of CubeFS $VERSION.
 This addresses the following CVE(s):
 
 * CVE-YEAR-ABCDEF (CVSS score $CVSS): $CVESUMMARY
@@ -60,7 +60,7 @@ vulnerable in practice. -->
 
 **How do I upgrade?**
 
-Follow the upgrade instructions at https://chubaofs.readthedocs.io
+Follow the upgrade instructions at https://cubefs.readthedocs.io/en/latest/
 
 **Vulnerability Details**
 
@@ -82,5 +82,5 @@ coordination in making this release.
 
 Thanks,
 
-$PERSON on behalf of the ChubaoFS Product Security Committee and maintainers
+$PERSON on behalf of the CubeFS Product Security Committee and maintainers
 ```

--- a/security/security-release-process.md
+++ b/security/security-release-process.md
@@ -1,6 +1,6 @@
 # Security Release Process
 
-ChubaoFS is a growing community of volunteers, users, and vendors. The ChubaoFS community has adopted this security disclosures and response policy to ensure we responsibly handle critical issues.
+CubeFS is a growing community of volunteers, users, and vendors. The CubeFS community has adopted this security disclosures and response policy to ensure we responsibly handle critical issues.
 
 ## Product Security Committee (PSC)
 
@@ -16,20 +16,20 @@ The initial PSC will consist of volunteers who have been involved in the initial
 
 The PSC members will share various tasks as listed below:
 
-- Triage: make sure the people who should be in "the know" (aka notified) are notified, also responds to issues that are not actually issues and let the ChubaoFS maintainers know that. This person is the escalation path for a bug if it is one. 
+- Triage: make sure the people who should be in "the know" (aka notified) are notified, also responds to issues that are not actually issues and let the CubeFS maintainers know that. This person is the escalation path for a bug if it is one. 
 - Infra: make sure we can test the fixes appropriately.
 - Disclosure: handles public messaging around the bug. Documentation on how to upgrade. Changelog. Explaining to public the severity. notifications of bugs sent to mailing lists etc. Requests CVEs.
 - Release: Create new release addressing a security fix.
 
 ### Contacting the Product Security Committee
 
-Contact the team by sending email to [chubaofs-users@groups.io](mailto:chubaofs-users@groups.io)
+Contact the team by sending email to [cubefs-users@groups.io](mailto:cubefs-users@groups.io)
 
 ### Product Security Committee Membership
 
 #### Joining
 
-The PSC should be consist of 2-4 members. New potential members to the PSC can express their interest to the PSC members. These individuals can be nominated by PSC members or ChubaoFS maintainers.
+The PSC should be consist of 2-4 members. New potential members to the PSC can express their interest to the PSC members. These individuals can be nominated by PSC members or CubeFS maintainers.
 
 If representation changes due to job shifts then PSC members are encouraged to grow the team or replace themselves through mentoring new members.
 
@@ -39,7 +39,7 @@ Selection of new members will be done by lazy consensus amongst members for addi
 
 #### Stepping Down
 
-Members may step down at any time and propose a replacement from existing active contributors of ChubaoFS.
+Members may step down at any time and propose a replacement from existing active contributors of CubeFS.
 
 #### Responsibilities
 
@@ -52,11 +52,11 @@ Members may step down at any time and propose a replacement from existing active
 
 ### Private Disclosure Processes
 
-The ChubaoFS Community asks that all suspected vulnerabilities be privately and responsibly disclosed as explained in the [README](README.md).
+The CubeFS Community asks that all suspected vulnerabilities be privately and responsibly disclosed as explained in the [README](README.md).
 
 ### Public Disclosure Processes
 
-If anyone knows of a publicly disclosed security vulnerability please IMMEDIATELY email [chubaofs-users@groups.io](mailto:chubaofs-users@groups.io) to inform the PSC about the vulnerability so they may start the patch, release, and communication process.
+If anyone knows of a publicly disclosed security vulnerability please IMMEDIATELY email [cubefs-users@groups.io](mailto:cubefs-users@groups.io) to inform the PSC about the vulnerability so they may start the patch, release, and communication process.
 
 If possible the PSC will ask the person making the public report if the issue can be handled via a private disclosure process. If the reporter denies the PSC will move swiftly with the fix and release process. In extreme cases GitHub can be asked to delete the issue but this generally isn't necessary and is unlikely to make a public disclosure less damaging.
 
@@ -70,7 +70,7 @@ development time, and release work. If the PSC is dealing with
 a Public Disclosure all timelines become ASAP. If the fix relies on another
 upstream project's disclosure timeline, that will adjust the process as well.
 We will work with the upstream project to fit their timeline and best protect
-ChubaoFS users.
+CubeFS users.
 
 ### Fix Team Organization
 
@@ -91,7 +91,7 @@ If the CVSS score is under ~4.0
 
 Note: CVSS is convenient but imperfect. Ultimately, the PSC has discretion on classifying the severity of a vulnerability.
 
-The severity of the bug and related handling decisions must be discussed on the chubaofs-users@groups.io mailing list.
+The severity of the bug and related handling decisions must be discussed on the cubefs-users@groups.io mailing list.
 
 ### Fix Disclosure Process
 
@@ -100,14 +100,14 @@ With the Fix Development underway, the PSC needs to come up with an overall comm
 **Fix Release Day** (Completed within 1-21 days of Disclosure)
 
 - The PSC will cherry-pick the patches onto the master branch and all relevant release branches. The Fix Team will `lgtm` and `approve`.
-- The ChubaoFS maintainers will merge these PRs as quickly as possible.
+- The CubeFS maintainers will merge these PRs as quickly as possible.
 - The PSC will ensure all the binaries are built, publicly available, and functional.
 - The PSC will announce the new releases, the CVE number, severity, and impact, and the location of the binaries to get wide distribution and user action. As much as possible this announcement should be actionable, and include any mitigating steps users can take prior to upgrading to a fixed version. The recommended target time is 4pm UTC on a non-Friday weekday. This means the announcement will be seen morning Pacific, early evening Europe, and late evening Asia. The announcement will be sent via the following channels:
-  - chubaofs-users@groups.io
+  - cubefs-users@groups.io
 
 ## Retrospective
 
 These steps should be completed 1-3 days after the Release Date. The retrospective process [should be blameless](https://landing.google.com/sre/book/chapters/postmortem-culture.html).
 
-- The PSC will send a retrospective of the process to chubaofs-users@groups.io including details on everyone involved, the timeline of the process, links to relevant PRs that introduced the issue, if relevant, and any critiques of the response and release process.
-- The PSC and Fix Team are also encouraged to send their own feedback on the process to chubaofs-users@groups.io. Honest critique is the only way we are going to get good at this as a community.
+- The PSC will send a retrospective of the process to cubefs-users@groups.io including details on everyone involved, the timeline of the process, links to relevant PRs that introduced the issue, if relevant, and any critiques of the response and release process.
+- The PSC and Fix Team are also encouraged to send their own feedback on the process to cubefs-users@groups.io. Honest critique is the only way we are going to get good at this as a community.


### PR DESCRIPTION
   update. support two replicas(data) volume
    
    * notice.two replicas can support modify and write(use other dp and it's extent) normally
    * support 3replics volume already created to set 2replicas and take effect while create new dp but not including old dp
    * improve meta partition status check
    * add interface to set dp readonly
    * enable force del dataReplica without strict check
    * enable force raft del while 2replicas volume have one replica crash then no leader happend
    * abnormal scenario in two replicas names A and B
    
    1) migration dst names C
       we realize the process as add replica C first,delete src A later
       abnormal resolve ways: if B crash, raft will not eabled,delete B first,wait migration finished,delete A,add another one
    2) B crash
       no leader, and B cann't be deleted according to raft rules first commit then apply
       abnormal resolve ways:
       new interface,force delete B,/dataReplica/delete?....force=true.
       datanode will check replica number(volume and dp must be 2 replics in case of poor usage) and flag of force.
       raft support new interface del replcia directly without use raft log commit(first backup dp data