### PR TITLE
[BugFix] The datanode shutdown logic affected data partitions unable to elect the leader

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -438,8 +438,8 @@ func (dp *DataPartition) Stop() {
 			close(dp.stopC)
 		}
 		// Close the store and raftstore.
-		dp.extentStore.Close()
 		dp.stopRaft()
+		dp.extentStore.Close()
 		_ = dp.storeAppliedID(atomic.LoadUint64(&dp.appliedID))
 	})
 	return

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -71,6 +71,12 @@ func (manager *SpaceManager) Stop() {
 	wg := sync.WaitGroup{}
 	partitionC := make(chan *DataPartition, parallelism)
 	wg.Add(1)
+
+	// Close raft store.
+	for _, partition := range manager.partitions {
+		partition.stopRaft()
+	}
+
 	go func(c chan<- *DataPartition) {
 		defer wg.Done()
 		for _, partition := range manager.partitions {


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 In datanode doShutdown(), we stop extentStore before raftStore. But stopping extentStore will take a long time. This will delay triggering the data partitions to elect the leader, causing the client task to fail.
