### PR TITLE
Enhancement: change the DentryCache sync.Mutex to sync.RWMutex

### DIFF
--- a/client/fs/dcache.go
+++ b/client/fs/dcache.go
@@ -21,7 +21,7 @@ import (
 
 // DentryCache defines the dentry cache.
 type DentryCache struct {
-	sync.Mutex
+	sync.RWMutex
 	cache      map[string]uint64
 	expiration time.Time
 }
@@ -51,8 +51,8 @@ func (dc *DentryCache) Get(name string) (uint64, bool) {
 		return 0, false
 	}
 
-	dc.Lock()
-	defer dc.Unlock()
+	dc.RLock()
+	defer dc.RUnlock()
 	if dc.expiration.Before(time.Now()) {
 		dc.cache = make(map[string]uint64)
 		return 0, false


### PR DESCRIPTION
Signed-off-by: liubingxing <liubbingxing@gmail.com>

Change the DentryCache sync.Mutex to sync.RWMutex to enhance the Concurrent call of DentryCache.Get()