### PR TITLE
build(cli): make cli with module name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore:
-        - 'blobstore/**'
+        # - 'blobstore/**'
 
 jobs:
 

--- a/blobstore/Dockerfile
+++ b/blobstore/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH=$PATH:$JAVA_HOME/bin
 
 WORKDIR /apps
 VOLUME ["/apps/conf", "/apps/bin"]
-COPY   ./bin/ /apps/bin
+COPY  ./bin/ /apps/bin
 COPY  ./cmd/clustermgr/clustermgr.conf /apps/conf/clustermgr.conf
 COPY  ./cmd/clustermgr/clustermgr1.conf /apps/conf/clustermgr1.conf
 COPY  ./cmd/clustermgr/clustermgr2.conf /apps/conf/clustermgr2.conf

--- a/blobstore/Makefile
+++ b/blobstore/Makefile
@@ -13,7 +13,6 @@
 # permissions and limitations under the License.
 
 PROJECTDIR=$(shell pwd)
-OS=$(shell uname -s)
 BINDIR=$(PROJECTDIR)/bin
 GCFLAGS=all=-trimpath=$(PROJECTDIR)
 ASMFLAGS=all=-trimpath=$(PROJECTDIR)
@@ -33,13 +32,14 @@ endif
 BUILD=go build -v -gcflags=$(GCFLAGS) -asmflags=$(ASMFLAGS) -ldflags='$(LDFLAGS)' -o $(BINDIR)
 INSTALL=CGO_ENABLED=0 $(BUILD)
 CGOINSTALL=CGO_ENABLED=1 $(BUILD)
-CMDDIR=github.com/cubefs/cubefs/blobstore/cmd
-TARGETS=blobnode cm access scheduler tinker proxy cli
+PROJECTMOD=github.com/cubefs/cubefs/blobstore
+CMDDIR=$(PROJECTMOD)/cmd
+TARGETS=clustermgr blobnode access scheduler proxy cli
 
 .PHONY: clean all $(TARGETS)
 all:$(TARGETS)
 
-cm:
+clustermgr:
 	@echo "building clustermgr"
 	@$(CGOINSTALL) $(CMDDIR)/clustermgr
 
@@ -61,7 +61,7 @@ proxy:
 
 cli:
 	@echo "building cli"
-	@$(CGOINSTALL) $(PROJECTDIR)/cli/cli
+	@$(CGOINSTALL) $(PROJECTMOD)/cli/cli
 
 clean:
 	@go clean -i ./...

--- a/blobstore/build.sh
+++ b/blobstore/build.sh
@@ -16,19 +16,19 @@ INSTALLDIR=${CURRENT_DIR}/.deps
 mkdir -p ${INSTALLDIR}/lib
 mkdir -p ${INSTALLDIR}/include
 
-ZLIB_VER=1.2.12
+ZLIB_VER=1.2.13
 BZIP2_VER=1.0.6
 SNAPPY_VER=1.1.7
 LZ4_VER=1.8.3
 ZSTD_VER=1.4.0
 ROCKSDB_VER=6.3.6
 GCCMAJOR=`gcc -dumpversion`
-check=$1
+check=--no-check-certificate
 
 pushd ${INSTALLDIR}
 if [ ! -f lib/libz.a ]; then
     rm -rf zlib-${ZLIB_VER}*
-    wget http://zlib.net/zlib-${ZLIB_VER}.tar.gz
+    wget https://github.com/madler/zlib/archive/refs/tags/v${ZLIB_VER}.tar.gz -O ./zlib-${ZLIB_VER}.tar.gz ${check}
     if [ $? -ne 0 ]; then
         exit 1
     fi

--- a/blobstore/init.sh
+++ b/blobstore/init.sh
@@ -5,7 +5,7 @@ function INIT()
     # build blobstore
     rootPath=$(cd $(dirname $0); pwd)
     source $rootPath/env.sh
-    ./build.sh --no-check-certificate
+    ./build.sh
     if [ $? -ne 0 ]; then
       echo "build failed"
       exit 1

--- a/blobstore/start_docker.sh
+++ b/blobstore/start_docker.sh
@@ -92,12 +92,6 @@ echo "start blobstore service successfully, wait minutes for internal state prep
 
 # wait for docker, avoid container exit
 while true
- do
+do
     sleep 300
 done
-
-
-
-
-
-


### PR DESCRIPTION
closes: #1571

Signed-off-by: slasher <shenjie1@oppo.com>

zlib 1.2.12 404 Not Found.
https://zlib.net/  
Due to the first bug fix, any installations of 1.2.12 or earlier should be replaced with 1.2.13.

