### PR TITLE
[Metric] Add connectionCnt metric for metanode

### DIFF
--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -19,6 +19,7 @@ import (
 	syslog "log"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	masterSDK "github.com/cubefs/cubefs/sdk/master"
@@ -65,6 +66,7 @@ type MetaNode struct {
 	metrics           *MetaNodeMetrics
 	tickInterval      int
 	raftRecvBufSize   int
+	connectionCnt     int64
 
 	control common.Control
 }
@@ -381,4 +383,14 @@ func NewServer() *MetaNode {
 func getClusterInfo() (ci *proto.ClusterInfo, err error) {
 	ci, err = masterClient.AdminAPI().GetClusterInfo()
 	return
+}
+
+// AddConnection adds a connection.
+func (m *MetaNode) AddConnection() {
+	atomic.AddInt64(&m.connectionCnt, 1)
+}
+
+// RemoveConnection removes a connection.
+func (m *MetaNode) RemoveConnection() {
+	atomic.AddInt64(&m.connectionCnt, -1)
 }

--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -65,6 +65,7 @@ func (m *MetaNode) collectPartitionMetrics() {
 				}
 				manager.mu.RUnlock()
 			}
+			exporter.NewGauge("connectionCnt").Set(float64(m.connectionCnt))
 		}
 	}
 }

--- a/metanode/server.go
+++ b/metanode/server.go
@@ -64,7 +64,11 @@ func (m *MetaNode) stopServer() {
 
 // Read data from the specified tcp connection until the connection is closed by the remote or the tcp service is down.
 func (m *MetaNode) serveConn(conn net.Conn, stopC chan uint8) {
-	defer conn.Close()
+	defer func() {
+		conn.Close()
+		m.RemoveConnection()
+	}()
+	m.AddConnection()
 	c := conn.(*net.TCPConn)
 	c.SetKeepAlive(true)
 	c.SetNoDelay(true)
@@ -139,7 +143,11 @@ func (m *MetaNode) stopSmuxServer() {
 }
 
 func (m *MetaNode) serveSmuxConn(conn net.Conn, stopC chan uint8) {
-	defer conn.Close()
+	defer func() {
+		conn.Close()
+		m.RemoveConnection()
+	}()
+	m.AddConnection()
 	c := conn.(*net.TCPConn)
 	c.SetKeepAlive(true)
 	c.SetNoDelay(true)


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add metric `connectionCnt` for metanode.

<img width="283" alt="image" src="https://user-images.githubusercontent.com/55134131/208918616-e1d736bd-2555-4ca0-91d6-2ae56797ae0d.png">
