### PR TITLE
[Enhancement] speed up metanode startup

### DIFF
--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -562,19 +562,33 @@ func (mp *metaPartition) load() (err error) {
 		return
 	}
 	snapshotPath := path.Join(mp.config.RootDir, snapshotDir)
-	if err = mp.loadInode(snapshotPath); err != nil {
-		return
+	var loadFuncs = []func(rootDir string) error{
+		mp.loadInode,
+		mp.loadDentry,
+		mp.loadExtend,
+		mp.loadMultipart,
+		mp.loadApplyID,
 	}
-	if err = mp.loadDentry(snapshotPath); err != nil {
-		return
+
+	errs := make([]error, 0)
+	var mutex sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(len(loadFuncs))
+	for _, f := range loadFuncs {
+		loadFunc := f
+		go func() {
+			defer wg.Done()
+			if e := loadFunc(snapshotPath); e != nil {
+				mutex.Lock()
+				errs = append(errs, e)
+				mutex.Unlock()
+			}
+		}()
 	}
-	if err = mp.loadExtend(snapshotPath); err != nil {
-		return
+	wg.Wait()
+	if len(errs) > 0 {
+		err = errs[0]
 	}
-	if err = mp.loadMultipart(snapshotPath); err != nil {
-		return
-	}
-	err = mp.loadApplyID(snapshotPath)
 	return
 }
 

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -37,10 +37,9 @@ func NewDentryResponse() *DentryResponse {
 func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 	forceUpdate bool) (status uint8) {
 	status = proto.OpOk
-	item := mp.inodeTree.CopyGet(NewInode(dentry.ParentId, 0))
-	log.LogInfof("action[fsmCreateDentry] ParentId [%v] get nil, dentry name [%v], inode [%v]", dentry.ParentId, dentry.Name, dentry.Inode)
 	var parIno *Inode
 	if !forceUpdate {
+		item := mp.inodeTree.CopyGet(NewInode(dentry.ParentId, 0))
 		if item == nil {
 			log.LogErrorf("action[fsmCreateDentry] ParentId [%v] get nil, dentry name [%v], inode [%v]", dentry.ParentId, dentry.Name, dentry.Inode)
 			status = proto.OpNotExistErr


### PR DESCRIPTION
Signed-off-by: liubingxing <liubbingxing@gmail.com>

As the number of files in the cluster increases, it takes longer to roll upgrade metanodes. 
During metanode startup, most the time is spent loading the snapshot files. 
1、Currently cubefs loads snapshot files in serial, we can change it to parallel loading, because there is no dependency to load these files.
2、In **fsmCreateDentry** function,  it is no need to call **mp.inodeTree.CopyGet** when the parameter **forceUpdate** is true.

We tested a metanode with 160 million inodes and dentries and the startup time changed from 15 minutes to 5 minutes.
