### PR TITLE
Enhancement: Cluster info lost MaxDpCntLimit

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -53,6 +53,7 @@ const (
 	nodeMarkDeleteRateKey         = "markDeleteRate"
 	nodeDeleteWorkerSleepMs       = "deleteWorkerSleepMs"
 	nodeAutoRepairRateKey         = "autoRepairRate"
+	nodeMaxDpCntLimit             = "maxDpCntLimit"
 )
 
 func newClusterInfoCmd(client *master.MasterClient) *cobra.Command {
@@ -64,7 +65,7 @@ func newClusterInfoCmd(client *master.MasterClient) *cobra.Command {
 			var cv *proto.ClusterView
 			var cn *proto.ClusterNodeInfo
 			var cp *proto.ClusterIP
-			var delPara map[string]string
+			var clusterPara map[string]string
 			if cv, err = client.AdminAPI().GetCluster(); err != nil {
 				errout("Error: %v", err)
 			}
@@ -76,14 +77,15 @@ func newClusterInfoCmd(client *master.MasterClient) *cobra.Command {
 			}
 			stdout("[Cluster]\n")
 			stdout(formatClusterView(cv, cn, cp))
-			if delPara, err = client.AdminAPI().GetDeleteParas(); err != nil {
+			if clusterPara, err = client.AdminAPI().GetClusterParas(); err != nil {
 				errout("Error: %v", err)
 			}
 
-			stdout(fmt.Sprintf("  BatchCount         : %v\n", delPara[nodeDeleteBatchCountKey]))
-			stdout(fmt.Sprintf("  MarkDeleteRate     : %v\n", delPara[nodeMarkDeleteRateKey]))
-			stdout(fmt.Sprintf("  DeleteWorkerSleepMs: %v\n", delPara[nodeDeleteWorkerSleepMs]))
-			stdout(fmt.Sprintf("  AutoRepairRate     : %v\n", delPara[nodeAutoRepairRateKey]))
+			stdout(fmt.Sprintf("  BatchCount         : %v\n", clusterPara[nodeDeleteBatchCountKey]))
+			stdout(fmt.Sprintf("  MarkDeleteRate     : %v\n", clusterPara[nodeMarkDeleteRateKey]))
+			stdout(fmt.Sprintf("  DeleteWorkerSleepMs: %v\n", clusterPara[nodeDeleteWorkerSleepMs]))
+			stdout(fmt.Sprintf("  AutoRepairRate     : %v\n", clusterPara[nodeAutoRepairRateKey]))
+			stdout(fmt.Sprintf("  MaxDpCntLimit      : %v\n", clusterPara[nodeMaxDpCntLimit]))
 			stdout("\n")
 		},
 	}

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -37,7 +37,7 @@ func formatClusterView(cv *proto.ClusterView, cn *proto.ClusterNodeInfo, cp *pro
 	sb.WriteString(fmt.Sprintf("  DataNode total     : %v GB\n", cv.DataNodeStatInfo.TotalGB))
 	sb.WriteString(fmt.Sprintf("  Volume count       : %v\n", len(cv.VolStatInfo)))
 	sb.WriteString(fmt.Sprintf("  EbsAddr            : %v\n", cp.EbsAddr))
-	sb.WriteString(fmt.Sprintf("  loadFactor         : %v\n", cn.LoadFactor))
+	sb.WriteString(fmt.Sprintf("  LoadFactor         : %v\n", cn.LoadFactor))
 	return sb.String()
 }
 

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -477,7 +477,7 @@ func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSle
 	return
 }
 
-func (api *AdminAPI) GetDeleteParas() (delParas map[string]string, err error) {
+func (api *AdminAPI) GetClusterParas() (delParas map[string]string, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminGetNodeInfo)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When run `cfs-cli cluster info`, the result losts `MaxDpCntLimit`. We should add it.
