### PR TITLE
[Feature] Decommission datapartitions, disks and datanodes automatically

### DIFF
--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -367,6 +367,7 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 	response.MaxCapacity = stat.MaxCapacityToCreatePartition
 	response.RemainingCapacity = stat.RemainingCapacityToCreatePartition
 	response.BadDisks = make([]string, 0)
+	response.LackDataPartitions = make([]uint64, 0)
 	response.StartTime = s.startTime
 	stat.Unlock()
 
@@ -397,4 +398,10 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 			response.BadDisks = append(response.BadDisks, d.Path)
 		}
 	}
+
+	lackPartitions, err := s.checkLocalPartitionMatchWithMaster()
+	if err != nil {
+		log.LogWarn(err)
+	}
+	response.LackDataPartitions = lackPartitions
 }

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -404,4 +404,6 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 		log.LogWarn(err)
 	}
 	response.LackDataPartitions = lackPartitions
+	response.DiskCount = len(disks)
+	log.LogInfof("#TESTLOG decommissionDisk DiskCount [%v], DiskLen", response.DiskCount, len(disks))
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -121,6 +121,22 @@ func (m *Server) setupAutoAllocation(w http.ResponseWriter, r *http.Request) {
 	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf("set DisableAutoAllocate to %v successfully", status)))
 }
 
