### PR TITLE
FIX: remove redundant condition for enablePush

### DIFF
--- a/util/exporter/exporter.go
+++ b/util/exporter/exporter.go
@@ -83,10 +83,6 @@ func Init(role string, cfg *config.Config) {
 	EnablePid = cfg.GetBoolWithDefault(ConfigKeyEnablePid, false)
 	log.LogInfo("enable report partition id info? ", EnablePid)
 
-	if len(cfg.GetString(ConfigKeyPushAddr)) > 0 {
-		enablePush = true
-	}
-
 	port := cfg.GetInt64(ConfigKeyExporterPort)
 
 	if port < 0 {


### PR DESCRIPTION
Signed-off-by: liubingxing <liubbingxing@gmail.com>

![image](https://user-images.githubusercontent.com/2844826/199150085-a53fee01-3e8d-452a-83a9-80eda99a289e.png)

remove the redundant condition for enablePush