### PR TITLE
update. support two replicas(data) volume

### DIFF
--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -301,6 +301,7 @@ func (manager *SpaceManager) CreatePartition(request *proto.CreateDataPartitionR
 		ClusterID:     manager.clusterID,
 		PartitionSize: request.PartitionSize,
 		PartitionType: int(request.PartitionTyp),
+		ReplicaNum:    request.ReplicaNum,
 	}
 	dp = manager.partitions[dpCfg.PartitionID]
 	if dp != nil {

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -970,7 +970,7 @@ func (s *DataNode) handlePacketToDecommissionDataPartition(p *repl.Packet) {
 	}
 	p.PartitionID = req.PartitionId
 
-	isRaftLeader, err = s.forwardToRaftLeader(dp, p)
+	isRaftLeader, err = s.forwardToRaftLeader(dp, p, false)
 	if !isRaftLeader {
 		err = raft.ErrNotLeader
 		return
@@ -1037,7 +1037,7 @@ func (s *DataNode) handlePacketToAddDataPartitionRaftMember(p *repl.Packet) {
 			"addRaftAddr(%v) has exsit", string(reqData), req.AddPeer.Addr)
 		return
 	}
-	isRaftLeader, err = s.forwardToRaftLeader(dp, p)
+	isRaftLeader, err = s.forwardToRaftLeader(dp, p, false)
 	if !isRaftLeader {
 		return
 	}
@@ -1090,6 +1090,10 @@ func (s *DataNode) handlePacketToRemoveDataPartitionRaftMember(p *repl.Packet) {
 	if dp == nil {
 		return
 	}
+
+	log.LogWarnf("handlePacketToRemoveDataPartitionRaftMember, req(%s) RemoveRaftPeer(%s) dp %v replicaNum %v",
+		string(reqData), req.RemovePeer.Addr, dp.partitionID, dp.replicaNum)
+
 	p.PartitionID = req.PartitionId
 
 	if !dp.IsExsitReplica(req.RemovePeer.Addr) {
@@ -1098,13 +1102,28 @@ func (s *DataNode) handlePacketToRemoveDataPartitionRaftMember(p *repl.Packet) {
 		return
 	}
 
-	isRaftLeader, err = s.forwardToRaftLeader(dp, p)
+	isRaftLeader, err = s.forwardToRaftLeader(dp, p, req.Force)
 	if !isRaftLeader {
 		return
 	}
-	if err = dp.CanRemoveRaftMember(req.RemovePeer); err != nil {
+	if err = dp.CanRemoveRaftMember(req.RemovePeer, req.Force); err != nil {
 		return
 	}
+
+	if dp.replicaNum == 2 && req.Force {
+		cc := &raftProto.ConfChange{
+			Type: raftProto.ConfRemoveNode,
+			Peer: raftProto.Peer{
+				ID: req.RemovePeer.ID,
+			},
+			Context: reqData,
+		}
+		s.raftStore.RaftServer().RemoveRaftForce(dp.partitionID, cc)
+		dp.ApplyMemberChange(cc, 0)
+		dp.PersistMetadata()
+		return
+	}
+
 	if req.RemovePeer.ID != 0 {
 		_, err = dp.ChangeRaftMember(raftProto.ConfRemoveNode, raftProto.Peer{ID: req.RemovePeer.ID}, reqData)
 		if err != nil {
@@ -1145,7 +1164,7 @@ func (s *DataNode) handlePacketToDataPartitionTryToLeaderrr(p *repl.Packet) {
 	return
 }
 
-func (s *DataNode) forwardToRaftLeader(dp *DataPartition, p *repl.Packet) (ok bool, err error) {
+func (s *DataNode) forwardToRaftLeader(dp *DataPartition, p *repl.Packet, force bool) (ok bool, err error) {
 	var (
 		conn       *net.TCPConn
 		leaderAddr string
@@ -1157,6 +1176,11 @@ func (s *DataNode) forwardToRaftLeader(dp *DataPartition, p *repl.Packet) (ok bo
 
 	// return NoLeaderError if leaderAddr is nil
 	if leaderAddr == "" {
+		if dp.replicaNum == 2 && force {
+			ok = true
+			log.LogInfof("action[forwardToRaftLeader] no leader but replica num %v continue", dp.replicaNum)
+			return
+		}
 		err = storage.NoLeaderError
 		return
 	}

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -356,6 +356,26 @@ func parseVolUpdateReq(r *http.Request, vol *Vol, req *updateVolReq) (err error)
 	return
 }
 
+func parseBoolFieldToUpdateVol(r *http.Request, vol *Vol) (followerRead, authenticate bool, err error) {
+	if followerReadStr := r.FormValue(followerReadKey); followerReadStr != "" {
+		if followerRead, err = strconv.ParseBool(followerReadStr); err != nil {
+			err = unmatchedKey(followerReadKey)
+			return
+		}
+	} else {
+		followerRead = vol.FollowerRead
+	}
+	if authenticateStr := r.FormValue(authenticateKey); authenticateStr != "" {
+		if authenticate, err = strconv.ParseBool(authenticateStr); err != nil {
+			err = unmatchedKey(authenticateKey)
+			return
+		}
+	} else {
+		authenticate = vol.authenticate
+	}
+	return
+}
+
 func parseRequestToSetVolCapacity(r *http.Request) (name, authKey string, capacity int, err error) {
 	if err = r.ParseForm(); err != nil {
 		return

--- a/master/const.go
+++ b/master/const.go
@@ -75,6 +75,8 @@ const (
 	srcAddrKey              = "srcAddr"
 	targetAddrKey           = "targetAddr"
 	forceKey                = "force"
+	raftForceDelKey         = "raftForceDel"
+	enablePosixAclKey       = "enablePosixAcl"
 )
 
 const (

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -53,12 +53,12 @@ func (partition *DataPartition) checkStatus(clusterName string, needLog bool, dp
 		partition.Status = proto.ReadOnly
 	}
 
-	if partition.isSingleReplica() && partition.SingleDecommissionStatus > 0 {
-		log.LogInfof("action[checkStatus] partition %v with single replica on decommison status %v",
-			partition.PartitionID, partition.Status)
+	if partition.isSpecialReplicaCnt() && partition.SingleDecommissionStatus > 0 {
+		log.LogInfof("action[checkStatus] partition %v with Special replica cnt %v on decommison status %v, live replicacnt %v",
+			partition.PartitionID, partition.ReplicaNum, partition.Status, len(liveReplicas))
 		partition.Status = proto.ReadOnly
 		if partition.SingleDecommissionStatus == datanode.DecommsionWaitAddRes {
-			if len(liveReplicas) == 2 && partition.checkReplicaNotHaveStatus(liveReplicas, proto.Unavailable) == true {
+			if len(liveReplicas) == int(partition.ReplicaNum+1) && partition.checkReplicaNotHaveStatus(liveReplicas, proto.Unavailable) == true {
 				partition.SingleDecommissionStatus = datanode.DecommsionWaitAddResFin
 				log.LogInfof("action[checkStatus] partition %v with single replica on decommison and continue to remove old replica",
 					partition.PartitionID)
@@ -124,10 +124,13 @@ func (partition *DataPartition) checkReplicaStatus(timeOutSec int64) {
 			if replica.Status == proto.ReadWrite {
 				replica.Status = proto.ReadOnly
 			}
+			if partition.isSpecialReplicaCnt() {
+				return
+			}
 			continue
 		}
 
-		if replica.dataNode.RdOnly && replica.Status == proto.ReadWrite {
+		if (replica.dataNode.RdOnly || partition.RdOnly) && replica.Status == proto.ReadWrite {
 			replica.Status = proto.ReadOnly
 		}
 	}
@@ -220,7 +223,7 @@ func (partition *DataPartition) checkDiskError(clusterID, leaderAddr string) {
 		}
 
 		if replica.Status == proto.Unavailable {
-			if partition.isSingleReplica() && len(partition.Hosts) > 1 {
+			if partition.isSpecialReplicaCnt() && len(partition.Hosts) > 1 {
 				log.LogWarnf("action[%v],clusterID[%v],partitionID:%v  On :%v status Unavailable",
 					checkDataPartitionDiskErr, clusterID, partition.PartitionID, addr)
 				continue

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -64,10 +64,10 @@ func (c *Cluster) checkDiskRecoveryProgress() {
 				continue
 			}
 			log.LogInfof("action[checkDiskRecoveryProgress] dp %v isSpec %v replics %v conf replics num %v",
-				partition.PartitionID, partition.isSingleReplica(), len(partition.Replicas), int(partition.ReplicaNum))
+				partition.PartitionID, partition.isSpecialReplicaCnt(), len(partition.Replicas), int(partition.ReplicaNum))
 			if len(partition.Replicas) == 0 ||
-				(!partition.isSingleReplica() && len(partition.Replicas) < int(partition.ReplicaNum)) ||
-				(partition.isSingleReplica() && len(partition.Replicas) > int(partition.ReplicaNum)) {
+				(!partition.isSpecialReplicaCnt() && len(partition.Replicas) < int(partition.ReplicaNum)) ||
+				(partition.isSpecialReplicaCnt() && len(partition.Replicas) > int(partition.ReplicaNum)) {
 				newBadDpIds = append(newBadDpIds, partitionID)
 				log.LogInfof("action[checkDiskRecoveryProgress] dp %v newBadDpIds [%v] replics %v conf replics num %v",
 					partition.PartitionID, newBadDpIds, len(partition.Replicas), int(partition.ReplicaNum))

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -282,9 +282,6 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 		Path(proto.AdminGetNodeInfo).
 		HandlerFunc(m.getNodeInfoHandler)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
-		Path(proto.AdminDomainCreate).
-		HandlerFunc(m.createDomainHandler)
-	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminGetIsDomainOn).
 		HandlerFunc(m.getIsDomainOn)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
@@ -308,6 +305,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminSetNodeRdOnly).
 		HandlerFunc(m.setNodeRdOnlyHandler)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminSetDpRdOnly).
+		HandlerFunc(m.setDpRdOnlyHandler)
 
 	// user management APIs
 	router.NewRoute().Methods(http.MethodPost).

--- a/master/meta_partition.go
+++ b/master/meta_partition.go
@@ -258,6 +258,7 @@ func (mp *MetaPartition) checkStatus(clusterID string, writeLog bool, replicaNum
 	mp.Lock()
 	defer mp.Unlock()
 
+	mp.checkReplicas()
 	liveReplicas := mp.getLiveReplicas()
 
 	if len(liveReplicas) <= replicaNum/2 {
@@ -417,11 +418,21 @@ func (mp *MetaPartition) getLiveReplicasAddr(liveReplicas []*MetaReplica) (addrs
 	}
 	return
 }
+
 func (mp *MetaPartition) getLiveReplicas() (liveReplicas []*MetaReplica) {
 	liveReplicas = make([]*MetaReplica, 0)
 	for _, mr := range mp.Replicas {
 		if mr.isActive() {
 			liveReplicas = append(liveReplicas, mr)
+		}
+	}
+	return
+}
+
+func (mp *MetaPartition) checkReplicas() {
+	for _, mr := range mp.Replicas {
+		if !mr.isActive() {
+			mr.Status = proto.Unavailable
 		}
 	}
 	return

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -102,6 +102,7 @@ type dataPartitionValue struct {
 	IsRecover     bool
 	PartitionType int
 	PartitionTTL  int64
+	RdOnly        bool
 }
 
 type replicaValue struct {
@@ -123,6 +124,7 @@ func newDataPartitionValue(dp *DataPartition) (dpv *dataPartitionValue) {
 		IsRecover:     dp.isRecover,
 		PartitionType: dp.PartitionType,
 		PartitionTTL:  dp.PartitionTTL,
+		RdOnly:        dp.RdOnly,
 	}
 	for _, replica := range dp.Replicas {
 		rv := &replicaValue{Addr: replica.Addr, DiskPath: replica.DiskPath}
@@ -964,6 +966,8 @@ func (c *Cluster) loadDataPartitions() (err error) {
 		dp.Peers = dpv.Peers
 		dp.OfflinePeerID = dpv.OfflinePeerID
 		dp.isRecover = dpv.IsRecover
+		dp.RdOnly = dpv.RdOnly
+
 		for _, rv := range dpv.Replicas {
 			if !contains(dp.Hosts, rv.Addr) {
 				continue

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -29,12 +29,13 @@ import (
 	"github.com/cubefs/cubefs/util/log"
 )
 
-func newCreateDataPartitionRequest(volName string, ID uint64, members []proto.Peer,
+func newCreateDataPartitionRequest(volName string, ID uint64, replicaNum int, members []proto.Peer,
 	dataPartitionSize int, hosts []string, createType int, partitionType int) (req *proto.CreateDataPartitionRequest) {
 	req = &proto.CreateDataPartitionRequest{
 		PartitionTyp:  partitionType,
 		PartitionId:   ID,
 		PartitionSize: dataPartitionSize,
+		ReplicaNum:    replicaNum,
 		VolumeId:      volName,
 		Members:       members,
 		Hosts:         hosts,

--- a/master/vol.go
+++ b/master/vol.go
@@ -36,6 +36,8 @@ type VolVarargs struct {
 	dpSelectorParm string
 	coldArgs       *coldVolArgs
 	domainId       uint64
+	dpReplicaNum   uint8
+	enablePosixAcl bool
 }
 
 // Vol represents a set of meta partitionMap and data partitionMap
@@ -315,12 +317,12 @@ func (vol *Vol) checkReplicaNum(c *Cluster) {
 
 	dps := vol.cloneDataPartitionMap()
 	for _, dp := range dps {
-		host := dp.getToBeDecommissionHost(int(vol.dpReplicaNum))
+		host := dp.getToBeDecommissionHost(int(dp.ReplicaNum))
 		if host == "" {
 			continue
 		}
 		if err = dp.removeOneReplicaByHost(c, host); err != nil {
-			if dp.isSingleReplica() && len(dp.Hosts) > 1 {
+			if dp.isSpecialReplicaCnt() && len(dp.Hosts) > 1 {
 				log.LogWarnf("action[checkReplicaNum] removeOneReplicaByHost host [%v],vol[%v],err[%v]", host, vol.Name, err)
 				continue
 			}

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -40,7 +40,6 @@ const (
 	AdminListVols                   = "/vol/list"
 	AdminSetNodeInfo                = "/admin/setNodeInfo"
 	AdminGetNodeInfo                = "/admin/getNodeInfo"
-	AdminDomainCreate               = "/admin/createDomain"
 	AdminGetAllNodeSetGrpInfo       = "/admin/getDomainInfo"
 	AdminGetNodeSetGrpInfo          = "/admin/getDomainNodeSetGrpInfo"
 	AdminGetIsDomainOn              = "/admin/getIsDomainOn"
@@ -49,6 +48,7 @@ const (
 	AdminUpdateDomainDataUseRatio   = "/admin/updateDomainDataRatio"
 	AdminUpdateZoneExcludeRatio     = "/admin/updateZoneExcludeRatio"
 	AdminSetNodeRdOnly              = "/admin/setNodeRdOnly"
+	AdminSetDpRdOnly                = "/admin/setDpRdOnly"
 	//graphql master api
 	AdminClusterAPI = "/api/cluster"
 	AdminUserAPI    = "/api/user"
@@ -156,6 +156,7 @@ type CreateDataPartitionRequest struct {
 	PartitionTyp  int
 	PartitionId   uint64
 	PartitionSize int
+	ReplicaNum    int
 	VolumeId      string
 	IsRandomWrite bool
 	Members       []Peer
@@ -201,6 +202,7 @@ type AddDataPartitionRaftMemberRequest struct {
 type RemoveDataPartitionRaftMemberRequest struct {
 	PartitionId uint64
 	RemovePeer  Peer
+	Force       bool
 }
 
 // AddMetaPartitionRaftMemberRequest defines the request of add raftMember a meta partition.

--- a/proto/model.go
+++ b/proto/model.go
@@ -206,6 +206,7 @@ type DataPartitionInfo struct {
 	FilesWithMissingReplica  map[string]int64 // key: file name, value: last time when a missing replica is found
 	SingleDecommissionStatus uint8
 	SingleDecommissionAddr   string
+	RdOnly                   bool
 }
 
 //FileInCore define file in data partition

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -379,18 +379,18 @@ func (p *Packet) IsMasterCommand() bool {
 }
 
 func (p *Packet) IsForwardPacket() bool {
-	r := p.RemainingFollowers > 0 && !p.IsSingleReplicatePacket()
+	r := p.RemainingFollowers > 0 && !p.isSpecialReplicaCnttePacket()
 	return r
 }
 
-func (p *Packet) IsSingleReplicatePacket() bool {
+func (p *Packet) isSpecialReplicaCnttePacket() bool {
 	r := p.RemainingFollowers == 127
 	return r
 }
 
 // A leader packet is the packet send to the leader and does not require packet forwarding.
 func (p *Packet) IsLeaderPacket() (ok bool) {
-	if (p.IsForwardPkt() || p.IsSingleReplicatePacket()) &&
+	if (p.IsForwardPkt() || p.isSpecialReplicaCnttePacket()) &&
 		(p.IsWriteOperation() || p.IsCreateExtentOperation() || p.IsMarkDeleteExtentOperation()) {
 		ok = true
 	}


### PR DESCRIPTION
 notice：two replicas can support modify and write(use other dp and it's extent) normally

features:
1. support 3replics volume already created to set 2replicas and take effect while create new dp but not including old dp
2. improve meta partition status check
3. add interface to set dp readonly
4. enable force del dataReplica without strict check
5. enable force raft del while 2replicas volume have one replica crash then no leader happend

 abnormal scenario in two replicas names A and B
    1) migration dst names C
       we realize the process as add replica C first,delete src A later
       abnormal resolve ways: if B crash, raft will not eabled,delete B first,wait migration finished,delete A,add another one
    2) B crash
       no leader, and B cann't be deleted according to raft rules first commit then apply
       abnormal resolve ways:
       new interface,force delete B,/dataReplica/delete?....force=true.
       datanode will check replica number(volume and dp must be 2 replics in case of poor usage) and flag of force.
       raft support new interface del replcia directly without use raft log commit(first backup dp data)

Signed-off-by: leonrayang <chl696@sina.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
