### PR TITLE
fix: allow meta partition to start when snapshot directory not exists

### DIFF
--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -94,7 +94,7 @@ func (mp *metaPartition) loadInode(rootDir string) (err error) {
 	}()
 	filename := path.Join(rootDir, inodeFile)
 	if _, err = os.Stat(filename); err != nil {
-		err = errors.NewErrorf("[loadInode] Stat: %s", err.Error())
+		err = nil
 		return
 	}
 	fp, err := os.OpenFile(filename, os.O_RDONLY, 0644)
@@ -160,7 +160,7 @@ func (mp *metaPartition) loadDentry(rootDir string) (err error) {
 	}()
 	filename := path.Join(rootDir, dentryFile)
 	if _, err = os.Stat(filename); err != nil {
-		err = errors.NewErrorf("[loadDentry] Stat: %s", err.Error())
+		err = nil
 		return
 	}
 	fp, err := os.OpenFile(filename, os.O_RDONLY, 0644)
@@ -215,8 +215,7 @@ func (mp *metaPartition) loadExtend(rootDir string) error {
 	var err error
 	filename := path.Join(rootDir, extendFile)
 	if _, err = os.Stat(filename); err != nil {
-		err = errors.NewErrorf("[loadExtend] Stat: %s", err.Error())
-		return err
+		return nil
 	}
 	fp, err := os.OpenFile(filename, os.O_RDONLY, 0644)
 	if err != nil {
@@ -261,8 +260,7 @@ func (mp *metaPartition) loadMultipart(rootDir string) error {
 	var err error
 	filename := path.Join(rootDir, multipartFile)
 	if _, err = os.Stat(filename); err != nil {
-		err = errors.NewErrorf("[loadMultipart] Stat: %s", err.Error())
-		return err
+		return nil
 	}
 	fp, err := os.OpenFile(filename, os.O_RDONLY, 0644)
 	if err != nil {
@@ -303,7 +301,7 @@ func (mp *metaPartition) loadMultipart(rootDir string) error {
 func (mp *metaPartition) loadApplyID(rootDir string) (err error) {
 	filename := path.Join(rootDir, applyIDFile)
 	if _, err = os.Stat(filename); err != nil {
-		err = errors.NewErrorf("[loadApplyID]: Stat %s", err.Error())
+		err = nil
 		return
 	}
 	data, err := ioutil.ReadFile(filename)


### PR DESCRIPTION
The problem:
In a previous commit which intended to strengthen the check when metanode loading metapartitions，the checking  has been  modified as reporting error if dir 'snapshot ' not exists in the metapartition's dir. But this may cause problems if the some metapartitions are newly created and has not generated  dir 'snapshot ' yet，in this senario metanode can't restart for it will failed to load sunch metapartitions .

The fix:
Rollback codes of checking dir 'snapshot ' to before the above commit，just sikp it if  dir 'snapshot ' not exists.