### PR TITLE
enhance:  add some enhance about permission and datanode's performance

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -184,6 +184,10 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		}
 	}
 
+	if !opt.EnablePosixACL {
+		opt.EnablePosixACL = s.ec.GetEnablePosixAcl()
+	}
+
 	if s.rootIno, err = s.mw.GetRootIno(opt.SubDir); err != nil {
 		return nil, err
 	}

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/cubefs/cubefs/util/buf"
 	"io/ioutil"
 	syslog "log"
 	"net"
@@ -38,6 +37,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/cubefs/cubefs/util/buf"
 
 	"github.com/cubefs/cubefs/sdk/master"
 	"github.com/cubefs/cubefs/util"

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -226,6 +226,7 @@ type updateVolReq struct {
 	capacity       uint64
 	followRead     bool
 	authenticate   bool
+	enablePosixAcl bool
 	zoneName       string
 	description    string
 	dpSelectorName string
@@ -308,6 +309,10 @@ func parseVolUpdateReq(r *http.Request, vol *Vol, req *updateVolReq) (err error)
 	req.zoneName = extractStrWithDefault(r, zoneNameKey, vol.zoneName)
 
 	if req.capacity, err = extractUint64WithDefault(r, volCapacityKey, vol.Capacity); err != nil {
+		return
+	}
+
+	if req.enablePosixAcl, err = extractBoolWithDefault(r, enablePosixAclKey, vol.enablePosixAcl); err != nil {
 		return
 	}
 

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -423,6 +423,7 @@ type createVolReq struct {
 	zoneName         string
 	description      string
 	volType          int
+	enablePosixAcl   bool
 	// cold vol args
 	coldArgs coldVolArgs
 }
@@ -539,6 +540,11 @@ func parseRequestToCreateVol(r *http.Request, req *createVolReq) (err error) {
 	req.zoneName = extractStr(r, zoneNameKey)
 	req.description = extractStr(r, descriptionKey)
 	req.domainId, err = extractUint64WithDefault(r, domainIdKey, 0)
+	if err != nil {
+		return
+	}
+
+	req.enablePosixAcl, err = extractPosixAcl(r)
 
 	return
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -726,6 +726,7 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+
 	if vol.dpReplicaNum == 1 && !req.followRead {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: "single replica must enable follower read"})
 	}
@@ -747,6 +748,7 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 	newArgs.authenticate = req.authenticate
 	newArgs.dpSelectorName = req.dpSelectorName
 	newArgs.dpSelectorParm = req.dpSelectorParm
+	newArgs.enablePosixAcl = req.enablePosixAcl
 	if req.coldArgs != nil {
 		newArgs.coldArgs = req.coldArgs
 	}

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1287,6 +1287,15 @@ func (m *Server) setNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	if val, ok := params[maxDpCntLimitKey]; ok {
+		if v, ok := val.(uint64); ok {
+			if err = m.cluster.setMaxDpCntLimit(v); err != nil {
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+		}
+	}
 	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf("set nodeinfo params %v successfully", params)))
 
 }
@@ -1894,6 +1903,7 @@ func (m *Server) getNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	resp[nodeDeleteWorkerSleepMs] = fmt.Sprintf("%v", m.cluster.cfg.MetaNodeDeleteWorkerSleepMs)
 	resp[nodeAutoRepairRateKey] = fmt.Sprintf("%v", m.cluster.cfg.DataNodeAutoRepairLimitRate)
 	resp[clusterLoadFactorKey] = fmt.Sprintf("%v", m.cluster.cfg.ClusterLoadFactor)
