### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/docs-zh/source/user-guide/k8s.md
+++ b/docs-zh/source/user-guide/k8s.md
@@ -140,10 +140,10 @@ component:
 image:
   # CSI related images
   csi_driver: ghcr.io/cubefs/cfs-csi-driver:3.2.0.150.0
-  csi_provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-  csi_attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
-  csi_resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-  driver_registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+  csi_provisioner: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+  csi_attacher: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+  csi_resizer: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+  driver_registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
 
 csi:
   driverName: csi.cubefs.com


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Kubernetes is migrating its image registry from [[k8s.gcr.io](http://k8s.gcr.io/)](http://k8s.gcr.io/) to [[registry.k8s.io](http://registry.k8s.io/)](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This is only a documentation change.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
