### PR TITLE
[BugFix] Creating vol when the cluster is frozen should not check the dp number

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2434,6 +2434,11 @@ func (c *Cluster) checkZoneName(name string,
 // Create a new volume.
 // By default we create 3 meta partitions and 10 data partitions during initialization.
 func (c *Cluster) createVol(req *createVolReq) (vol *Vol, err error) {
+	if c.DisableAutoAllocate {
+		log.LogWarn("the cluster is frozen")
+		return nil, fmt.Errorf("the cluster is frozen, can not create volume")
+	}
+
 	var (
 		readWriteDataPartitions int
 	)


### PR DESCRIPTION

Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When we freeze the cluster, then create volume. There is an error `initDataPartition failed, less than 3`. However, the volume was created successfully. 
![image](https://user-images.githubusercontent.com/55134131/203580657-59ebed6d-db69-4525-ad42-0a5f8b9cab1d.png)

Because after freeze the cluster, `DisableAutoAllocate` would be set to true, and would not auto allocate dataPartitions for new volume. So the number of dataPartitions is 0. So we should not check the dp number in this scenario.

The related code:
```
func (c *Cluster) batchCreateDataPartition(vol *Vol, reqCount int) (err error) {
	for i := 0; i < reqCount; i++ {
		if c.DisableAutoAllocate { // After freeze the cluster, c.DisableAutoAllocate would be set to true
			log.LogWarn("disable auto allocate dataPartition")
			return fmt.Errorf("cluster is disable auto allocate dataPartition")
		}

		if _, err = c.createDataPartition(vol.Name, nil); err != nil {
			log.LogErrorf("action[batchCreateDataPartition] after create [%v] data partition,occurred error,err[%v]", i, err)
			break
		}
	}
	return
}
```

