### PR TITLE
[Enhancemant] Demand write nodes should be calculated based on zone number and replica number

### DIFF
--- a/master/topology.go
+++ b/master/topology.go
@@ -1071,12 +1071,10 @@ func (t *topology) getZoneByIndex(index int) (zone *Zone) {
 func calculateDemandWriteNodes(zoneNum int, replicaNum int) (demandWriteNodes int) {
 	if zoneNum == 1 {
 		demandWriteNodes = replicaNum
+	} else if zoneNum >= replicaNum {
+		demandWriteNodes = 1
 	} else {
-		if replicaNum == 1 {
-			demandWriteNodes = 1
-		} else {
-			demandWriteNodes = 2
-		}
+		demandWriteNodes = 2
 	}
 	return
 }


### PR DESCRIPTION

Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Demand write nodes should be calculated based on zone number and replica number.  For example, if the number of zones is greater than the number of replicas, the number of demand write nodes is 1 will be ok.  Currently, a volume(`crosszone=true`) cannot be created when there is only one metanode in each zone.



