### PR TITLE
[Enhancement] Optimize the qos for random write

### DIFF
--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -238,9 +238,6 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 		raftApplyID, dp.partitionID, opItem.extentID, opItem.offset, opItem.size)
 
 	for i := 0; i < 20; i++ {
-		dp.disk.allocCheckLimit(proto.FlowWriteType, uint32(opItem.size))
-		dp.disk.allocCheckLimit(proto.IopsWriteType, 1)
-
 		err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, storage.RandomWriteType, opItem.opcode == proto.OpSyncRandomWrite)
 		if err == nil {
 			break

--- a/datanode/wrap_prepare.go
+++ b/datanode/wrap_prepare.go
@@ -92,7 +92,7 @@ func (s *DataNode) checkPartition(p *repl.Packet) (err error) {
 			return
 		}
 	}
-	if p.IsWriteOperation() {
+	if p.IsWriteOperation() || p.IsRandomWrite() {
 		dp.disk.allocCheckLimit(proto.FlowWriteType, uint32(p.Size))
 		dp.disk.allocCheckLimit(proto.IopsWriteType, 1)
 	}


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

We advance the check of disk limiter to `checkPartition()` for random write, which can improve the efficiency of disk limiter. Also consistent with the logic of `sequential write`.

