### PR TITLE
[BugFix] QosCtrlManager uses wrong type when update limit

### DIFF
--- a/master/limiter.go
+++ b/master/limiter.go
@@ -114,7 +114,7 @@ func (qosManager *QosCtrlManager) volUpdateLimit(limitArgs *qosArgs) {
 	//}
 	if limitArgs.flowWVal != 0 {
 		qosManager.serverFactorLimitMap[proto.FlowWriteType].Total = limitArgs.flowWVal
-		qosManager.serverFactorLimitMap[proto.IopsWriteType].LastMagnify = 0
+		qosManager.serverFactorLimitMap[proto.FlowWriteType].LastMagnify = 0
 		qosManager.serverFactorLimitMap[proto.FlowWriteType].Buffer = limitArgs.flowWVal
 	}
 	if limitArgs.flowRVal != 0 {


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
QosCtrlManager uses wrong type when update `LastMagnify` for flowWVal.