### PR TITLE
[Feature] add file statistics function

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -4213,3 +4213,30 @@ func (m *Server) setCheckDataReplicasEnable(w http.ResponseWriter, r *http.Reque
 	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf(
 		"set checkDataReplicasEnable to [%v] successfully", enable)))
 }
+
+func (m *Server) setFileStats(w http.ResponseWriter, r *http.Request) {
+	var (
+		err    error
+		enable bool
+	)
+	if enable, err = parseAndExtractStatus(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	oldValue := m.cluster.fileStatsEnable
+	m.cluster.fileStatsEnable = enable
+	if err = m.cluster.syncPutCluster(); err != nil {
+		m.cluster.fileStatsEnable = oldValue
+		log.LogErrorf("action[setFileStats] syncPutCluster failed %v", err)
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrPersistenceByRaft))
+		return
+	}
+	log.LogInfof("action[setFileStats] enable be set [%v]", enable)
+	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf(
+		"set setFileStats to [%v] successfully", enable)))
+}
+
+func (m *Server) getFileStats(w http.ResponseWriter, r *http.Request) {
+	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf(
+		"getFileStats enable value [%v]", m.cluster.fileStatsEnable)))
+}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -75,6 +75,7 @@ type Cluster struct {
 	checkAutoCreateDataPartition bool
 	masterClient                 *masterSDK.MasterClient
 	checkDataReplicasEnable      bool
+	fileStatsEnable              bool
 }
 
 type followerReadManager struct {
@@ -503,7 +504,7 @@ func (c *Cluster) checkMetaNodeHeartbeat() {
 	c.metaNodes.Range(func(addr, metaNode interface{}) bool {
 		node := metaNode.(*MetaNode)
 		node.checkHeartbeat()
-		task := node.createHeartbeatTask(c.masterAddr())
+		task := node.createHeartbeatTask(c.masterAddr(), c.fileStatsEnable)
 		hbReq := task.Request.(*proto.HeartBeatRequest)
 		for _, vol := range c.vols {
 			if vol.FollowerRead {

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -189,6 +189,12 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminQueryDecommissionToken).
 		HandlerFunc(m.queryDecommissionToken)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminSetFileStats).
+		HandlerFunc(m.setFileStats)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminGetFileStats).
+		HandlerFunc(m.getFileStats)
 
 	// volume management APIs
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/meta_node.go
+++ b/master/meta_node.go
@@ -145,11 +145,12 @@ func (metaNode *MetaNode) reachesThreshold() bool {
 	return float32(float64(metaNode.Used)/float64(metaNode.Total)) > metaNode.Threshold
 }
 
-func (metaNode *MetaNode) createHeartbeatTask(masterAddr string) (task *proto.AdminTask) {
+func (metaNode *MetaNode) createHeartbeatTask(masterAddr string, fileStatsEnable bool) (task *proto.AdminTask) {
 	request := &proto.HeartBeatRequest{
 		CurrTime:   time.Now().Unix(),
 		MasterAddr: masterAddr,
 	}
+	request.FileStatsEnable = fileStatsEnable
 	task = proto.NewAdminTask(proto.OpMetaNodeHeartbeat, metaNode.Addr, request)
 	return
 }

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -50,6 +50,7 @@ type clusterValue struct {
 	DirChildrenNumLimit         uint32
 	DecommissionLimit           uint64
 	CheckDataReplicasEnable     bool
+	FileStatsEnable             bool
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -70,6 +71,7 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		DirChildrenNumLimit:         c.cfg.DirChildrenNumLimit,
 		DecommissionLimit:           c.DecommissionLimit,
 		CheckDataReplicasEnable:     c.checkDataReplicasEnable,
+		FileStatsEnable:             c.fileStatsEnable,
 	}
 	return cv
 }
@@ -873,6 +875,7 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.diskQosEnable = cv.DiskQosEnable
 		c.cfg.QosMasterAcceptLimit = cv.QosLimitUpload
 		c.DecommissionLimit = cv.DecommissionLimit //dont update nodesets limit for nodesets are not loaded
+		c.fileStatsEnable = cv.FileStatsEnable
 
 		if c.cfg.QosMasterAcceptLimit < QosMasterAcceptCnt {
 			c.cfg.QosMasterAcceptLimit = QosMasterAcceptCnt

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -67,6 +67,7 @@ type metadataManager struct {
 	partitions         map[uint64]MetaPartition // Key: metaRangeId, Val: metaPartition
 	metaNode           *MetaNode
 	flDeleteBatchCount atomic.Value
+	fileStatsEnable    bool
 }
 
 func (m *metadataManager) getPacketLabels(p *Packet) (labels map[string]string) {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -69,6 +69,7 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 			resp.Result = err.Error()
 			goto end
 		}
+		m.fileStatsEnable = req.FileStatsEnable
 		// collect memory info
 		resp.Total = configTotalMem
 		resp.Used, err = util.GetProcessMemory(os.Getpid())

--- a/metanode/partition_file_stats.go
+++ b/metanode/partition_file_stats.go
@@ -1,0 +1,136 @@
+package metanode
+
+import (
+	"fmt"
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/exporter"
+	"time"
+)
+
+type FileSizeRange uint32
+
+const (
+	Size1K   uint64 = 2 << 10
+	Size1M   uint64 = 2 << 20
+	Size16M         = 16 * Size1M
+	Size32M         = 32 * Size1M
+	Size64M         = 64 * Size1M
+	Size128M        = 128 * Size1M
+	Size256M        = 256 * Size1M
+)
+
+const (
+	LessThan1K FileSizeRange = iota
+	LessThan1M
+	LessThan16M
+	LessThan32M
+	LessThan64M
+	LessThan128M
+	LessThan256M
+	BiggerThan256M
+	MaxRangeType
+)
+
+const (
+	fileStatsCheckPeriod = time.Second * 30
+)
+
+func toString(fileSize FileSizeRange) string {
+	switch fileSize {
+	case LessThan1K:
+		return "<1K"
+	case LessThan1M:
+		return "<1M"
+	case LessThan16M:
+		return "<16M"
+	case LessThan32M:
+		return "<32M"
+	case LessThan64M:
+		return "<64M"
+	case LessThan128M:
+		return "<128M"
+	case LessThan256M:
+		return "<256M"
+	case BiggerThan256M:
+		return ">256M"
+	default:
+		return "unknown"
+	}
+}
+
+func (mp *metaPartition) setMetrics(fileRange []int64) {
+	for i, val := range fileRange {
+		labels := map[string]string{
+			"partid":    fmt.Sprintf("%d", mp.config.PartitionId),
+			"volName":   mp.config.VolName,
+			"sizeRange": toString(FileSizeRange(i)),
+		}
+		exporter.NewGauge("fileStats").SetWithLabels(float64(val), labels)
+	}
+}
+
+func (mp *metaPartition) fileStats(ino *Inode) {
+	if !mp.manager.fileStatsEnable {
+		return
+	}
+	fileRange := mp.fileRange
+	if ino.NLink > 0 && proto.IsRegular(ino.Type) {
+		if 0 <= ino.Size && ino.Size < Size1K {
+			fileRange[LessThan1K] += 1
+		} else if Size1K <= ino.Size && ino.Size < Size1M {
+			fileRange[LessThan1M] += 1
+		} else if Size1M <= ino.Size && ino.Size < Size16M {
+			fileRange[LessThan16M] += 1
+		} else if Size16M <= ino.Size && ino.Size < Size32M {
+			fileRange[LessThan32M] += 1
+		} else if Size32M <= ino.Size && ino.Size < Size64M {
+			fileRange[LessThan64M] += 1
+		} else if Size64M <= ino.Size && ino.Size < Size128M {
+			fileRange[LessThan128M] += 1
+		} else if Size128M <= ino.Size && ino.Size < Size256M {
+			fileRange[LessThan256M] += 1
+		} else {
+			fileRange[BiggerThan256M] += 1
+		}
+	}
+}
+
+func (mp *metaPartition) startFileStats() {
+	checkTicker := time.NewTicker(fileStatsCheckPeriod)
+	go func(stopC chan bool) {
+		lastEnable := false
+		isLeader := false
+		for {
+			select {
+			case <-stopC:
+				// if this mp is closed, clear the metric
+				if lastEnable {
+					fileRange := make([]int64, MaxRangeType)
+					mp.setMetrics(fileRange)
+				}
+				checkTicker.Stop()
+				return
+			case <-checkTicker.C:
+				if !mp.manager.fileStatsEnable {
+					// if fileStatsEnable change from true to false, clear the metric
+					if lastEnable {
+						fileRange := make([]int64, MaxRangeType)
+						mp.setMetrics(fileRange)
+					}
+					lastEnable = false
+					continue
+				}
+
+				lastEnable = true
+
+				// Clear the metric if status change from leader to follower
+				if _, isLeader = mp.IsLeader(); isLeader {
+					mp.setMetrics(mp.fileRange)
+				} else {
+					fileRange := make([]int64, MaxRangeType)
+					mp.setMetrics(fileRange)
+				}
+			}
+		}
+	}(mp.stopC)
+}

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -405,6 +405,7 @@ func (mp *metaPartition) storeInode(rootDir string,
 	var data []byte
 	lenBuf := make([]byte, 4)
 	sign := crc32.NewIEEE()
+	mp.fileRange = make([]int64, MaxRangeType)
 	sm.inodeTree.Ascend(func(i BtreeItem) bool {
 		ino := i.(*Inode)
 
@@ -413,6 +414,7 @@ func (mp *metaPartition) storeInode(rootDir string,
 		}
 
 		size += ino.Size
+		mp.fileStats(ino)
 
 		// set length
 		binary.BigEndian.PutUint32(lenBuf, uint32(len(data)))

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -65,6 +65,9 @@ const (
 	AdminUpdateDecommissionLimit              = "/admin/updateDecommissionLimit"
 	AdminQueryDecommissionLimit               = "/admin/queryDecommissionLimit"
 	AdminQueryDecommissionToken               = "/admin/queryDecommissionToken"
+	AdminSetFileStats                         = "/admin/setFileStatsEnable"
+	AdminGetFileStats                         = "/admin/getFileStatsEnable"
+
 	//graphql master api
 	AdminClusterAPI = "/api/cluster"
 	AdminUserAPI    = "/api/user"
@@ -415,6 +418,7 @@ type HeartBeatRequest struct {
 	MasterAddr string
 	FLReadVols []string
 	QosToDataNode
+	FileStatsEnable bool
 }
 
 // PartitionReport defines the partition report.


### PR DESCRIPTION
Adding the file stats function to analyse the files for each volume. 
It will read the inode file from snapshot dir and count the files for several size range.
We can view the file distribution for each volume on grafana.
![image](https://user-images.githubusercontent.com/2844826/222948317-6a684512-f4a3-41bb-8bb7-db11fd3d385d.png)


We also add a cmd to control the file stats function enable, the default value is false.