### PR TITLE
BugFix: MaxMemAvailWeight overflow when metanode used mem larger than config.total mem

### DIFF
--- a/master/meta_node.go
+++ b/master/meta_node.go
@@ -125,7 +125,12 @@ func (metaNode *MetaNode) updateMetric(resp *proto.MetaNodeHeartbeatResponse, th
 	} else {
 		metaNode.Ratio = float64(resp.Used) / float64(resp.Total)
 	}
-	metaNode.MaxMemAvailWeight = resp.Total - resp.Used
+	left := int64(resp.Total - resp.Used)
+	if left < 0 {
+		metaNode.MaxMemAvailWeight = 0
+	} else {
+		metaNode.MaxMemAvailWeight = uint64(left)
+	}
 	metaNode.ZoneName = resp.ZoneName
 	metaNode.Threshold = threshold
 }


### PR DESCRIPTION
Signed-off-by: liubingxing <liubbingxing@gmail.com>

 MaxMemAvailWeight overflow when metanode used mem larger than config.total mem
<img width="446" alt="image" src="https://user-images.githubusercontent.com/2844826/209500037-4e63d4e2-298d-4c9e-a253-b243d3ac5704.png">

