### PR TITLE
update: 1) update metanode or datanode id need drop old one before 2)update adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -22,11 +22,13 @@ This page contains a list of organizations who are using CubeFS in production or
 | [NetEase](https://www.163.com) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
 | [Meizu](https://www.meizu.com) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
 | [OPPO](https://www.oppo.com/en) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
+| [Qihoo 360](https://www.so.com) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
 | [BEIKE](https://www.ke.com) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
 | [Reconova](http://www.reconova.com) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
 | [LinkSure Network](https://cn.wifi.com) | ![production](https://img.shields.io/badge/-production-blue?style=flat) |
+| [Da-Jiang Innovations](https://www.dji.com/cn) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |
 | [Yanhuang Data](https://yanhuangdata.com/) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |
-| [Qihoo 360](https://www.so.com) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |
+| [BIGO LIVE](https://www.bigo.tv/cn/) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |
 | [Xiaomi](https://www.mi.com/global/) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |
 | [Sinosoft](http://www.sinosoft.com.cn) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |
 | [DADA](https://about.imdada.cn) | ![testing](https://img.shields.io/badge/-testing-green?style=flat) |

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -572,6 +572,9 @@ func (c *Cluster) updateDataNodeBaseInfo(nodeAddr string, id uint64) (err error)
 		return
 	}
 
+	if err = c.syncDeleteDataNode(dataNode); err != nil {
+		return
+	}
 	dataNode.ID = id
 	if err = c.syncUpdateDataNode(dataNode); err != nil {
 		return
@@ -592,7 +595,9 @@ func (c *Cluster) updateMetaNodeBaseInfo(nodeAddr string, id uint64) (err error)
 	if metaNode.ID == id {
 		return
 	}
-
+	if err = c.syncDeleteMetaNode(metaNode); err != nil {
+		return
+	}
 	metaNode.ID = id
 	if err = c.syncUpdateMetaNode(metaNode); err != nil {
 		return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
it's a tool used by abnormal senario that nodeid not consistent between datanode or metanode meta and master, we need use this interface update the master

**Which issue this PR fixes** 

the process of "/dataNode/update" and "/metaNode/update" should drop the old one and set the new one. or else would exist two different version of node id info

**Special notes for your reviewer**:
it's not a common interface be used,should get advice from the commutnity if need.
