### PR TITLE
enhance: add a configurable switch to control whether the volume's dataparitions become read-only when the volume is full

### DIFF
--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -96,7 +96,7 @@ const (
 	CliFlagCrossZone          = "crossZone"
 	CliNormalZonesFirst       = "normalZonesFirst"
 	CliFlagCount              = "count"
-
+	CliDpReadOnlyWhenVolFull  = "readonly-when-full"
 	//CliFlagSetDataPartitionCount	= "count" use dp-count instead
 
 	//Shorthand format of resource name

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -114,6 +114,7 @@ func formatSimpleVolView(svv *proto.SimpleVolView) string {
 	sb.WriteString(fmt.Sprintf("  Status               : %v\n", formatVolumeStatus(svv.Status)))
 	sb.WriteString(fmt.Sprintf("  ZoneName             : %v\n", svv.ZoneName))
 	sb.WriteString(fmt.Sprintf("  VolType              : %v\n", svv.VolType))
+	sb.WriteString(fmt.Sprintf("  DpReadOnlyWhenVolFull: %v\n", svv.DpReadOnlyWhenVolFull))
 	if svv.VolType == 1 {
 		sb.WriteString(fmt.Sprintf("  ObjBlockSize         : %v byte\n", svv.ObjBlockSize))
 		sb.WriteString(fmt.Sprintf("  CacheCapacity        : %v G\n", svv.CacheCapacity))

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -230,17 +230,18 @@ func extractBoolWithDefault(r *http.Request, key string, def bool) (val bool, er
 }
 
 type updateVolReq struct {
-	name           string
-	authKey        string
-	capacity       uint64
-	followRead     bool
-	authenticate   bool
-	enablePosixAcl bool
-	zoneName       string
-	description    string
-	dpSelectorName string
-	dpSelectorParm string
-	coldArgs       *coldVolArgs
+	name                  string
+	authKey               string
+	capacity              uint64
+	followRead            bool
+	authenticate          bool
+	enablePosixAcl        bool
+	zoneName              string
+	description           string
+	dpSelectorName        string
+	dpSelectorParm        string
+	coldArgs              *coldVolArgs
+	dpReadOnlyWhenVolFull bool
 }
 
 func parseColdVolUpdateArgs(r *http.Request, vol *Vol) (args *coldVolArgs, err error) {
@@ -330,6 +331,10 @@ func parseVolUpdateReq(r *http.Request, vol *Vol, req *updateVolReq) (err error)
 	}
 
 	if req.followRead, err = extractBoolWithDefault(r, followerReadKey, vol.FollowerRead); err != nil {
+		return
+	}
+
+	if req.dpReadOnlyWhenVolFull, err = extractBoolWithDefault(r, dpReadOnlyWhenVolFull, vol.DpReadOnlyWhenVolFull); err != nil {
 		return
 	}
 
@@ -487,6 +492,7 @@ type createVolReq struct {
 	description                          string
 	volType                              int
 	enablePosixAcl                       bool
+	DpReadOnlyWhenVolFull                bool
 	qosLimitArgs                         *qosArgs
 	clientReqPeriod, clientHitTriggerCnt uint32
 	// cold vol args
@@ -615,6 +621,10 @@ func parseRequestToCreateVol(r *http.Request, req *createVolReq) (err error) {
 	}
 
 	req.enablePosixAcl, err = extractPosixAcl(r)
+
+	if req.DpReadOnlyWhenVolFull, err = extractBoolWithDefault(r, dpReadOnlyWhenVolFull, false); err != nil {
+		return
+	}
 
 	return
 }

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2645,6 +2645,8 @@ func (c *Cluster) doCreateVol(req *createVolReq) (vol *Vol, err error) {
 		IopsWLimit:   req.qosLimitArgs.iopsWVal,
 		FlowRlimit:   req.qosLimitArgs.flowRVal,
 		FlowWlimit:   req.qosLimitArgs.flowWVal,
+
+		DpReadOnlyWhenVolFull: req.DpReadOnlyWhenVolFull,
 	}
 
 	log.LogInfof("[doCreateVol] volView, %v", vv)

--- a/master/const.go
+++ b/master/const.go
@@ -94,6 +94,7 @@ const (
 	Limit                   = "limit"
 	TimeOut                 = "timeout"
 	CountByMeta             = "countByMeta"
+	dpReadOnlyWhenVolFull   = "dpReadOnlyWhenVolFull"
 )
 
 const (

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -198,16 +198,17 @@ func newDataPartitionValue(dp *DataPartition) (dpv *dataPartitionValue) {
 }
 
 type volValue struct {
-	ID                uint64
-	Name              string
-	ReplicaNum        uint8
-	DpReplicaNum      uint8
-	Status            uint8
-	DataPartitionSize uint64
-	Capacity          uint64
-	Owner             string
-	FollowerRead      bool
-	Authenticate      bool
+	ID                    uint64
+	Name                  string
+	ReplicaNum            uint8
+	DpReplicaNum          uint8
+	Status                uint8
+	DataPartitionSize     uint64
+	Capacity              uint64
+	Owner                 string
+	FollowerRead          bool
+	Authenticate          bool
+	DpReadOnlyWhenVolFull bool
 
 	CrossZone       bool
 	DomainOn        bool
@@ -290,6 +291,8 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		FlowWMagnify:        vol.qosManager.getQosMagnify(bsProto.FlowWriteType),
 		ClientReqPeriod:     vol.qosManager.ClientReqPeriod,
 		ClientHitTriggerCnt: vol.qosManager.ClientHitTriggerCnt,
+
+		DpReadOnlyWhenVolFull: vol.DpReadOnlyWhenVolFull,
 	}
 
 	return

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -722,33 +722,34 @@ func NewLimitRsp2Client() *LimitRsp2Client {
 
 // SimpleVolView defines the simple view of a volume
 type SimpleVolView struct {
-	ID                 uint64
-	Name               string
-	Owner              string
-	ZoneName           string
-	DpReplicaNum       uint8
-	MpReplicaNum       uint8
-	InodeCount         uint64
-	DentryCount        uint64
-	MaxMetaPartitionID uint64
-	Status             uint8
-	Capacity           uint64 // GB
-	RwDpCnt            int
-	MpCnt              int
-	DpCnt              int
-	FollowerRead       bool
-	NeedToLowerReplica bool
-	Authenticate       bool
-	CrossZone          bool
-	DefaultPriority    bool
-	DomainOn           bool
-	CreateTime         string
-	EnableToken        bool
-	EnablePosixAcl     bool
-	Description        string
-	DpSelectorName     string
-	DpSelectorParm     string
-	DefaultZonePrior   bool
+	ID                    uint64
+	Name                  string
+	Owner                 string
+	ZoneName              string
+	DpReplicaNum          uint8
+	MpReplicaNum          uint8
+	InodeCount            uint64
+	DentryCount           uint64
+	MaxMetaPartitionID    uint64
+	Status                uint8
+	Capacity              uint64 // GB
+	RwDpCnt               int
+	MpCnt                 int
+	DpCnt                 int
+	FollowerRead          bool
+	NeedToLowerReplica    bool
+	Authenticate          bool
+	CrossZone             bool
+	DefaultPriority       bool
+	DomainOn              bool
+	CreateTime            string
+	EnableToken           bool
+	EnablePosixAcl        bool
+	Description           string
+	DpSelectorName        string
+	DpSelectorParm        string
+	DefaultZonePrior      bool
+	DpReadOnlyWhenVolFull bool
 
 	VolType          int
 	ObjBlockSize     int
@@ -804,22 +805,24 @@ type MasterAPIAccessResp struct {
 }
 
 type VolInfo struct {
-	Name       string
-	Owner      string
-	CreateTime int64
-	Status     uint8
-	TotalSize  uint64
-	UsedSize   uint64
+	Name                  string
+	Owner                 string
+	CreateTime            int64
+	Status                uint8
+	TotalSize             uint64
+	UsedSize              uint64
+	DpReadOnlyWhenVolFull bool
 }
 
-func NewVolInfo(name, owner string, createTime int64, status uint8, totalSize, usedSize uint64) *VolInfo {
+func NewVolInfo(name, owner string, createTime int64, status uint8, totalSize, usedSize uint64, dpReadOnlyWhenVolFull bool) *VolInfo {
 	return &VolInfo{
-		Name:       name,
-		Owner:      owner,
-		CreateTime: createTime,
-		Status:     status,
-		TotalSize:  totalSize,
-		UsedSize:   usedSize,
+		Name:                  name,
+		Owner:                 owner,
+		CreateTime:            createTime,
+		Status:                status,
+		TotalSize:             totalSize,
+		UsedSize:              usedSize,
+		DpReadOnlyWhenVolFull: dpReadOnlyWhenVolFull,
 	}
 }
 

--- a/proto/model.go
+++ b/proto/model.go
@@ -174,15 +174,16 @@ type NodeStatInfo struct {
 }
 
 type VolStatInfo struct {
-	Name           string
-	TotalSize      uint64
-	UsedSize       uint64
-	UsedRatio      string
-	CacheTotalSize uint64
-	CacheUsedSize  uint64
-	CacheUsedRatio string
-	EnableToken    bool
-	InodeCount     uint64
+	Name                  string
+	TotalSize             uint64
+	UsedSize              uint64
+	UsedRatio             string
+	CacheTotalSize        uint64
+	CacheUsedSize         uint64
+	CacheUsedRatio        string
+	EnableToken           bool
+	InodeCount            uint64
+	DpReadOnlyWhenVolFull bool
 }
 
 // DataPartition represents the structure of storing the file contents.

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -260,7 +260,8 @@ func (api *AdminAPI) DeleteVolume(volName, authKey string) (err error) {
 }
 
 func (api *AdminAPI) UpdateVolume(volName, description, auth, zoneName string, capacity uint64, followerRead bool,
-	ebsBlkSize int, CacheCap uint64, cacheAction, cacheThreshold, cacheTTL, cacheHighWater, cacheLowWater, cacheLRUInterval int, cacheRule string) (err error) {
+	ebsBlkSize int, CacheCap uint64, cacheAction, cacheThreshold, cacheTTL, cacheHighWater, cacheLowWater,
+	cacheLRUInterval int, cacheRule string, dpReadOnlyWhenVolFull bool) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminUpdateVol)
 	request.addParam("name", volName)
 	request.addParam("description", description)
@@ -277,7 +278,7 @@ func (api *AdminAPI) UpdateVolume(volName, description, auth, zoneName string, c
 	request.addParam("cacheLowWater", strconv.Itoa(cacheLowWater))
 	request.addParam("cacheLRUInterval", strconv.Itoa(cacheLRUInterval))
 	request.addParam("cacheRuleKey", cacheRule)
-
+	request.addParam("dpReadOnlyWhenVolFull", strconv.FormatBool(dpReadOnlyWhenVolFull))
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -308,7 +309,8 @@ func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey string) 
 
 func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, crossZone, normalZonesFirst bool, business string,
 	mpCount, replicaNum, size, volType int, followerRead bool, zoneName, cacheRuleKey string, ebsBlkSize,
-	cacheCapacity, cacheAction, cacheThreshold, cacheTTL, cacheHighWater, cacheLowWater, cacheLRUInterval int) (err error) {
+	cacheCapacity, cacheAction, cacheThreshold, cacheTTL, cacheHighWater, cacheLowWater, cacheLRUInterval int,
+	dpReadOnlyWhenVolFull bool) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminCreateVol)
 	request.addParam("name", volName)
 	request.addParam("owner", owner)
@@ -331,6 +333,7 @@ func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, cross
 	request.addParam("cacheHighWater", strconv.Itoa(cacheHighWater))
 	request.addParam("cacheLowWater", strconv.Itoa(cacheLowWater))
 	request.addParam("cacheLRUInterval", strconv.Itoa(cacheLRUInterval))
+	request.addParam("dpReadOnlyWhenVolFull", strconv.FormatBool(dpReadOnlyWhenVolFull))
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}


### PR DESCRIPTION
The background:
Recent versions have enhanced checking of volume uese space, if a volume's used space >= capacity, all its datapartitions will be changed to readonly status, to make it can't be written any more. But this enhancement will cause write op failed when upgrading elder versions if volumes's used space have been exceeds capacity.
So, a configurable switch to control checking of volume's used space is needed.

The enhancement:
Add a configurable switch to control checking of volume's used space. when a volume's used space >= capacity, all its datapartitions will be changed to readonly status only if the switch is on.

The switch is off by default.
The switch can be set in /admin/createVol cmd. example: `cfs-cli volume create ${VolName} ${Owner}  --readonly-when-full=true -y`
The switch can be changed by the /vol/update cmd. example: `curl -v "http://192.168.0.13:17010/vol/update?name=VOLNAME&dpReadOnlyWhenVolFull=true&authKey=XXYYAABB"` or `cfs-cli volume update ltptest --readonly-when-full=true -y`