### PR TITLE
 [BugFix] dir inode.id can not be removed from follower freeList

### DIFF
--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -562,7 +562,7 @@ func (i *Inode) GetNLink() uint32 {
 
 func (i *Inode) IsTempFile() bool {
 	i.RLock()
-	ok := i.NLink == 0
+	ok := i.NLink == 0 && !proto.IsDir(i.Type)
 	i.RUnlock()
 	return ok
 }


### PR DESCRIPTION
Signed-off-by: liubingxing <liubbingxing@gmail.com>

Recently, we add the metrics for **freeList** and found that the length of freelist on the follower did not decrease when we deleted a dir.
The reason is that the leader may ignore the dir inode, not send **opFSMInternalDeleteInode** to follower which will remove the dir from the freelist.
![image](https://user-images.githubusercontent.com/2844826/206620733-d2330aeb-33bb-47f0-8924-372ae9293372.png)
As the freelist is used to delete the extent file async, the dir inode.id is no need to push into freelist.
