### PR TITLE
FIX: fix the base images name in Dockerfile-dev

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM ghcr.io/chubaofs/cbfs-base:latest
+FROM ghcr.io/cubefs/cbfs-base:1.0-golang-1.16.12
 
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list \
         && apt-get update


### PR DESCRIPTION
fix the base images name in DockerFile-dev from "ghcr.io/chubaofs/cbfs-base:latest" to "ghcr.io/cubefs/cbfs-base:1.0-golang-1.16.12"
as it was updated in [https://github.com/cubefs/cubefs/pull/1520](https://github.com/cubefs/cubefs/pull/1520)