### PR TITLE
Enhancement: Add more info for mp to facilitate trace

### DIFF
--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -121,6 +121,11 @@ func (m *MetaNode) getPartitionByIDHandler(w http.ResponseWriter, r *http.Reques
 	leader, _ := mp.IsLeader()
 	msg["leaderAddr"] = leader
 	conf := mp.GetBaseConfig()
+	msg["partition_id"] = conf.PartitionId
+	msg["partition_type"] = conf.PartitionType
+	msg["vol_name"] = conf.VolName
+	msg["start"] = conf.Start
+	msg["end"] = conf.End
 	msg["peers"] = conf.Peers
 	msg["nodeId"] = conf.NodeId
 	msg["cursor"] = conf.Cursor


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The interface `getPartitionById` should return more detail message to facilitate trace. Otherwise, after the mp is queried, `VolName`, `PartitionType` and the `Range` of the mp need to be queried through other interfaces.
 
After the change:
<img width="339" alt="mp-info-after" src="https://user-images.githubusercontent.com/55134131/199912348-33e5e541-174e-4792-8764-46d1666a38ed.png">


