### PR TITLE
Fix: metanode: reduce btree cow times and change copyGet in deleteWorker to Get

### DIFF
--- a/cli/cmd/compatibility.go
+++ b/cli/cmd/compatibility.go
@@ -127,7 +127,7 @@ func verifyDentry(client *api.MetaHttpClient, mp metanode.MetaPartition) (err er
 		return true
 	})
 	if err == nil {
-		stdout("The number of dentry is %v, all dentry are consistent \n", mp.GetDentryTree().Len())
+		stdout("The number of dentry is %v, all dentry are consistent \n", mp.GetDentryTreeLen())
 	}
 	return
 }
@@ -179,7 +179,7 @@ func verifyInode(client *api.MetaHttpClient, mp metanode.MetaPartition) (err err
 		return true
 	})
 	if err == nil {
-		stdout("The number of inodes is %v, all inodes are consistent \n", mp.GetInodeTree().Len())
+		stdout("The number of inodes is %v, all inodes are consistent \n", mp.GetInodeTreeLen())
 	}
 	return
 }

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -75,8 +75,8 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 				MaxInodeID:  mConf.Cursor,
 				VolName:     mConf.VolName,
 				Size:        partition.DataSize(),
-				InodeCnt:    uint64(partition.GetInodeTree().Len()),
-				DentryCnt:   uint64(partition.GetDentryTree().Len()),
+				InodeCnt:    uint64(partition.GetInodeTreeLen()),
+				DentryCnt:   uint64(partition.GetDentryTreeLen()),
 			}
 			addr, isLeader := partition.IsLeader()
 			if addr == "" {

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -45,14 +45,8 @@ func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
 		exporter.Vol: mp.config.VolName,
 	}
 
-	it := mp.GetInodeTree()
-	itDentry := mp.getDentryTree()
-	if it != nil {
-		exporter.NewGauge("mpInodeCount").SetWithLabels(float64(it.Len()), labels)
-	}
-	if itDentry != nil {
-		exporter.NewGauge("mpDentryCount").SetWithLabels(float64(itDentry.Len()), labels)
-	}
+	exporter.NewGauge("mpInodeCount").SetWithLabels(float64(mp.GetInodeTreeLen()), labels)
+	exporter.NewGauge("mpDentryCount").SetWithLabels(float64(mp.GetDentryTreeLen()), labels)
 }
 
 func (m *MetaNode) collectPartitionMetrics() {

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -124,6 +124,7 @@ type OpInode interface {
 	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
 	SetAttr(reqData []byte, p *Packet) (err error)
 	GetInodeTree() *BTree
+	GetInodeTreeLen() int
 	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
 	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
 	ClearInodeCache(req *proto.ClearInodeCacheRequest, p *Packet) (err error)
@@ -149,6 +150,7 @@ type OpDentry interface {
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
 	GetDentryTree() *BTree
+	GetDentryTreeLen() int
 }
 
 // OpExtent defines the interface for the extent operations.
@@ -726,8 +728,8 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 		DoCompare:   true,
 	}
 	resp.MaxInode = mp.GetCursor()
-	resp.InodeCount = uint64(mp.getInodeTree().Len())
-	resp.DentryCount = uint64(mp.getDentryTree().Len())
+	resp.InodeCount = uint64(mp.GetInodeTreeLen())
+	resp.DentryCount = uint64(mp.GetDentryTreeLen())
 	resp.ApplyID = mp.applyID
 	if err != nil {
 		err = errors.Trace(err,

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -146,7 +146,7 @@ func (mp *metaPartition) deleteWorker() {
 			}
 
 			//check inode nlink == 0 and deletMarkFlag unset
-			if inode, ok := mp.inodeTree.CopyGet(&Inode{Inode: ino}).(*Inode); ok {
+			if inode, ok := mp.inodeTree.Get(&Inode{Inode: ino}).(*Inode); ok {
 				if inode.ShouldDelayDelete() {
 					log.LogDebugf("[metaPartition] deleteWorker delay to remove inode: %v as NLink is 0", inode)
 					delayDeleteInos = append(delayDeleteInos, ino)
@@ -233,7 +233,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 	allInodes := make([]*Inode, 0)
 	for _, ino := range inoSlice {
 		ref := &Inode{Inode: ino}
-		inode, ok := mp.inodeTree.CopyGet(ref).(*Inode)
+		inode, ok := mp.inodeTree.Get(ref).(*Inode)
 		if !ok {
 			continue
 		}

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -170,8 +170,8 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		resp = mp.fsmSendToChan(msg.V)
 
 	case opFSMStoreTick:
-		inodeTree := mp.getInodeTree()
-		dentryTree := mp.getDentryTree()
+		inodeTree := mp.inodeTree.GetTree()
+		dentryTree := mp.dentryTree.GetTree()
 		extendTree := mp.extendTree.GetTree()
 		multipartTree := mp.multipartTree.GetTree()
 		msg := &storeMsg{

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -159,10 +159,6 @@ func (mp *metaPartition) fsmUpdateDentry(dentry *Dentry) (
 	return
 }
 
-func (mp *metaPartition) getDentryTree() *BTree {
-	return mp.dentryTree.GetTree()
-}
-
 func (mp *metaPartition) readDirOnly(req *ReadDirOnlyReq) (resp *ReadDirOnlyResp) {
 	resp = &ReadDirOnlyResp{}
 	begDentry := &Dentry{

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -102,10 +102,6 @@ func (mp *metaPartition) hasInode(ino *Inode) (ok bool) {
 	return
 }
 
-func (mp *metaPartition) getInodeTree() *BTree {
-	return mp.inodeTree.GetTree()
-}
-
 // Ascend is the wrapper of inodeTree.Ascend
 func (mp *metaPartition) Ascend(f func(i BtreeItem) bool) {
 	mp.inodeTree.Ascend(f)

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -239,3 +239,11 @@ func (mp *metaPartition) Lookup(req *LookupReq, p *Packet) (err error) {
 func (mp *metaPartition) GetDentryTree() *BTree {
 	return mp.dentryTree.GetTree()
 }
+
+// GetDentryTreeLen returns the dentry tree length.
+func (mp *metaPartition) GetDentryTreeLen() int {
+	if mp.dentryTree == nil {
+		return 0
+	}
+	return mp.dentryTree.Len()
+}

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -321,6 +321,14 @@ func (mp *metaPartition) GetInodeTree() *BTree {
 	return mp.inodeTree.GetTree()
 }
 
+// GetInodeTreeLen returns the inode tree length.
+func (mp *metaPartition) GetInodeTreeLen() int {
+	if mp.inodeTree == nil {
+		return 0
+	}
+	return mp.inodeTree.Len()
+}
+
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error) {
 	var bytes = make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, req.Inode)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. reduce btree copy when get btree length, this optimization can reduce copy on write times
2. get inode in deleteWorker is readonly, there is no need use CopyGet.  When bulk delete, CopyGet in deleteWork will lead to too many inodes COW. if snapshot is slow, these lazy to delete inodes will have 2 copies in memory, which may cause oom.  


![cubefs](https://user-images.githubusercontent.com/6017354/203056756-41cabd8c-74f7-47fb-a357-b42e9974afae.png)
