### PR TITLE
[Enhancemant] Support fuse request timeout, add client metrics

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -447,7 +447,7 @@ func main() {
 		}
 	}
 
-	if err = fs.Serve(fsConn, super); err != nil {
+	if err = fs.Serve(fsConn, super, opt); err != nil {
 		log.LogFlush()
 		syslog.Printf("fs Serve returns err(%v)", err)
 		os.Exit(1)
@@ -625,7 +625,8 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 		fuse.FSName("cubefs-" + opt.Volname),
 		fuse.Subtype("cubefs"),
 		fuse.LocalVolume(),
-		fuse.VolumeName("cubefs-" + opt.Volname)}
+		fuse.VolumeName("cubefs-" + opt.Volname),
+		fuse.RequestTimeout(opt.RequestTimeout)}
 
 	if opt.Rdonly {
 		options = append(options, fuse.ReadOnly())
@@ -730,6 +731,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.MetaSendTimeout = GlobalMountOptions[proto.MetaSendTimeout].GetInt64()
 	opt.MaxStreamerLimit = GlobalMountOptions[proto.MaxStreamerLimit].GetInt64()
 	opt.EnableAudit = GlobalMountOptions[proto.EnableAudit].GetBool()
+	opt.RequestTimeout = GlobalMountOptions[proto.RequestTimeout].GetInt64()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/depends/bazil.org/fuse/examples/clockfs/clockfs.go
+++ b/depends/bazil.org/fuse/examples/clockfs/clockfs.go
@@ -55,7 +55,7 @@ func run(mountpoint string) error {
 	filesys.clockFile.tick()
 	// This goroutine never exits. That's fine for this example.
 	go filesys.clockFile.update()
-	if err := srv.Serve(filesys); err != nil {
+	if err := srv.Serve(filesys, nil); err != nil {
 		return err
 	}
 

--- a/depends/bazil.org/fuse/examples/hellofs/hello.go
+++ b/depends/bazil.org/fuse/examples/hellofs/hello.go
@@ -41,7 +41,7 @@ func main() {
 	}
 	defer c.Close()
 
-	err = fs.Serve(c, FS{})
+	err = fs.Serve(c, FS{}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/depends/bazil.org/fuse/fs/fstestutil/mounted.go
+++ b/depends/bazil.org/fuse/fs/fstestutil/mounted.go
@@ -80,7 +80,7 @@ func MountedFunc(fn func(*Mount) fs.FS, conf *fs.Config, options ...fuse.MountOp
 	filesys := fn(mnt)
 	go func() {
 		defer close(done)
-		serveErr <- server.Serve(filesys)
+		serveErr <- server.Serve(filesys, nil)
 	}()
 
 	select {

--- a/depends/bazil.org/fuse/options.go
+++ b/depends/bazil.org/fuse/options.go
@@ -16,6 +16,7 @@ type mountConfig struct {
 	maxReadahead     uint32
 	initFlags        InitFlags
 	osxfuseLocations []OSXFUSEPaths
+	RequestTimeout   int64
 }
 
 func escapeComma(s string) string {
@@ -325,6 +326,14 @@ func AllowNonEmptyMount() MountOption {
 func PosixACL() MountOption {
 	return func(conf *mountConfig) error {
 		conf.initFlags |= InitPOSIXACL
+		return nil
+	}
+}
+
+// RequestTimeout set request timeout.
+func RequestTimeout(timeout int64) MountOption {
+	return func(conf *mountConfig) error {
+		conf.RequestTimeout = timeout
 		return nil
 	}
 }

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -48,6 +48,7 @@ const (
 	EnablePosixACL
 	EnableSummary
 	EnableUnixPermission
+	RequestTimeout
 
 	//adls
 	VolType
@@ -153,6 +154,7 @@ func InitMountOptions(opts []MountOption) {
 	opts[BcacheBatchCnt] = MountOption{"bcacheBatchCnt", "The block cache get meta count", "", int64(100000)}
 	opts[BcacheCheckIntervalS] = MountOption{"bcacheCheckIntervalS", "The block cache check interval", "", int64(300)}
 	opts[EnableAudit] = MountOption{"enableAudit", "enable client audit logging", "", false}
+	opts[RequestTimeout] = MountOption{"requestTimeout", "The Request Expiration Time", "", int64(0)}
 
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
@@ -302,4 +304,5 @@ type MountOptions struct {
 	BuffersTotalLimit    int64
 	MaxStreamerLimit     int64
 	EnableAudit          bool
+	RequestTimeout       int64
 }


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
A fuse client can hang due to a server exception or hardware failure. We have implemented a timeout mechanism for fuse clients, which is not enabled by default but is enabled by configuring `requestTimeout`. Currently, this feature works well in our cluster.