+func (m *Server) setupAutoDecommission(w http.ResponseWriter, r *http.Request) {
+	var (
+		status bool
+		err    error
+	)
+	if status, err = parseAndExtractStatus(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	if err = m.cluster.setAutoDecommission(status); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf("set AutoDecommission to %v successfully", status)))
+}
+
 // View the topology of the cluster.
 func (m *Server) getTopology(w http.ResponseWriter, r *http.Request) {
 	tv := &TopologyView{

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -3316,3 +3316,13 @@ func (m *Server) associateVolWithUser(userID, volName string) error {
 
 	return nil
 }
+
+func (m *Server) getAllDecommissionDataNodes(w http.ResponseWriter, r *http.Request) {
+	dataNodes := m.cluster.allDecommissionDataNodes()
+	sendOkReply(w, r, newSuccessHTTPReply(dataNodes))
+}
+
+func (m *Server) getAllDecommissionDisks(w http.ResponseWriter, r *http.Request) {
+	dataNodes := m.cluster.allDecommissionDisks()
+	sendOkReply(w, r, newSuccessHTTPReply(dataNodes))
+}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -67,6 +67,7 @@ type Cluster struct {
 	diskQosEnable       bool
 	QosAcceptLimit      *rate.Limiter
 	AutoDecommission    bool
+	diskCount           int
 }
 
 type followerReadManager struct {
@@ -510,8 +511,8 @@ func (c *Cluster) scheduleToDecommission() {
 					log.LogDebugf("auto decommission is disabled")
 					continue
 				}
-				if c.BadDPCount > c.cfg.DecommissionDpLimit {
-					log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v", c.cfg.DecommissionDpLimit)
+				if c.BadDPCount > uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor) {
+					log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v", uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor)
 					continue
 				}
 				c.decommissionDatanodes()
@@ -538,8 +539,8 @@ func (c *Cluster) decommissionDatanodes() {
 			log.LogDebugf("datanode: [%v] is decommissioning", dataNode.Addr)
 			return true
 		}
-		if c.BadDPCount > c.cfg.DecommissionDpLimit {
-			log.LogInfof("the number of decommissioning dataPartitions are exceeds %v", c.cfg.DecommissionDpLimit)
+		if c.BadDPCount > uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor) {
+			log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v", float64(c.diskCount)*c.cfg.DecommissionDpFactor)
 			return true
 		}
 		if dataNode.isStale && !dataNode.ToBeOffline {
@@ -572,8 +573,8 @@ func (c *Cluster) decommissionDisks() {
 		}
 
 		for _, badDisk := range dataNode.BadDisks {
-			if c.BadDPCount > c.cfg.DecommissionDpLimit {
-				log.LogInfof("the number of decommissioning dataPartitions are exceeds %v", c.cfg.DecommissionDpLimit)
+			if c.BadDPCount > uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor) {
+				log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v", float64(c.diskCount)*c.cfg.DecommissionDpFactor)
 				return true
 			}
 			var (
@@ -624,8 +625,8 @@ func (c *Cluster) decommissionDataPartitions() {
 		}
 
 		for _, lackDataPartition := range dataNode.LackDataPartitions {
-			if c.BadDPCount > c.cfg.DecommissionDpLimit {
-				log.LogInfof("the number of decommissioning dataPartitions are exceeds %v", c.cfg.DecommissionDpLimit)
+			if c.BadDPCount > uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor) {
+				log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v", float64(c.diskCount)*c.cfg.DecommissionDpFactor)
 				return true
 			}
 			dp, err := c.getDataPartitionByID(lackDataPartition)

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -512,7 +512,8 @@ func (c *Cluster) scheduleToDecommission() {
 					continue
 				}
 				if c.BadDPCount > uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor) {
-					log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v", uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor)
+					log.LogDebugf("the number of decommissioning dataPartitions are exceeds %v",
+						uint64(float64(c.diskCount)*c.cfg.DecommissionDpFactor))
 					continue
 				}
 				c.decommissionDatanodes()

--- a/master/config.go
+++ b/master/config.go
@@ -55,7 +55,7 @@ const (
 	defaultIntervalToCheckCrc                  = 20 * defaultIntervalToCheck // in terms of seconds
 	noHeartBeatTimes                           = 3                           // number of times that no heartbeat reported
 	defaultNodeTimeOutSec                      = noHeartBeatTimes * defaultIntervalToCheckHeartbeat
-	defaultNodeStaleSec                        = 60 * 60 * 3
+	defaultNodeStaleSec                        = 60 * 10
 	defaultDataPartitionTimeOutSec             = 5 * defaultIntervalToCheckHeartbeat
 	defaultMissingDataPartitionInterval        = 24 * 3600
 
@@ -75,7 +75,6 @@ const (
 	defaultDiffSpaceUsage                              = 1024 * 1024 * 1024
 	defaultNodeSetGrpStep                              = 1
 	defaultMasterMinQosAccept                          = 20000
-	defaultDecommissionDnLimit                         = 1
 	defaultDecommissionDpLimit                         = 100
 )
 

--- a/master/config.go
+++ b/master/config.go
@@ -113,7 +113,6 @@ type clusterConfig struct {
 	DomainBuildAsPossible               bool
 	DataPartitionUsageThreshold         float64
 	QosMasterAcceptLimit                uint64
-	DecommissionDnLimit                 int64
 	DecommissionDpLimit                 uint64
 }
 

--- a/master/config.go
+++ b/master/config.go
@@ -75,6 +75,8 @@ const (
 	defaultDiffSpaceUsage                              = 1024 * 1024 * 1024
 	defaultNodeSetGrpStep                              = 1
 	defaultMasterMinQosAccept                          = 20000
+	defaultDecommissionDnLimit                         = 1
+	defaultDecommissionDpLimit                         = 100
 )
 
 // AddrDatabase is a map that stores the address of a given host (e.g., the leader)
@@ -111,6 +113,8 @@ type clusterConfig struct {
 	DomainBuildAsPossible               bool
 	DataPartitionUsageThreshold         float64
 	QosMasterAcceptLimit                uint64
+	DecommissionDnLimit                 int64
+	DecommissionDpLimit                 uint64
 }
 
 func newClusterConfig() (cfg *clusterConfig) {

--- a/master/config.go
+++ b/master/config.go
@@ -75,7 +75,7 @@ const (
 	defaultDiffSpaceUsage                              = 1024 * 1024 * 1024
 	defaultNodeSetGrpStep                              = 1
 	defaultMasterMinQosAccept                          = 20000
-	defaultDecommissionDpLimit                         = 100
+	defaultDecommissionDpFactor                        = 2
 )
 
 // AddrDatabase is a map that stores the address of a given host (e.g., the leader)
@@ -112,7 +112,7 @@ type clusterConfig struct {
 	DomainBuildAsPossible               bool
 	DataPartitionUsageThreshold         float64
 	QosMasterAcceptLimit                uint64
-	DecommissionDpLimit                 uint64
+	DecommissionDpFactor                float64
 }
 
 func newClusterConfig() (cfg *clusterConfig) {

--- a/master/config.go
+++ b/master/config.go
@@ -55,6 +55,7 @@ const (
 	defaultIntervalToCheckCrc                  = 20 * defaultIntervalToCheck // in terms of seconds
 	noHeartBeatTimes                           = 3                           // number of times that no heartbeat reported
 	defaultNodeTimeOutSec                      = noHeartBeatTimes * defaultIntervalToCheckHeartbeat
+	defaultNodeStaleSec                        = 10 * 60
 	defaultDataPartitionTimeOutSec             = 5 * defaultIntervalToCheckHeartbeat
 	defaultMissingDataPartitionInterval        = 24 * 3600
 
@@ -82,6 +83,7 @@ var AddrDatabase = make(map[uint64]string)
 type clusterConfig struct {
 	secondsToFreeDataPartitionAfterLoad int64
 	NodeTimeOutSec                      int64
+	NodeStaleSec                        int64
 	MissingDataPartitionInterval        int64
 	DataPartitionTimeOutSec             int64
 	IntervalToAlarmMissingDataPartition int64

--- a/master/config.go
+++ b/master/config.go
@@ -55,7 +55,7 @@ const (
 	defaultIntervalToCheckCrc                  = 20 * defaultIntervalToCheck // in terms of seconds
 	noHeartBeatTimes                           = 3                           // number of times that no heartbeat reported
 	defaultNodeTimeOutSec                      = noHeartBeatTimes * defaultIntervalToCheckHeartbeat
-	defaultNodeStaleSec                        = 10 * 60
+	defaultNodeStaleSec                        = 60 * 60 * 3
 	defaultDataPartitionTimeOutSec             = 5 * defaultIntervalToCheckHeartbeat
 	defaultMissingDataPartitionInterval        = 24 * 3600
 

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -48,6 +48,7 @@ type DataNode struct {
 	TotalPartitionSize        uint64
 	NodeSetID                 uint64
 	PersistenceDataPartitions []uint64
+	LackDataPartitions        []uint64
 	BadDisks                  []string
 	DecommissionedDisks       sync.Map
 	ToBeOffline               bool
@@ -115,6 +116,7 @@ func (dataNode *DataNode) updateNodeMetric(resp *proto.DataNodeHeartbeatResponse
 	dataNode.DataPartitionCount = resp.CreatedPartitionCnt
 	dataNode.DataPartitionReports = resp.PartitionReports
 	dataNode.TotalPartitionSize = resp.TotalPartitionSize
+	dataNode.LackDataPartitions = resp.LackDataPartitions
 	dataNode.BadDisks = resp.BadDisks
 	dataNode.StartTime = resp.StartTime
 	if dataNode.Total == 0 {

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -58,6 +58,7 @@ type DataNode struct {
 	QosIopsWLimit             uint64
 	QosFlowRLimit             uint64
 	QosFlowWLimit             uint64
+	DiskCount                 int
 }
 
 func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
@@ -126,6 +127,8 @@ func (dataNode *DataNode) updateNodeMetric(resp *proto.DataNodeHeartbeatResponse
 	}
 	dataNode.ReportTime = time.Now()
 	dataNode.isActive = true
+	dataNode.DiskCount = resp.DiskCount
+	log.LogInfof("#TESTLOG decommissionDisk dataNode [%v], diskCount [%v]", dataNode.Addr, dataNode.DiskCount)
 }
 
 func (dataNode *DataNode) canAlloc() bool {

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -37,6 +37,7 @@ type DataNode struct {
 	StartTime                 int64
 	LastUpdateTime            time.Time
 	isActive                  bool
+	isStale                   bool
 	sync.RWMutex              `graphql:"-"`
 	UsageRatio                float64           // used / total space
 	SelectedTimes             uint64            // number times that this datanode has been selected as the location for a data partition.
@@ -69,7 +70,7 @@ func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
 	return
 }
 
-func (dataNode *DataNode) checkLiveness() {
+func (dataNode *DataNode) checkLiveness(c *Cluster) {
 	dataNode.Lock()
 	defer dataNode.Unlock()
 	log.LogInfof("action[checkLiveness] datanode[%v] report time[%v],since report time[%v], need gap [%v]",
@@ -77,7 +78,13 @@ func (dataNode *DataNode) checkLiveness() {
 	if time.Since(dataNode.ReportTime) > time.Second*time.Duration(defaultNodeTimeOutSec) {
 		dataNode.isActive = false
 	}
-
+	if time.Since(dataNode.ReportTime) > time.Second*time.Duration(c.cfg.NodeStaleSec) {
+		dataNode.isStale = true
+		log.LogInfof("action[checkLiveness] datanode[%v] is stale, report time[%v]", dataNode.Addr, dataNode.ReportTime)
+	} else if dataNode.isStale {
+		dataNode.isStale = false
+		log.LogInfof("action[checkLiveness] datanode[%v] is recover, report time[%v]", dataNode.Addr, dataNode.ReportTime)
+	}
 	return
 }
 

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -123,6 +123,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 		Path(proto.AdminClusterFreeze).
 		HandlerFunc(m.setupAutoAllocation)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminAutoDecommission).
+		HandlerFunc(m.setupAutoDecommission)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AddRaftNode).
 		HandlerFunc(m.addRaftNode)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -347,6 +347,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminSetDpRdOnly).
 		HandlerFunc(m.setDpRdOnlyHandler)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.ReportLackDataPartitions).
+		HandlerFunc(m.reportLackDataPartitions)
 
 	// user management APIs
 	router.NewRoute().Methods(http.MethodPost).

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -134,7 +134,15 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.RaftStatus).
 		HandlerFunc(m.getRaftStatus)
-	router.NewRoute().Methods(http.MethodGet).Path(proto.AdminClusterStat).HandlerFunc(m.clusterStat)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminClusterStat).
+		HandlerFunc(m.clusterStat)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminGetDecommissionDatanodes).
+		HandlerFunc(m.getAllDecommissionDataNodes)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminGetDecommissionDisks).
+		HandlerFunc(m.getAllDecommissionDisks)
 
 	// volume management APIs
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -45,6 +45,7 @@ type clusterValue struct {
 	FaultDomain                 bool
 	DiskQosEnable               bool
 	QosLimitUpload              uint64
+	AutoDecommission            bool
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -61,6 +62,7 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		FaultDomain:                 c.FaultDomain,
 		DiskQosEnable:               c.diskQosEnable,
 		QosLimitUpload:              uint64(c.QosAcceptLimit.Limit()),
+		AutoDecommission:            c.AutoDecommission,
 	}
 	return cv
 }
@@ -694,6 +696,7 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.DisableAutoAllocate = cv.DisableAutoAllocate
 		c.diskQosEnable = cv.DiskQosEnable
 		c.cfg.QosMasterAcceptLimit = cv.QosLimitUpload
+		c.AutoDecommission = cv.AutoDecommission
 
 		if c.cfg.QosMasterAcceptLimit < QosMasterAcceptCnt {
 			c.cfg.QosMasterAcceptLimit = QosMasterAcceptCnt

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -219,6 +219,7 @@ func (mm *monitorMetrics) setBadPartitionMetrics() {
 		return true
 	})
 	mm.badMpCount.SetWithLabels(float64(badMpCount), map[string]string{"type": "bad_mp"})
+	mm.cluster.BadMPCount = badMpCount
 
 	badDpCount := uint64(0)
 	mm.cluster.BadDataPartitionIds.Range(func(key, value interface{}) bool {
@@ -226,6 +227,7 @@ func (mm *monitorMetrics) setBadPartitionMetrics() {
 		return true
 	})
 	mm.badDpCount.SetWithLabels(float64(badDpCount), map[string]string{"type": "bad_dp"})
+	mm.cluster.BadDPCount = badDpCount
 }
 
 func (mm *monitorMetrics) deleteVolMetric(volName string) {

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -219,7 +219,6 @@ func (mm *monitorMetrics) setBadPartitionMetrics() {
 		return true
 	})
 	mm.badMpCount.SetWithLabels(float64(badMpCount), map[string]string{"type": "bad_mp"})
-	mm.cluster.BadMPCount = badMpCount
 
 	badDpCount := uint64(0)
 	mm.cluster.BadDataPartitionIds.Range(func(key, value interface{}) bool {

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -344,7 +344,6 @@ func (mm *monitorMetrics) setToBeOfflineDataNodesCount() {
 		return true
 	})
 	mm.dataNodesToBeOffline.Set(float64(toBeOfflineDataNodesCount))
-	mm.cluster.dataNodesToBeOffline = toBeOfflineDataNodesCount
 }
 
 func (mm *monitorMetrics) clearVolMetrics() {

--- a/master/server.go
+++ b/master/server.go
@@ -301,6 +301,12 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 	if m.config.NodeStaleSec < defaultNodeStaleSec {
 		m.config.NodeStaleSec = defaultNodeStaleSec
 	}
+	if m.config.DecommissionDnLimit < defaultDecommissionDnLimit {
+		m.config.DecommissionDnLimit = defaultDecommissionDnLimit
+	}
+	if m.config.DecommissionDpLimit < defaultDecommissionDpLimit {
+		m.config.DecommissionDpLimit = defaultDecommissionDpLimit
+	}
 	return
 }
 

--- a/master/server.go
+++ b/master/server.go
@@ -298,6 +298,9 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 	if m.electionTick <= 3 {
 		m.electionTick = 5
 	}
+	if m.config.NodeStaleSec < defaultNodeStaleSec {
+		m.config.NodeStaleSec = defaultNodeStaleSec
+	}
 	return
 }
 

--- a/master/server.go
+++ b/master/server.go
@@ -301,9 +301,6 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 	if m.config.NodeStaleSec < defaultNodeStaleSec {
 		m.config.NodeStaleSec = defaultNodeStaleSec
 	}
-	if m.config.DecommissionDnLimit < defaultDecommissionDnLimit {
-		m.config.DecommissionDnLimit = defaultDecommissionDnLimit
-	}
 	if m.config.DecommissionDpLimit < defaultDecommissionDpLimit {
 		m.config.DecommissionDpLimit = defaultDecommissionDpLimit
 	}

--- a/master/server.go
+++ b/master/server.go
@@ -301,8 +301,8 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 	if m.config.NodeStaleSec < defaultNodeStaleSec {
 		m.config.NodeStaleSec = defaultNodeStaleSec
 	}
-	if m.config.DecommissionDpLimit < defaultDecommissionDpLimit {
-		m.config.DecommissionDpLimit = defaultDecommissionDpLimit
+	if m.config.DecommissionDpFactor < defaultDecommissionDpFactor {
+		m.config.DecommissionDpFactor = defaultDecommissionDpFactor
 	}
 	return
 }

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -339,6 +339,7 @@ type DataNodeHeartbeatResponse struct {
 	Result              string
 	BadDisks            []string
 	LackDataPartitions  []uint64
+	DiskCount           int
 }
 
 // MetaPartitionReport defines the meta partition report.

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -53,6 +53,9 @@ const (
 	AdminSetNodeRdOnly              = "/admin/setNodeRdOnly"
 	AdminSetDpRdOnly                = "/admin/setDpRdOnly"
 	AdminDataPartitionChangeLeader  = "/dataPartition/changeleader"
+	AdminGetDecommissionDatanodes   = "/admin/getDecommissionDatanodes"
+	AdminGetDecommissionDisks       = "/admin/getDecommissionDisks"
+
 	//graphql master api
 	AdminClusterAPI = "/api/cluster"
 	AdminUserAPI    = "/api/user"

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -327,6 +327,7 @@ type DataNodeHeartbeatResponse struct {
 	Status              uint8
 	Result              string
 	BadDisks            []string
+	LackDataPartitions  []uint64
 }
 
 // MetaPartitionReport defines the meta partition report.

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -94,6 +94,7 @@ const (
 	DecommissionDataNode           = "/dataNode/decommission"
 	MigrateDataNode                = "/dataNode/migrate"
 	CancelDecommissionDataNode     = "/dataNode/cancelDecommission"
+	ReportLackDataPartitions       = "/dataNode/reportLackDataPartitions"
 	DecommissionDisk               = "/disk/decommission"
 	RecommissionDisk               = "/disk/recommission"
 	GetDataNode                    = "/dataNode/get"
@@ -302,6 +303,12 @@ type PartitionReport struct {
 	IsLeader        bool
 	ExtentCount     int
 	NeedCompare     bool
+}
+
+// LackPartitionReport defines the lack partitions report.
+type LackPartitionReport struct {
+	Addr           string
+	LackPartitions []uint64
 }
 
 type DataNodeQosResponse struct {

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -35,6 +35,7 @@ const (
 	AdminCreateVol                  = "/admin/createVol"
 	AdminGetVol                     = "/admin/getVol"
 	AdminClusterFreeze              = "/cluster/freeze"
+	AdminAutoDecommission           = "/cluster/autoDecommission"
 	AdminClusterStat                = "/cluster/stat"
 	AdminGetIP                      = "/admin/getIp"
 	AdminCreateMetaPartition        = "/metaPartition/create"

--- a/proto/model.go
+++ b/proto/model.go
@@ -146,6 +146,11 @@ type BadPartitionView struct {
 	PartitionIDs []uint64
 }
 
+type DecommissionDiskView struct {
+	Addr              string
+	DecommissionDisks []string
+}
+
 type ClusterStatInfo struct {
 	DataNodeStatInfo *NodeStatInfo
 	MetaNodeStatInfo *NodeStatInfo

--- a/sdk/master/api_node.go
+++ b/sdk/master/api_node.go
@@ -150,3 +150,16 @@ func (api *NodeAPI) DataNodeMigrate(srcAddr, targetAddr string, count int) (err 
 	}
 	return
 }
+
+func (api *NodeAPI) ReportLackPartitions(report *proto.LackPartitionReport) (err error) {
+	var encoded []byte
+	if encoded, err = json.Marshal(report); err != nil {
+		return
+	}
+	var request = newAPIRequest(http.MethodPost, proto.ReportLackDataPartitions)
+	request.addBody(encoded)
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}


### PR DESCRIPTION
Signed-off-by: Tao Li <tomscut@apache.org>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Decommission datapartitions, disks and datanodes automatically.

1. This feature is disabled by default, we can enable it by API `/cluster/autoDecommission`. 
2. Automatically decommission the datanodes in stale state. A datanode in stale state typically has no heartbeat for more than a certain amount of time.
3. Automatically decommission baddisks. 
4. Automatically decommission lackPartitions. 
5. Provides APIs `/admin/getDecommissionDatanodes` and `/admin/getDecommissionDisks` to query datanodes and disks are decommissioning or decommissioned.
