### PR TITLE
chore: disable release ci checks

### DIFF
--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -19,15 +19,16 @@ jobs:
         uses: actions/checkout@v3
       - name: Release and run ltp tests
         run: |
-          docker/run_docker.sh -t
-          docker/run_docker.sh --ltptest
-      - name: Pack docker_data
-        if: ${{ always() }}
-        run: pushd docker && sudo tar --exclude='docker_data/datanode*/disk' --exclude='docker_data/disk' -czvf docker_data.tar.gz docker_data
-      - name: Upload docker_data.tar.gz
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: docker_data
-          path: docker/docker_data.tar.gz
-          retention-days: 7
+          echo "disable release ci checks"
+#          docker/run_docker.sh -t
+#          docker/run_docker.sh --ltptest
+#      - name: Pack docker_data
+#        if: ${{ always() }}
+#        run: pushd docker && sudo tar --exclude='docker_data/datanode*/disk' --exclude='docker_data/disk' -czvf docker_data.tar.gz docker_data
+#      - name: Upload docker_data.tar.gz
+#        if: ${{ always() }}
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: docker_data
+#          path: docker/docker_data.tar.gz
+#          retention-days: 7


### PR DESCRIPTION
disable release ci checks. (cherry pick from branch release-3.2.1)
