### PR TITLE
Enhance: add a http request to get cluster persist configuration

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -4244,3 +4244,21 @@ func (m *Server) getFileStats(w http.ResponseWriter, r *http.Request) {
 	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf(
 		"getFileStats enable value [%v]", m.cluster.fileStatsEnable)))
 }
+
+func (m *Server) GetClusterValue(w http.ResponseWriter, r *http.Request) {
+	result, err := m.cluster.fsm.store.SeekForPrefix([]byte(clusterPrefix))
+	if err != nil {
+		log.LogErrorf("action[GetClusterValue],err:%v", err.Error())
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrInternalError))
+		return
+	}
+	for _, value := range result {
+		cv := &clusterValue{}
+		if err = json.Unmarshal(value, cv); err != nil {
+			log.LogErrorf("action[GetClusterValue], unmarshal err:%v", err.Error())
+			sendErrReply(w, r, newErrHTTPReply(proto.ErrUnmarshalData))
+			return
+		}
+		sendOkReply(w, r, newSuccessHTTPReply(cv))
+	}
+}

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -196,6 +196,10 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 		Path(proto.AdminGetFileStats).
 		HandlerFunc(m.getFileStats)
 
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminGetClusterValue).
+		HandlerFunc(m.GetClusterValue)
+
 	// volume management APIs
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminCreateVol).

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -67,7 +67,7 @@ const (
 	AdminQueryDecommissionToken               = "/admin/queryDecommissionToken"
 	AdminSetFileStats                         = "/admin/setFileStatsEnable"
 	AdminGetFileStats                         = "/admin/getFileStatsEnable"
-
+	AdminGetClusterValue                      = "/admin/getClusterValue"
 	//graphql master api
 	AdminClusterAPI = "/api/cluster"
 	AdminUserAPI    = "/api/user"


### PR DESCRIPTION
Sometimes, we want to get the status of the cluster, especially for functions that are enabled through dynamic configuration, such as DiskQos, DecommissionLimit, FileStats, etc. 
We want to add an interface that can view the values of these configurations, rather than looking them up one by one

<img width="335" alt="image" src="https://user-images.githubusercontent.com/2844826/231630022-2e16b67a-005c-4f0a-ba36-e78e10e459a7.png">

