### PR TITLE
ignore running ci when matching those paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,16 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
 


### PR DESCRIPTION
    paths-ignore:
      - '.github/**'
      - 'docs/**'
      - '**.md'

Signed-off-by: slasher <mcq.sejust@gmail.com>