### PR TITLE
FIX: fix the wrong fuse subtype

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -599,7 +599,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 		fuse.AsyncRead(),
 		fuse.AutoInvalData(opt.AutoInvalData),
 		fuse.FSName("cubefs-" + opt.Volname),
-		fuse.Subtype("cubes"),
+		fuse.Subtype("cubefs"),
 		fuse.LocalVolume(),
 		fuse.VolumeName("cubefs-" + opt.Volname)}
 


### PR DESCRIPTION
Signed-off-by: liubingxing <liubbingxing@gmail.com>

fix the wrong fuse subtype from "cubes" to "cubefs"
![image](https://user-images.githubusercontent.com/2844826/199430795-310a9af8-3d37-40ef-b185-277bd55ef430.png)

