### PR TITLE
chore(docs): ignore cfs ci when matching those paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,19 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-        - 'blobstore/**'
+      - 'blobstore/**'
+      - '.github/**'
+      - 'docs/**'
+      - 'docs-zh/**'
+      - '**.md'
   pull_request:
     branches: [ master ]
     paths-ignore:
-        # - 'blobstore/**'
+      # - 'blobstore/**'
+      - '.github/**'
+      - 'docs/**'
+      - 'docs-zh/**'
+      - '**.md'
 
 jobs:
 


### PR DESCRIPTION
    paths-ignore:
      - '.github/**'
      - 'docs/**'
      - 'docs-zh/**'
      - '**.md'

Signed-off-by: slasher <shenjie1@oppo.com>

