### PR TITLE
Fix: InodeCount is shown to be inconsistent in /admin/getCluster and /client/volStat

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -226,7 +226,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 	for _, name := range vols {
 		stat, ok := m.cluster.volStatInfo.Load(name)
 		if !ok {
-			cv.VolStatInfo = append(cv.VolStatInfo, newVolStatInfo(name, 0, 0, 0, 0))
+			cv.VolStatInfo = append(cv.VolStatInfo, newVolStatInfo(name, 0, 0, 0, 0, 0))
 			continue
 		}
 		cv.VolStatInfo = append(cv.VolStatInfo, stat.(*volStatInfo))

--- a/master/cluster_stat.go
+++ b/master/cluster_stat.go
@@ -29,7 +29,7 @@ type nodeStatInfo = proto.NodeStatInfo
 
 type volStatInfo = proto.VolStatInfo
 
-func newVolStatInfo(name string, total, used, cacheTotal, cacheUsed uint64) *volStatInfo {
+func newVolStatInfo(name string, total, used, cacheTotal, cacheUsed, inodeCount uint64) *volStatInfo {
 	usedRatio := strconv.FormatFloat(float64(used)/float64(total), 'f', 3, 32)
 	cacheUsedRatio := "0.00"
 	if cacheTotal > 0 {
@@ -44,6 +44,7 @@ func newVolStatInfo(name string, total, used, cacheTotal, cacheUsed uint64) *vol
 		CacheTotalSize: cacheTotal,
 		CacheUsedSize:  cacheUsed,
 		CacheUsedRatio: cacheUsedRatio,
+		InodeCount:     inodeCount,
 	}
 }
 
@@ -177,6 +178,11 @@ func (c *Cluster) updateVolStatInfo() {
 			cacheUsed, cacheTotal = 0, 0
 		}
 
-		c.volStatInfo.Store(vol.Name, newVolStatInfo(vol.Name, total, used, cacheTotal, cacheUsed))
+		var inodeCount uint64
+		for _, mp := range vol.MetaPartitions {
+			inodeCount += mp.InodeCount
+		}
+
+		c.volStatInfo.Store(vol.Name, newVolStatInfo(vol.Name, total, used, cacheTotal, cacheUsed, inodeCount))
 	}
 }

--- a/master/gapi_cluster.go
+++ b/master/gapi_cluster.go
@@ -631,7 +631,7 @@ func (m *ClusterService) makeClusterView() *proto.ClusterView {
 	for _, name := range vols {
 		stat, ok := m.cluster.volStatInfo.Load(name)
 		if !ok {
-			cv.VolStatInfo = append(cv.VolStatInfo, newVolStatInfo(name, 0, 0, 0, 0))
+			cv.VolStatInfo = append(cv.VolStatInfo, newVolStatInfo(name, 0, 0, 0, 0, 0))
 			continue
 		}
 		cv.VolStatInfo = append(cv.VolStatInfo, stat.(*volStatInfo))


### PR DESCRIPTION
Fix: InodeCount is shown to be inconsistent in /admin/getCluster and /client/volStat

Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
InodeCount is shown to be inconsistent in /admin/getCluster **(always 0)** and /client/volStat.

 /admin/getCluster:
<img width="235" alt="image" src="https://user-images.githubusercontent.com/55134131/199886275-c6246413-89d9-4035-8847-66d060bd22af.png">

/client/volStat:
<img width="269" alt="image" src="https://user-images.githubusercontent.com/55134131/199886213-3d31278a-7f9b-46cc-82ab-92875c05b11a.png">