+	resp[maxDpCntLimitKey] = fmt.Sprintf("%v", m.cluster.cfg.MaxDpCntLimit)
 
 	sendOkReply(w, r, newSuccessHTTPReply(resp))
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1194,7 +1194,7 @@ func (m *Server) migrateDataNodeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !targetNode.isWriteAble() {
+	if !targetNode.isWriteAble() || !targetNode.dpCntInLimit() {
 		err = fmt.Errorf("[%s] is not writable, can't used as target addr for migrate", targetAddr)
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1018,6 +1018,7 @@ func newSimpleView(vol *Vol) *proto.SimpleVolView {
 		Status:             vol.Status,
 		Capacity:           vol.Capacity,
 		FollowerRead:       vol.FollowerRead,
+		EnablePosixAcl:     vol.enablePosixAcl,
 		NeedToLowerReplica: vol.NeedToLowerReplica,
 		Authenticate:       vol.authenticate,
 		CrossZone:          vol.crossZone,
@@ -2222,6 +2223,19 @@ func parseReqToDecoDisk(r *http.Request) (nodeAddr, diskPath string, limit int, 
 	return
 }
 
+func extractPosixAcl(r *http.Request) (enablePosix bool, err error) {
+	var value string
+	if value = r.FormValue(enablePosixAclKey); value == "" {
+		return
+	}
+
+	status, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("parse %s failed, val %s", enablePosixAclKey, value)
+	}
+
+	return status, nil
+}
 func (m *Server) migrateMetaNodeHandler(w http.ResponseWriter, r *http.Request) {
 	srcAddr, targetAddr, limit, err := parseMigrateNodeParam(r)
 	if err != nil {

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2441,6 +2441,7 @@ func (c *Cluster) doCreateVol(req *createVolReq) (vol *Vol, err error) {
 		DomainId:          req.domainId,
 		CreateTime:        createTime,
 		Description:       req.description,
+		EnablePosixAcl:    req.enablePosixAcl,
 
 		VolType:          req.volType,
 		EbsBlkSize:       req.coldArgs.objBlockSize,

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2684,6 +2684,20 @@ func (c *Cluster) setMetaNodeDeleteWorkerSleepMs(val uint64) (err error) {
 	return
 }
 
+func (c *Cluster) setMaxDpCntLimit(val uint64) (err error) {
+	oldVal := atomic.LoadUint64(&c.cfg.MaxDpCntLimit)
+	atomic.StoreUint64(&c.cfg.MaxDpCntLimit, val)
+	maxDpCntOneNode = uint32(val)
+	if err = c.syncPutCluster(); err != nil {
+		log.LogErrorf("action[MaxDpCntLimit] err[%v]", err)
+		atomic.StoreUint64(&c.cfg.MaxDpCntLimit, oldVal)
+		maxDpCntOneNode = uint32(oldVal)
+		err = proto.ErrPersistenceByRaft
+		return
+	}
+	return
+}
+
 func (c *Cluster) setDisableAutoAllocate(disableAutoAllocate bool) (err error) {
 	oldFlag := c.DisableAutoAllocate
 	c.DisableAutoAllocate = disableAutoAllocate

--- a/master/config.go
+++ b/master/config.go
@@ -94,6 +94,7 @@ type clusterConfig struct {
 	MetaNodeDeleteBatchCount            uint64 //metanode delete batch count
 	DataNodeDeleteLimitRate             uint64 //datanode delete limit rate
 	MetaNodeDeleteWorkerSleepMs         uint64 //datanode delete limit rate
+	MaxDpCntLimit                       uint64
 	DataNodeAutoRepairLimitRate         uint64 //datanode autorepair limit rate
 	peers                               []raftstore.PeerAddress
 	peerAddrs                           []string

--- a/master/const.go
+++ b/master/const.go
@@ -66,6 +66,7 @@ const (
 	nodeDeleteWorkerSleepMs = "deleteWorkerSleepMs"
 	nodeAutoRepairRateKey   = "autoRepairRate"
 	clusterLoadFactorKey    = "loadFactor"
+	maxDpCntLimitKey        = "maxDpCntLimit"
 	descriptionKey          = "description"
 	dpSelectorNameKey       = "dpSelectorName"
 	dpSelectorParmKey       = "dpSelectorParm"

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -135,6 +135,10 @@ func (dataNode *DataNode) isWriteAble() (ok bool) {
 	return
 }
 
+func (dataNode *DataNode) dpCntInLimit() bool {
+	return dataNode.DataPartitionCount <= dpCntOneNodeLimit()
+}
+
 func (dataNode *DataNode) isWriteAbleWithSize(size uint64) (ok bool) {
 	dataNode.RLock()
 	defer dataNode.RUnlock()

--- a/master/gapi_volume.go
+++ b/master/gapi_volume.go
@@ -189,6 +189,7 @@ func (s *VolumeService) createVolume(ctx context.Context, args struct {
 	if per == USER && args.Owner != uid {
 		return nil, fmt.Errorf("[%s] not has permission to create volume for [%s]", uid, args.Owner)
 	}
+
 	req := &createVolReq{
 		name:             args.Name,
 		owner:            args.Owner,

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -168,6 +168,8 @@ type volValue struct {
 	CacheLowWater    int
 	CacheLRUInterval int
 	CacheRule        string
+
+	EnablePosixAcl bool
 }
 
 func (v *volValue) Bytes() (raw []byte, err error) {
@@ -198,6 +200,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		DpSelectorName:    vol.dpSelectorName,
 		DpSelectorParm:    vol.dpSelectorParm,
 		DefaultPriority:   vol.defaultPriority,
+		EnablePosixAcl:    vol.enablePosixAcl,
 
 		VolType:          vol.VolType,
 		EbsBlkSize:       vol.EbsBlkSize,

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -40,6 +40,7 @@ type clusterValue struct {
 	MetaNodeDeleteBatchCount    uint64
 	MetaNodeDeleteWorkerSleepMs uint64
 	DataNodeAutoRepairLimitRate uint64
+	MaxDpCntLimit               uint64
 	FaultDomain                 bool
 }
 
@@ -53,6 +54,7 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		MetaNodeDeleteWorkerSleepMs: c.cfg.MetaNodeDeleteWorkerSleepMs,
 		DataNodeAutoRepairLimitRate: c.cfg.DataNodeAutoRepairLimitRate,
 		DisableAutoAllocate:         c.DisableAutoAllocate,
+		MaxDpCntLimit:               c.cfg.MaxDpCntLimit,
 		FaultDomain:                 c.FaultDomain,
 	}
 	return cv
@@ -597,6 +599,11 @@ func (c *Cluster) updateDataNodeDeleteLimitRate(val uint64) {
 	atomic.StoreUint64(&c.cfg.DataNodeDeleteLimitRate, val)
 }
 
+func (c *Cluster) updateMaxDpCntLimit(val uint64) {
+	atomic.StoreUint64(&c.cfg.MaxDpCntLimit, val)
+	maxDpCntOneNode = uint32(val)
+}
+
 func (c *Cluster) loadClusterValue() (err error) {
 	result, err := c.fsm.store.SeekForPrefix([]byte(clusterPrefix))
 	if err != nil {
@@ -616,6 +623,8 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.updateMetaNodeDeleteWorkerSleepMs(cv.MetaNodeDeleteWorkerSleepMs)
 		c.updateDataNodeDeleteLimitRate(cv.DataNodeDeleteLimitRate)
 		c.updateDataNodeAutoRepairLimit(cv.DataNodeAutoRepairLimitRate)
+		c.updateMaxDpCntLimit(cv.MaxDpCntLimit)
+
 		log.LogInfof("action[loadClusterValue], metaNodeThreshold[%v]", cv.Threshold)
 	}
 	return

--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -162,7 +162,7 @@ func getAvailCarryDataNodeTab(maxTotal uint64, excludeHosts []string, dataNodes 
 			log.LogDebugf("contains return")
 			return true
 		}
-		if !dataNode.isWriteAble() || dataNode.ToBeOffline || dataNode.DataPartitionCount > dpCntOneNodeLimit() {
+		if !dataNode.isWriteAble() || dataNode.ToBeOffline || !dataNode.dpCntInLimit() {
 			log.LogInfof("dataNode [%v] is not writeable, offline %v, dpCnt %d", dataNode.Addr, dataNode.ToBeOffline, dataNode.DataPartitionCount)
 			log.LogDebugf("isWritable return")
 			return true

--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -162,8 +162,9 @@ func getAvailCarryDataNodeTab(maxTotal uint64, excludeHosts []string, dataNodes 
 			log.LogDebugf("contains return")
 			return true
 		}
-		if !dataNode.isWriteAble() || dataNode.ToBeOffline {
-			log.LogInfof("[getAvailCarryDataNodeTab] dataNode [%v] is not writeable", dataNode.Addr)
+		if !dataNode.isWriteAble() || dataNode.ToBeOffline || dataNode.DataPartitionCount > dpCntOneNodeLimit() {
+			log.LogInfof("dataNode [%v] is not writeable, offline %v, dpCnt %d", dataNode.Addr, dataNode.ToBeOffline, dataNode.DataPartitionCount)
+			log.LogDebugf("isWritable return")
 			return true
 		}
 

--- a/master/server.go
+++ b/master/server.go
@@ -61,6 +61,8 @@ var (
 
 	useConnPool = true //for test
 	gConfig     *clusterConfig
+
+	maxDpCntOneNode = uint32(3000)
 )
 
 var overSoldFactor = defaultOverSoldFactor
@@ -85,6 +87,13 @@ func setOverSoldFactor(factor float32) {
 	if factor != overSoldFactor {
 		overSoldFactor = factor
 	}
+}
+func dpCntOneNodeLimit() uint32 {
+	if maxDpCntOneNode <= 0 {
+		return 3000
+	}
+
+	return maxDpCntOneNode
 }
 
 // Server represents the server in a cluster

--- a/master/topology.go
+++ b/master/topology.go
@@ -988,7 +988,7 @@ func (ns *nodeSet) canWriteForDataNode(replicaNum int) bool {
 	var count int
 	ns.dataNodes.Range(func(key, value interface{}) bool {
 		node := value.(*DataNode)
-		if node.isWriteAble() {
+		if node.isWriteAble() && node.DataPartitionCount < dpCntOneNodeLimit() {
 			count++
 		}
 		if count >= replicaNum {
@@ -1485,7 +1485,10 @@ func (zone *Zone) canWriteForDataNode(replicaNum uint8) (can bool) {
 	var leastAlive uint8
 	zone.dataNodes.Range(func(addr, value interface{}) bool {
 		dataNode := value.(*DataNode)
-		if dataNode.isActive == true && dataNode.isWriteAbleWithSize(30*util.GB) == true {
+		if dataNode.DataPartitionCount > dpCntOneNodeLimit() {
+			return true
+		}
+		if dataNode.isActive && dataNode.isWriteAbleWithSize(30*util.GB) {
 			leastAlive++
 		}
 		if leastAlive >= replicaNum {

--- a/master/topology.go
+++ b/master/topology.go
@@ -988,7 +988,7 @@ func (ns *nodeSet) canWriteForDataNode(replicaNum int) bool {
 	var count int
 	ns.dataNodes.Range(func(key, value interface{}) bool {
 		node := value.(*DataNode)
-		if node.isWriteAble() && node.DataPartitionCount < dpCntOneNodeLimit() {
+		if node.isWriteAble() && node.dpCntInLimit() {
 			count++
 		}
 		if count >= replicaNum {
@@ -1485,7 +1485,7 @@ func (zone *Zone) canWriteForDataNode(replicaNum uint8) (can bool) {
 	var leastAlive uint8
 	zone.dataNodes.Range(func(addr, value interface{}) bool {
 		dataNode := value.(*DataNode)
-		if dataNode.DataPartitionCount > dpCntOneNodeLimit() {
+		if !dataNode.dpCntInLimit() {
 			return true
 		}
 		if dataNode.isActive && dataNode.isWriteAbleWithSize(30*util.GB) {

--- a/master/vol.go
+++ b/master/vol.go
@@ -1031,6 +1031,7 @@ func setVolFromArgs(args *VolVarargs, vol *Vol) {
 	vol.Capacity = args.capacity
 	vol.FollowerRead = args.followerRead
 	vol.authenticate = args.authenticate
+	vol.enablePosixAcl = args.enablePosixAcl
 
 	if proto.IsCold(vol.VolType) {
 		coldArgs := args.coldArgs
@@ -1073,6 +1074,7 @@ func getVolVarargs(vol *Vol) *VolVarargs {
 		authenticate:   vol.authenticate,
 		dpSelectorName: vol.dpSelectorName,
 		dpSelectorParm: vol.dpSelectorParm,
+		enablePosixAcl: vol.enablePosixAcl,
 
 		coldArgs: args,
 	}

--- a/master/vol.go
+++ b/master/vol.go
@@ -72,6 +72,7 @@ type Vol struct {
 	crossZone          bool
 	domainOn           bool
 	defaultPriority    bool // old default zone first
+	enablePosixAcl     bool
 	zoneName           string
 	MetaPartitions     map[uint64]*MetaPartition `graphql:"-"`
 	mpsLock            sync.RWMutex
@@ -114,6 +115,7 @@ func newVol(vv volValue) (vol *Vol) {
 	vol.description = vv.Description
 	vol.defaultPriority = vv.DefaultPriority
 	vol.domainId = vv.DomainId
+	vol.enablePosixAcl = vv.EnablePosixAcl
 
 	vol.VolType = vv.VolType
 	vol.EbsBlkSize = vv.EbsBlkSize
@@ -125,7 +127,6 @@ func newVol(vv volValue) (vol *Vol) {
 	vol.CacheLowWater = vv.CacheLowWater
 	vol.CacheLRUInterval = vv.CacheLRUInterval
 	vol.CacheRule = vv.CacheRule
-
 	return
 }
 

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -41,8 +41,10 @@ func (m *MetaNode) startStat() {
 
 func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
 	labels := map[string]string{
-		"partid": fmt.Sprintf("%d", mp.config.PartitionId),
+		"partid":     fmt.Sprintf("%d", mp.config.PartitionId),
+		exporter.Vol: mp.config.VolName,
 	}
+
 	it := mp.GetInodeTree()
 	if it != nil {
 		exporter.NewGauge("mpInodeCount").SetWithLabels(float64(it.Len()), labels)

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -504,6 +504,8 @@ type SimpleVolView struct {
 	DefaultPriority    bool
 	DomainOn           bool
 	CreateTime         string
+	EnableToken        bool
+	EnablePosixAcl     bool
 	Description        string
 	DpSelectorName     string
 	DpSelectorParm     string

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -16,10 +16,11 @@ package stream
 
 import (
 	"fmt"
-	"golang.org/x/time/rate"
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/data/wrapper"
@@ -174,6 +175,10 @@ retry:
 	client.writeLimiter = rate.NewLimiter(writeLimit, defaultWriteLimitBurst)
 
 	return
+}
+
+func (client *ExtentClient) GetEnablePosixAcl() bool {
+	return client.dataWrapper.EnablePosixAcl
 }
 
 // Open request shall grab the lock until request is sent to the request channel

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -43,6 +43,7 @@ type Wrapper struct {
 	clusterName           string
 	volName               string
 	volType               int
+	EnablePosixAcl        bool
 	masters               []string
 	partitions            map[uint64]*DataPartition
 	followerRead          bool
@@ -131,6 +132,8 @@ func (w *Wrapper) getSimpleVolView() (err error) {
 	w.dpSelectorName = view.DpSelectorName
 	w.dpSelectorParm = view.DpSelectorParm
 	w.volType = view.VolType
+	w.EnablePosixAcl = view.EnablePosixAcl
+
 	log.LogInfof("getSimpleVolView: get volume simple info: ID(%v) name(%v) owner(%v) status(%v) capacity(%v) "+
 		"metaReplicas(%v) dataReplicas(%v) mpCnt(%v) dpCnt(%v) followerRead(%v) createTime(%v) dpSelectorName(%v) "+
 		"dpSelectorParm(%v)",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- add posixAcl cfg on vol (fixes #1485)
- add vol info in `cfs_metanode_mpInodeCount`(fixes #1482)
- limit datapartition cnt in one datanode (fixes #1481)

**Special notes for your reviewer**:
`**max datapartition count in one datanode is limit to 3000 default.** `

**Release note**:
```
use `curl "masterIp:17010/admin/setNodeInfo?maxDpCntLmit=3000"` to update.
user `curl "masterIp:17010/admin/getNodeInfo"` to view. (0 meas default 3000)

when create or update volume, add `enablePosixAcl` to control volume posix acl switch.
```
