### PR TITLE
fix: remove redundant memcopy when reading raft snapshot

### DIFF
--- a/depends/tiglabs/raft/raft_snapshot.go
+++ b/depends/tiglabs/raft/raft_snapshot.go
@@ -68,7 +68,7 @@ func (r *snapshotReader) Next() ([]byte, error) {
 	}
 
 	// read size header
-	r.reader.Reset()
+	// r.reader.Reset()
 	var buf []byte
 	if buf, r.err = r.reader.ReadFull(4); r.err != nil {
 		return nil, r.err
@@ -80,7 +80,7 @@ func (r *snapshotReader) Next() ([]byte, error) {
 	}
 
 	// read data
-	r.reader.Reset()
+	// r.reader.Reset()
 	if buf, r.err = r.reader.ReadFull(int(size)); r.err != nil {
 		return nil, r.err
 	}


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** 
remove redundant memcopy when reading raft snapshot

**Special notes for your reviewer**:

