### PR TITLE
feature：add cluster creation time

### DIFF
--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -896,6 +896,11 @@ func parseAndExtractSetNodeInfoParams(r *http.Request) (params map[string]interf
 		params[maxDpCntLimitKey] = val
 	}
 
+	if value = r.FormValue(clusterCreateTimeKey); value != "" {
+		noParams = false
+		params[clusterCreateTimeKey] = value
+	}
+
 	if noParams {
 		err = keyNotFound(nodeDeleteBatchCountKey)
 		return

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -203,6 +203,7 @@ func (m *Server) clusterStat(w http.ResponseWriter, r *http.Request) {
 func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 	cv := &proto.ClusterView{
 		Name:                m.cluster.Name,
+		CreateTime:          time.Unix(m.cluster.CreateTime, 0).Format(proto.TimeFormat),
 		LeaderAddr:          m.leaderInfo.addr,
 		DisableAutoAlloc:    m.cluster.DisableAutoAllocate,
 		MetaNodeThreshold:   m.cluster.cfg.MetaNodeThreshold,
@@ -1696,6 +1697,23 @@ func (m *Server) setNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	if val, ok := params[clusterCreateTimeKey]; ok {
+		if createTimeParam, ok := val.(string); ok {
+			var createTime time.Time
+			var err error
+			if createTime, err = time.ParseInLocation(proto.TimeFormat, createTimeParam, time.Local); err != nil {
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+
+			if err = m.cluster.setClusterCreateTime(createTime.Unix()); err != nil {
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+		}
+	}
+
 	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf("set nodeinfo params %v successfully", params)))
 
 }

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -33,6 +33,7 @@ import (
 // Cluster stores all the cluster-level information.
 type Cluster struct {
 	Name                string
+	CreateTime          int64
 	vols                map[string]*Vol
 	dataNodes           sync.Map
 	metaNodes           sync.Map
@@ -2727,6 +2728,18 @@ func (c *Cluster) setMaxDpCntLimit(val uint64) (err error) {
 		log.LogErrorf("action[MaxDpCntLimit] err[%v]", err)
 		atomic.StoreUint64(&c.cfg.MaxDpCntLimit, oldVal)
 		maxDpCntOneNode = uint32(oldVal)
+		err = proto.ErrPersistenceByRaft
+		return
+	}
+	return
+}
+
+func (c *Cluster) setClusterCreateTime(createTime int64) (err error) {
+	oldVal := c.CreateTime
+	c.CreateTime = createTime
+	if err = c.syncPutCluster(); err != nil {
+		log.LogErrorf("action[setClusterCreateTime] err[%v]", err)
+		c.CreateTime = oldVal
 		err = proto.ErrPersistenceByRaft
 		return
 	}

--- a/master/const.go
+++ b/master/const.go
@@ -67,6 +67,7 @@ const (
 	nodeAutoRepairRateKey   = "autoRepairRate"
 	clusterLoadFactorKey    = "loadFactor"
 	maxDpCntLimitKey        = "maxDpCntLimit"
+	clusterCreateTimeKey    = "clusterCreateTime"
 	descriptionKey          = "description"
 	dpSelectorNameKey       = "dpSelectorName"
 	dpSelectorParmKey       = "dpSelectorParm"

--- a/master/master_manager.go
+++ b/master/master_manager.go
@@ -42,6 +42,8 @@ func (m *Server) handleLeaderChange(leader uint64) {
 		Warn(m.clusterName, fmt.Sprintf("clusterID[%v] leader is changed to %v",
 			m.clusterName, m.leaderInfo.addr))
 		if oldLeaderAddr != m.leaderInfo.addr {
+			m.cluster.checkPersistClusterValue()
+
 			m.loadMetadata()
 			m.metaReady = true
 		}

--- a/proto/model.go
+++ b/proto/model.go
@@ -97,6 +97,7 @@ type MetaReplicaInfo struct {
 // ClusterView provides the view of a cluster.
 type ClusterView struct {
 	Name                string
+	CreateTime          string
 	LeaderAddr          string
 	DisableAutoAlloc    bool
 	MetaNodeThreshold   float32


### PR DESCRIPTION
Signed-off-by: true1064 <true1063@163.com>

**What this PR does / why we need it**:
add 'cluster creation time' feature to master, 
and provides cmds to:
-  query the cluster creation time.
-  set cluster creation time manually.

**Which issue this PR fixes** : fixes  #1468

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
1. how the master record cluster createion time:
- For newly clusters created by master with this feature：when master raft leader is elected for the first time，the cluster creation time is automatically set  and persisted.
- For clusters created by master prior this feature:  the cluster creation time is left as default value zero, and will be be displayed as "1970-01-01 00:00:00" when query. Users can set cluster creation time manually for those clusters.

2. how to query cluster createion time:
- by the cmd 'admin/getCluster'，exmaple:
  curl -v "http://192.168.0.12:17010/admin/getCluster"  |  python -m json.tool

3. how to set cluster creation time manually:
- by the cmd 'admin/setNodeInfo' whit parm 'clusterCreateTime" and date format "YYYY-MM-DD HH:MM:SS"，exmaple:
  curl -v "http://192.168.0.11:17010/admin/setNodeInfo" --data-urlencode "clusterCreateTime=2021-01-02 10:33:44"