### PR TITLE
Feature: support setting MaxDpCntLimit by cfs-cli

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -190,7 +190,7 @@ If the memory usage reaches this threshold, all the mata partition will be readO
 }
 
 func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
-	var optAutoRepairRate, optMarkDeleteRate, optDelBatchCount, optDelWorkerSleepMs, optLoadFactor string
+	var optAutoRepairRate, optMarkDeleteRate, optDelBatchCount, optDelWorkerSleepMs, optLoadFactor, opMaxDpCntLimit string
 	var cmd = &cobra.Command{
 		Use:   CliOpSetCluster,
 		Short: cmdClusterSetClusterInfoShort,
@@ -204,7 +204,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 				}
 			}()
 
-			if err = client.AdminAPI().SetClusterParas(optDelBatchCount, optMarkDeleteRate, optDelWorkerSleepMs, optAutoRepairRate, optLoadFactor); err != nil {
+			if err = client.AdminAPI().SetClusterParas(optDelBatchCount, optMarkDeleteRate, optDelWorkerSleepMs, optAutoRepairRate, optLoadFactor, opMaxDpCntLimit); err != nil {
 				return
 			}
 			stdout("Cluster parameters has been set successfully. \n")
@@ -215,6 +215,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optMarkDeleteRate, CliFlagMarkDelRate, "", "DataNode batch mark delete limit rate. if 0 for no infinity limit")
 	cmd.Flags().StringVar(&optAutoRepairRate, CliFlagAutoRepairRate, "", "DataNode auto repair rate")
 	cmd.Flags().StringVar(&optDelWorkerSleepMs, CliFlagDelWorkerSleepMs, "", "MetaNode delete worker sleep time with millisecond. if 0 for no sleep")
+	cmd.Flags().StringVar(&opMaxDpCntLimit, CliFlagMaxDpCntLimit, "", "Maximum number of dp on each datanode, default 3000, 0 represents setting to default")
 
 	return cmd
 }

--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -92,6 +92,7 @@ const (
 	CliFlagDelWorkerSleepMs   = "deleteWorkerSleepMs"
 	CliFlagLoadFactor         = "loadFactor"
 	CliFlagMarkDelRate        = "markDeleteRate"
+	CliFlagMaxDpCntLimit      = "maxDpCntLimit"
 	CliFlagCrossZone          = "crossZone"
 	CliNormalZonesFirst       = "normalZonesFirst"
 	CliFlagCount              = "count"

--- a/docs/source/admin-api/master/cluster.rst
+++ b/docs/source/admin-api/master/cluster.rst
@@ -212,7 +212,10 @@ Set node info of cluster.
 .. csv-table:: Parameters
    :header: "Parameter", "Type", "Description"
 
+   "autoRepairRate", "uint64", "dataNode auto repair rate"
    "batchCount", "uint64", "metanode delete batch count"
    "deleteWorkerSleepMs", "uint64", "metanode delete worker sleep time with millisecond. if 0 for no sleep"
+   "loadFactor", "uint64", "load factor"
    "markDeleteRate", "uint64", "datanode batch markdelete limit rate. if 0 for no infinity limit"
+   "maxDpCntLimit", "uint64", "maximum number of dp on each datanode, default 3000, 0 represents setting to default"
 

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -462,13 +462,14 @@ func (api *AdminAPI) SetMetaNodeThreshold(threshold float64) (err error) {
 	return
 }
 
-func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate, loadFactor string) (err error) {
+func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate, loadFactor, maxDpCntLimit string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminSetNodeInfo)
 	request.addParam("batchCount", batchCount)
 	request.addParam("markDeleteRate", markDeleteRate)
 	request.addParam("deleteWorkerSleepMs", deleteWorkerSleepMs)
 	request.addParam("autoRepairRate", autoRepairRate)
 	request.addParam("loadFactor", loadFactor)
+	request.addParam("maxDpCntLimit", maxDpCntLimit)
 
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We can set node info by cfs-cli. But `MaxDpCntLimit` cannot be set by cfs-cli at present. We should support this.

Before the change:
![image](https://user-images.githubusercontent.com/55134131/198921662-75bdc5bd-b1e9-440f-bcb6-31e2246cba8a.png)

After the change:
![image](https://user-images.githubusercontent.com/55134131/198921760-3b616014-1803-41f4-b573-3bc2311a6d26.png)

