### PR TITLE
[BugFix] update dp replicas after removing a raft node

### DIFF
--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -427,7 +427,14 @@ func (dp *DataPartition) removeRaftNode(req *proto.RemoveDataPartitionRaftMember
 		dp.Disk().space.DeletePartition(dp.partitionID)
 		isUpdated = false
 	}
-	log.LogInfof("Fininsh RemoveRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
+	// update dp replicas after removing a raft node
+	if isUpdated {
+		dp.replicasLock.Lock()
+		dp.replicas = make([]string, len(dp.config.Hosts))
+		copy(dp.replicas, dp.config.Hosts)
+		dp.replicasLock.Unlock()
+	}
+	log.LogInfof("Finish RemoveRaftNode  PartitionID(%v) nodeID(%v)  do RaftLog (%v) ",
 		req.PartitionId, dp.config.NodeID, string(data))
 
 	return


### PR DESCRIPTION
we test the cubefs by the following step:
1. delete one replica of a dp from the host(dn1)
    #cli del-replica dn1 info dp 
2. add the replica of this dp back to the host in step 1
   #cli add-replica dn1 info dp 
and found that the meta info of this dp lack of dn1.

The reason is that the dp.replicas was not updated after #removeRaftNode, and cause bad judgment in #handlePacketToAddDataPartitionRaftMember
<img width="833" alt="image" src="https://user-images.githubusercontent.com/2844826/203780654-571f4049-f053-4cb4-9c8d-320cf0c1a2a1.png">


