### PR TITLE
[Enhancement] add authentication for master admin api

### DIFF
--- a/authnode/api_service.go
+++ b/authnode/api_service.go
@@ -557,6 +557,12 @@ func genAuthAPIAccessResp(req *proto.APIAccessReq, keyInfo *keystore.KeyInfo, ts
 
 	resp.KeyInfo = *keyInfo
 
+	resp.AuthIDKey, err = proto.GenAuthIDKey(keyInfo.ID, keyInfo.AuthKey)
+	if err != nil {
+		err = fmt.Errorf("gen authIDKey for response failed %s", err.Error())
+		return
+	}
+
 	if jresp, err = json.Marshal(resp); err != nil {
 		err = fmt.Errorf("json marshal for response failed %s", err.Error())
 		return

--- a/authtool/authtool.go
+++ b/authtool/authtool.go
@@ -366,11 +366,11 @@ func accessAuthServer() {
 		}
 
 		if flaginfo.api.request == CreateKey {
-			if err = resp.KeyInfo.DumpJSONFile(flaginfo.api.output); err != nil {
+			if err = resp.KeyInfo.DumpJSONFile(flaginfo.api.output, resp.AuthIDKey); err != nil {
 				panic(err)
 			}
 		} else {
-			if res, err = resp.KeyInfo.DumpJSONStr(); err != nil {
+			if res, err = resp.KeyInfo.DumpJSONStr(resp.AuthIDKey); err != nil {
 				panic(err)
 			}
 		}
@@ -512,7 +512,7 @@ func main() {
 				Role:    "AuthService",
 				Caps:    []byte(`{"*"}`),
 			}
-			keyInfo.DumpJSONFile(*output[i])
+			keyInfo.DumpJSONFile(*output[i], "")
 		}
 
 	default:

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -46,6 +46,7 @@ func runCLI() (err error) {
 func setupCommands(cfg *cmd.Config) *cobra.Command {
 	var mc = master.NewMasterClient(cfg.MasterAddr, false)
 	mc.SetTimeout(cfg.Timeout)
+	mc.SetClientIDKey(cfg.ClientIDKey)
 	cfsRootCmd := cmd.NewRootCmd(mc)
 	//	var completionCmd = &cobra.Command{
 	//		Use:   "completion",

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -121,6 +121,7 @@ func newClusterStatCmd(client *master.MasterClient) *cobra.Command {
 }
 
 func newClusterFreezeCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:       CliOpFreeze + " [ENABLE]",
 		ValidArgs: []string{"true", "false"},
@@ -146,7 +147,7 @@ If 'freeze=true', CubeFS WILL NOT automatically allocate new data partitions `,
 				err = fmt.Errorf("Parse bool fail: %v\n", err)
 				return
 			}
-			if err = client.AdminAPI().IsFreezeCluster(enable); err != nil {
+			if err = client.AdminAPI().IsFreezeCluster(enable, clientIDKey); err != nil {
 				return
 			}
 			if enable {
@@ -156,10 +157,12 @@ If 'freeze=true', CubeFS WILL NOT automatically allocate new data partitions `,
 			}
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newClusterSetThresholdCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpSetThreshold + " [THRESHOLD]",
 		Short: cmdClusterThresholdShort,
@@ -184,16 +187,18 @@ If the memory usage reaches this threshold, all the meta partition will be readO
 				err = fmt.Errorf("Threshold too big\n")
 				return
 			}
-			if err = client.AdminAPI().SetMetaNodeThreshold(threshold); err != nil {
+			if err = client.AdminAPI().SetMetaNodeThreshold(threshold, clientIDKey); err != nil {
 				return
 			}
 			stdout("MetaNode threshold is set to %v!\n", threshold)
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var optAutoRepairRate, optMarkDeleteRate, optDelBatchCount, optDelWorkerSleepMs, optLoadFactor, opMaxDpCntLimit string
 	var cmd = &cobra.Command{
 		Use:   CliOpSetCluster,
@@ -208,7 +213,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 				}
 			}()
 
-			if err = client.AdminAPI().SetClusterParas(optDelBatchCount, optMarkDeleteRate, optDelWorkerSleepMs, optAutoRepairRate, optLoadFactor, opMaxDpCntLimit); err != nil {
+			if err = client.AdminAPI().SetClusterParas(optDelBatchCount, optMarkDeleteRate, optDelWorkerSleepMs, optAutoRepairRate, optLoadFactor, opMaxDpCntLimit, clientIDKey); err != nil {
 				return
 			}
 			stdout("Cluster parameters has been set successfully. \n")
@@ -220,6 +225,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optAutoRepairRate, CliFlagAutoRepairRate, "", "DataNode auto repair rate")
 	cmd.Flags().StringVar(&optDelWorkerSleepMs, CliFlagDelWorkerSleepMs, "", "MetaNode delete worker sleep time with millisecond. if 0 for no sleep")
 	cmd.Flags().StringVar(&opMaxDpCntLimit, CliFlagMaxDpCntLimit, "", "Maximum number of dp on each datanode, default 3000, 0 represents setting to default")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 
 	return cmd
 }

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -47,8 +47,9 @@ var (
 )
 
 type Config struct {
-	MasterAddr []string `json:"masterAddr"`
-	Timeout    uint16   `json:"timeout"`
+	MasterAddr  []string `json:"masterAddr"`
+	Timeout     uint16   `json:"timeout"`
+	ClientIDKey string   `json:"clientIDKey"`
 }
 
 func newConfigCmd() *cobra.Command {

--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -111,6 +111,7 @@ const (
 	CliFlagForceInode          = "forceInode"
 	CliFlagEnableQuota         = "enableQuota"
 	CliFlagDeleteLockTime      = "delete-lock-time"
+	CliFlagClientIDKey         = "clientIDKey"
 
 	//CliFlagSetDataPartitionCount	= "count" use dp-count instead
 
@@ -119,6 +120,9 @@ const (
 	ResourceMetaNodeShortHand      = "mn"
 	ResourceDataPartitionShortHand = "dp"
 	ResourceMetaPartitionShortHand = "mp"
+
+	//Usages
+	CliUsageClientIDKey = "needed if cluster authentication is on"
 )
 
 type MasterOp int

--- a/cli/cmd/datanode.go
+++ b/cli/cmd/datanode.go
@@ -123,7 +123,10 @@ func newDataNodeInfoCmd(client *master.MasterClient) *cobra.Command {
 }
 
 func newDataNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
-	var optCount int
+	var (
+		optCount    int
+		clientIDKey string
+	)
 	var cmd = &cobra.Command{
 		Use:   CliOpDecommission + " [{HOST}:{PORT}]",
 		Short: cmdDataNodeDecommissionInfoShort,
@@ -141,7 +144,7 @@ func newDataNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 				stdout("Migrate dp count should >= 0\n")
 				return
 			}
-			if err = client.NodeAPI().DataNodeDecommission(nodeAddr, optCount); err != nil {
+			if err = client.NodeAPI().DataNodeDecommission(nodeAddr, optCount, clientIDKey); err != nil {
 				return
 			}
 			stdout("Decommission data node successfully\n")
@@ -155,10 +158,12 @@ func newDataNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&optCount, CliFlagCount, 0, "DataNode delete mp count")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newDataNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var optCount int
 	var cmd = &cobra.Command{
 		Use:   CliOpMigrate + " src[{HOST}:{PORT}] dst[{HOST}:{PORT}]",
@@ -179,7 +184,7 @@ func newDataNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 				return
 			}
 
-			if err = client.NodeAPI().DataNodeMigrate(src, dst, optCount); err != nil {
+			if err = client.NodeAPI().DataNodeMigrate(src, dst, optCount, clientIDKey); err != nil {
 				return
 			}
 			stdout("Migrate data node successfully\n")
@@ -193,5 +198,6 @@ func newDataNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&optCount, CliFlagCount, dpMigrateMax, "Migrate dp count,default 15")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }

--- a/cli/cmd/datapartition.go
+++ b/cli/cmd/datapartition.go
@@ -246,6 +246,7 @@ The "reset" command will be released in next version`,
 
 func newDataPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command {
 	var raftForceDel bool
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpDecommission + " [ADDRESS] [DATA PARTITION ID]",
 		Short: cmdDataPartitionDecommissionShort,
@@ -265,7 +266,7 @@ func newDataPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 			if err != nil {
 				return
 			}
-			if err = client.AdminAPI().DecommissionDataPartition(partitionID, address, raftForceDel); err != nil {
+			if err = client.AdminAPI().DecommissionDataPartition(partitionID, address, raftForceDel, clientIDKey); err != nil {
 				return
 			}
 			stdout("Decommission data partition successfully\n")
@@ -278,10 +279,12 @@ func newDataPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 		},
 	}
 	cmd.Flags().BoolVarP(&raftForceDel, "raftForceDel", "r", false, "true for raftForceDel")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newDataPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpReplicate + " [ADDRESS] [DATA PARTITION ID]",
 		Short: cmdDataPartitionReplicateShort,
@@ -300,7 +303,7 @@ func newDataPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
 			if partitionID, err = strconv.ParseUint(args[1], 10, 64); err != nil {
 				return
 			}
-			if err = client.AdminAPI().AddDataReplica(partitionID, address); err != nil {
+			if err = client.AdminAPI().AddDataReplica(partitionID, address, clientIDKey); err != nil {
 				return
 			}
 			stdout("Add replication successfully\n")
@@ -312,10 +315,12 @@ func newDataPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
 			return validDataNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newDataPartitionDeleteReplicaCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpDelReplica + " [ADDRESS] [DATA PARTITION ID]",
 		Short: cmdDataPartitionDeleteReplicaShort,
@@ -334,7 +339,7 @@ func newDataPartitionDeleteReplicaCmd(client *master.MasterClient) *cobra.Comman
 			if partitionID, err = strconv.ParseUint(args[1], 10, 64); err != nil {
 				return
 			}
-			if err = client.AdminAPI().DeleteDataReplica(partitionID, address); err != nil {
+			if err = client.AdminAPI().DeleteDataReplica(partitionID, address, clientIDKey); err != nil {
 				return
 			}
 			stdout("Delete replication successfully\n")
@@ -346,6 +351,7 @@ func newDataPartitionDeleteReplicaCmd(client *master.MasterClient) *cobra.Comman
 			return validDataNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 

--- a/cli/cmd/http_service.go
+++ b/cli/cmd/http_service.go
@@ -13,10 +13,11 @@ type clientHandler interface {
 }
 
 type volumeClient struct {
-	name     string
-	capacity uint64
-	opCode   MasterOp
-	client   *master.MasterClient
+	name        string
+	capacity    uint64
+	opCode      MasterOp
+	client      *master.MasterClient
+	clientIDKey string
 }
 
 func NewVolumeClient(opCode MasterOp, client *master.MasterClient) (vol *volumeClient) {
@@ -36,7 +37,7 @@ func (vol *volumeClient) excuteHttp() (err error) {
 		if vol.capacity <= vv.Capacity {
 			return errors.New(fmt.Sprintf("Expand capacity must larger than %v!\n", vv.Capacity))
 		}
-		if err = vol.client.AdminAPI().VolExpand(vol.name, vol.capacity, util.CalcAuthKey(vv.Owner)); err != nil {
+		if err = vol.client.AdminAPI().VolExpand(vol.name, vol.capacity, util.CalcAuthKey(vv.Owner), vol.clientIDKey); err != nil {
 			return
 		}
 	case OpShrinkVol:
@@ -47,7 +48,7 @@ func (vol *volumeClient) excuteHttp() (err error) {
 		if vol.capacity >= vv.Capacity {
 			return errors.New(fmt.Sprintf("Expand capacity must less than %v!\n", vv.Capacity))
 		}
-		if err = vol.client.AdminAPI().VolShrink(vol.name, vol.capacity, util.CalcAuthKey(vv.Owner)); err != nil {
+		if err = vol.client.AdminAPI().VolShrink(vol.name, vol.capacity, util.CalcAuthKey(vv.Owner), vol.clientIDKey); err != nil {
 			return
 		}
 	case OpDeleteVol:

--- a/cli/cmd/metanode.go
+++ b/cli/cmd/metanode.go
@@ -123,7 +123,10 @@ func newMetaNodeInfoCmd(client *master.MasterClient) *cobra.Command {
 	return cmd
 }
 func newMetaNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
-	var optCount int
+	var (
+		optCount    int
+		clientIDKey string
+	)
 	var cmd = &cobra.Command{
 		Use:   CliOpDecommission + " [{HOST}:{PORT}]",
 		Short: cmdMetaNodeDecommissionInfoShort,
@@ -141,7 +144,7 @@ func newMetaNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 				stdout("Migrate mp count should >= 0\n")
 				return
 			}
-			if err = client.NodeAPI().MetaNodeDecommission(nodeAddr, optCount); err != nil {
+			if err = client.NodeAPI().MetaNodeDecommission(nodeAddr, optCount, clientIDKey); err != nil {
 				return
 			}
 			stdout("Decommission meta node successfully\n")
@@ -155,10 +158,14 @@ func newMetaNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&optCount, CliFlagCount, 0, "MetaNode delete mp count")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
-	var optCount int
+	var (
+		optCount    int
+		clientIDKey string
+	)
 	var cmd = &cobra.Command{
 		Use:   CliOpMigrate + " src[{HOST}:{PORT}] dst[{HOST}:{PORT}]",
 		Short: cmdMetaNodeMigrateInfoShort,
@@ -177,7 +184,7 @@ func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 				stdout("Migrate mp count should between [1-15]\n")
 				return
 			}
-			if err = client.NodeAPI().MetaNodeMigrate(src, dst, optCount); err != nil {
+			if err = client.NodeAPI().MetaNodeMigrate(src, dst, optCount, clientIDKey); err != nil {
 				return
 			}
 			stdout("Migrate meta node successfully\n")
@@ -191,5 +198,6 @@ func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&optCount, CliFlagCount, mpMigrateMax, "Migrate mp count")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }

--- a/cli/cmd/metapartition.go
+++ b/cli/cmd/metapartition.go
@@ -257,6 +257,7 @@ the corrupt nodes, the few remaining replicas can not reach an agreement with on
 }
 
 func newMetaPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpDecommission + " [ADDRESS] [META PARTITION ID]",
 		Short: cmdMetaPartitionDecommissionShort,
@@ -273,7 +274,7 @@ func newMetaPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 			}()
 			address := args[0]
 			partitionID, err = strconv.ParseUint(args[1], 10, 64)
-			if err = client.AdminAPI().DecommissionMetaPartition(partitionID, address); err != nil {
+			if err = client.AdminAPI().DecommissionMetaPartition(partitionID, address, clientIDKey); err != nil {
 				return
 			}
 			stdout("Decommission meta partition successfully\n")
@@ -285,10 +286,12 @@ func newMetaPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 			return validMetaNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newMetaPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpReplicate + " [ADDRESS] [META PARTITION ID]",
 		Short: cmdMetaPartitionReplicateShort,
@@ -305,7 +308,7 @@ func newMetaPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
 			}()
 			address := args[0]
 			partitionID, err = strconv.ParseUint(args[1], 10, 64)
-			if err = client.AdminAPI().AddMetaReplica(partitionID, address); err != nil {
+			if err = client.AdminAPI().AddMetaReplica(partitionID, address, clientIDKey); err != nil {
 				return
 			}
 			stdout("Add replication successfully\n")
@@ -317,10 +320,12 @@ func newMetaPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
 			return validMetaNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 
 func newMetaPartitionDeleteReplicaCmd(client *master.MasterClient) *cobra.Command {
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   CliOpDelReplica + " [ADDRESS] [META PARTITION ID]",
 		Short: cmdMetaPartitionDeleteReplicaShort,
@@ -340,7 +345,7 @@ func newMetaPartitionDeleteReplicaCmd(client *master.MasterClient) *cobra.Comman
 			if err != nil {
 				return
 			}
-			if err = client.AdminAPI().DeleteMetaReplica(partitionID, address); err != nil {
+			if err = client.AdminAPI().DeleteMetaReplica(partitionID, address, clientIDKey); err != nil {
 				return
 			}
 			stdout("Delete replication successfully\n")
@@ -352,5 +357,6 @@ func newMetaPartitionDeleteReplicaCmd(client *master.MasterClient) *cobra.Comman
 			return validMetaNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -55,6 +55,7 @@ func newUserCreateCmd(client *master.MasterClient) *cobra.Command {
 	var optAccessKey string
 	var optSecretKey string
 	var optUserType string
+	var clientIDKey string
 	var optYes bool
 	var cmd = &cobra.Command{
 		Use:   cmdUserCreateUse,
@@ -116,7 +117,7 @@ func newUserCreateCmd(client *master.MasterClient) *cobra.Command {
 				Type:      userType,
 			}
 			var userInfo *proto.UserInfo
-			if userInfo, err = client.UserAPI().CreateUser(&param); err != nil {
+			if userInfo, err = client.UserAPI().CreateUser(&param, clientIDKey); err != nil {
 				err = fmt.Errorf("Create user failed: %v\n", err)
 				return
 			}
@@ -131,6 +132,7 @@ func newUserCreateCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optAccessKey, "access-key", "", "Specify user access key for object storage interface authentication [16 digits & letters]")
 	cmd.Flags().StringVar(&optSecretKey, "secret-key", "", "Specify user secret key for object storage interface authentication [32 digits & letters]")
 	cmd.Flags().StringVar(&optUserType, "user-type", "normal", "Specify user type [normal | admin]")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	cmd.Flags().BoolVarP(&optYes, "yes", "y", false, "Answer yes for all questions")
 	return cmd
 }
@@ -144,6 +146,7 @@ func newUserUpdateCmd(client *master.MasterClient) *cobra.Command {
 	var optAccessKey string
 	var optSecretKey string
 	var optUserType string
+	var clientIDKey string
 	var optYes bool
 	var cmd = &cobra.Command{
 		Use:   cmdUserUpdateUse,
@@ -205,7 +208,7 @@ func newUserUpdateCmd(client *master.MasterClient) *cobra.Command {
 				Type:      userType,
 			}
 			var userInfo *proto.UserInfo
-			if userInfo, err = client.UserAPI().UpdateUser(&param); err != nil {
+			if userInfo, err = client.UserAPI().UpdateUser(&param, clientIDKey); err != nil {
 				return
 			}
 
@@ -217,6 +220,7 @@ func newUserUpdateCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optAccessKey, "access-key", "", "Update user access key")
 	cmd.Flags().StringVar(&optSecretKey, "secret-key", "", "Update user secret key")
 	cmd.Flags().StringVar(&optUserType, "user-type", "", "Update user type [normal | admin]")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	cmd.Flags().BoolVarP(&optYes, "yes", "y", false, "Answer yes for all questions")
 	return cmd
 }
@@ -229,6 +233,7 @@ const (
 func newUserDeleteCmd(client *master.MasterClient) *cobra.Command {
 	var optYes bool
 	//var optForce bool
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   cmdUserDeleteUse,
 		Short: cmdUserDeleteShort,
@@ -251,7 +256,7 @@ func newUserDeleteCmd(client *master.MasterClient) *cobra.Command {
 				}
 			}
 
-			if err = client.UserAPI().DeleteUser(userID); err != nil {
+			if err = client.UserAPI().DeleteUser(userID, clientIDKey); err != nil {
 				err = fmt.Errorf("Delete user failed:\n%v\n", err)
 				return
 			}
@@ -266,6 +271,7 @@ func newUserDeleteCmd(client *master.MasterClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&optYes, "yes", "y", false, "Answer yes for all questions")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	//cmd.Flags().BoolVarP(&optForce, "force", "f", false, "Force to delete user")
 	return cmd
 }
@@ -313,6 +319,7 @@ const (
 
 func newUserPermCmd(client *master.MasterClient) *cobra.Command {
 	var subdir string
+	var clientIDKey string
 	var cmd = &cobra.Command{
 		Use:   cmdUserPermUse,
 		Short: cmdUserPermShort,
@@ -364,11 +371,11 @@ func newUserPermCmd(client *master.MasterClient) *cobra.Command {
 			}
 			if perm.IsNone() {
 				param := proto.NewUserPermRemoveParam(userID, volume)
-				userInfo, err = client.UserAPI().RemovePolicy(param)
+				userInfo, err = client.UserAPI().RemovePolicy(param, clientIDKey)
 			} else {
 				param := proto.NewUserPermUpdateParam(userID, volume)
 				param.SetPolicy(perm.String())
-				userInfo, err = client.UserAPI().UpdatePolicy(param)
+				userInfo, err = client.UserAPI().UpdatePolicy(param, clientIDKey)
 			}
 			if err != nil {
 				return
@@ -383,6 +390,7 @@ func newUserPermCmd(client *master.MasterClient) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&subdir, "subdir", "", "Subdir")
+	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }
 

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -106,6 +106,8 @@ const (
 
 	//rate limit control enable
 	ConfigDiskQosEnable = "diskQosEnable" //bool
+
+	ConfigServiceIDKey = "serviceIDKey"
 )
 
 // DataNode defines the structure of a data node.
@@ -153,6 +155,7 @@ type DataNode struct {
 	diskFlowWriteLimit      uint64
 	clusterUuid             string
 	clusterUuidEnable       bool
+	serviceIDKey            string
 }
 
 func NewServer() *DataNode {
@@ -305,6 +308,8 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 		s.zoneName = DefaultZoneName
 	}
 	s.metricsDegrade = cfg.GetInt64(CfgMetricsDegrade)
+
+	s.serviceIDKey = cfg.GetString(ConfigServiceIDKey)
 
 	log.LogDebugf("action[parseConfig] load masterAddrs(%v).", MasterClient.Nodes())
 	log.LogDebugf("action[parseConfig] load port(%v).", s.port)
@@ -469,7 +474,8 @@ func (s *DataNode) register(cfg *config.Config) {
 
 			// register this data node on the master
 			var nodeID uint64
-			if nodeID, err = MasterClient.NodeAPI().AddDataNode(fmt.Sprintf("%s:%v", LocalIP, s.port), s.zoneName); err != nil {
+			if nodeID, err = MasterClient.NodeAPI().AddDataNodeWithAuthNode(fmt.Sprintf("%s:%v", LocalIP, s.port),
+				s.zoneName, s.serviceIDKey); err != nil {
 				log.LogErrorf("action[registerToMaster] cannot register this node to master[%v] err(%v).",
 					masterAddr, err)
 				timer.Reset(2 * time.Second)

--- a/master/const.go
+++ b/master/const.go
@@ -118,6 +118,7 @@ const (
 	enableQuota                = "enableQuota"
 	dpDiscardKey               = "dpDiscard"
 	ignoreDiscardKey           = "ignoreDiscard"
+	ClientIDKey                = "clientIDKey"
 )
 
 const (

--- a/master/server.go
+++ b/master/server.go
@@ -59,6 +59,10 @@ const (
 	cfgElectionTick      = "electionTick"
 	SecretKey            = "masterServiceKey"
 	Stat                 = "stat"
+	Authenticate         = "authenticate"
+	AuthNodeHost         = "authNodeHost"
+	AuthNodeEnableHTTPS  = "authNodeEnableHTTPS"
+	AuthNodeCertFile     = "authNodeCertFile"
 )
 
 var (
@@ -160,6 +164,11 @@ func (m *Server) Start(cfg *config.Config) (err error) {
 	if m.cluster.MasterSecretKey, err = cryptoutil.Base64Decode(MasterSecretKey); err != nil {
 		return fmt.Errorf("action[Start] failed %v, err: master service Key invalid = %s", proto.ErrInvalidCfg, MasterSecretKey)
 	}
+	m.cluster.authenticate = cfg.GetBool(Authenticate)
+	if m.cluster.authenticate {
+		m.cluster.initAuthentication(cfg)
+	}
+
 	m.cluster.scheduleTask()
 	m.startHTTPService(ModuleName, cfg)
 	exporter.RegistConsul(m.clusterName, ModuleName, cfg)

--- a/metanode/const.go
+++ b/metanode/const.go
@@ -215,6 +215,7 @@ const (
 	cfgSmuxMaxBuffer             = "smuxMaxBuffer"             //int
 	cfgRetainLogs                = "retainLogs"                //string, raft RetainLogs
 	cfgRaftSyncSnapFormatVersion = "raftSyncSnapFormatVersion" //int, format version of snapshot that raft leader sent to follower
+	cfgServiceIDKey              = "serviceIDKey"
 
 	metaNodeDeleteBatchCountKey = "batchCount"
 	configNameResolveInterval   = "nameResolveInterval" // int

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -74,6 +74,7 @@ type MetaNode struct {
 	connectionCnt             int64
 	clusterUuid               string
 	clusterUuidEnable         bool
+	serviceIDKey              string
 
 	control common.Control
 }
@@ -214,6 +215,8 @@ func (m *MetaNode) parseConfig(cfg *config.Config) (err error) {
 	if deleteBatchCount > 1 {
 		updateDeleteBatchCount(uint64(deleteBatchCount))
 	}
+
+	m.serviceIDKey = cfg.GetString(cfgServiceIDKey)
 
 	total, _, err := util.GetMemInfo()
 	if err != nil {
@@ -461,7 +464,7 @@ func (m *MetaNode) register() (err error) {
 			step++
 		}
 		var nodeID uint64
-		if nodeID, err = masterClient.NodeAPI().AddMetaNode(nodeAddress, m.zoneName); err != nil {
+		if nodeID, err = masterClient.NodeAPI().AddMetaNodeWithAuthNode(nodeAddress, m.zoneName, m.serviceIDKey); err != nil {
 			log.LogErrorf("register: register to master fail: address(%v) err(%s)", nodeAddress, err)
 			time.Sleep(3 * time.Second)
 			continue

--- a/proto/auth_proto.go
+++ b/proto/auth_proto.go
@@ -198,6 +198,74 @@ const (
 
 	//Master API ClientVol
 	MsgMasterFetchVolViewReq MsgType = MsgMasterAPIAccessReq + 0x10000
+
+	//Master API cluster management
+	MsgMasterClusterFreezeReq    MsgType = MsgMasterAPIAccessReq + 0x20100
+	MsgMasterAddRaftNodeReq      MsgType = MsgMasterAPIAccessReq + 0x20200
+	MsgMasterRemoveRaftNodeReq   MsgType = MsgMasterAPIAccessReq + 0x20300
+	MsgMasterSetNodeInfoReq      MsgType = MsgMasterAPIAccessReq + 0x20400
+	MsgMasterSetNodeRdOnlyReq    MsgType = MsgMasterAPIAccessReq + 0x20500
+	MsgMasterAutoDecommissionReq MsgType = MsgMasterAPIAccessReq + 0x20600
+
+	// Master API volume management
+	MsgMasterCreateVolReq MsgType = MsgMasterAPIAccessReq + 0x30100
+	MsgMasterDeleteVolReq MsgType = MsgMasterAPIAccessReq + 0x30200
+	MsgMasterUpdateVolReq MsgType = MsgMasterAPIAccessReq + 0x30300
+	MsgMasterVolShrinkReq MsgType = MsgMasterAPIAccessReq + 0x30400
+	MsgMasterVolExpandReq MsgType = MsgMasterAPIAccessReq + 0x30500
+
+	// Master API meta partition management
+	MsgMasterLoadMetaPartitionReq         MsgType = MsgMasterAPIAccessReq + 0x40100
+	MsgMasterDecommissionMetaPartitionReq MsgType = MsgMasterAPIAccessReq + 0x40200
+	MsgMasterChangeMetaPartitionLeaderReq MsgType = MsgMasterAPIAccessReq + 0x40300
+	MsgMasterCreateMetaPartitionReq       MsgType = MsgMasterAPIAccessReq + 0x40400
+	MsgMasterAddMetaReplicaReq            MsgType = MsgMasterAPIAccessReq + 0x40500
+	MsgMasterDeleteMetaReplicaReq         MsgType = MsgMasterAPIAccessReq + 0x40600
+	MsgMasterQosUpdateReq                 MsgType = MsgMasterAPIAccessReq + 0x40700
+	MsgMasterQosUpdateZoneLimitReq        MsgType = MsgMasterAPIAccessReq + 0x40800
+	MsgMasterQosUpdateMasterLimitReq      MsgType = MsgMasterAPIAccessReq + 0x40900
+	MsgMasterQosUpdateClientParamReq      MsgType = MsgMasterAPIAccessReq + 0x40a00
+
+	// Master API data partition management
+	MsgMasterCreateDataPartitionReq       MsgType = MsgMasterAPIAccessReq + 0x50100
+	MsgMasterDataPartitionChangeLeaderReq MsgType = MsgMasterAPIAccessReq + 0x50200
+	MsgMasterLoadDataPartitionReq         MsgType = MsgMasterAPIAccessReq + 0x50300
+	MsgMasterDecommissionDataPartitionReq MsgType = MsgMasterAPIAccessReq + 0x50400
+	MsgMasterAddDataReplicaReq            MsgType = MsgMasterAPIAccessReq + 0x50500
+	MsgMasterDeleteDataReplicaReq         MsgType = MsgMasterAPIAccessReq + 0x50600
+	MsgMasterSetDpRdOnlyReq               MsgType = MsgMasterAPIAccessReq + 0x50700
+	MsgMasterReportLackDataPartitions     MsgType = MsgMasterAPIAccessReq + 0x50800
+
+	// Master API meta node management
+	MsgMasterAddMetaNodeReq          MsgType = MsgMasterAPIAccessReq + 0x60100
+	MsgMasterDecommissionMetaNodeReq MsgType = MsgMasterAPIAccessReq + 0x60200
+	MsgMasterMigrateMetaNodeReq      MsgType = MsgMasterAPIAccessReq + 0x60300
+	MsgMasterSetMetaNodeThresholdReq MsgType = MsgMasterAPIAccessReq + 0x60400
+	MsgMasterUpdateMetaNodeReq       MsgType = MsgMasterAPIAccessReq + 0x60500
+
+	// Master API data node management
+	MsgMasterAddDataNodeReq                MsgType = MsgMasterAPIAccessReq + 0x70100
+	MsgMasterDecommissionDataNodeReq       MsgType = MsgMasterAPIAccessReq + 0x70200
+	MsgMasterMigrateDataNodeReq            MsgType = MsgMasterAPIAccessReq + 0x70300
+	MsgMasterCancelDecommissionDataNodeReq MsgType = MsgMasterAPIAccessReq + 0x70400
+	MsgMasterDecommissionDiskReq           MsgType = MsgMasterAPIAccessReq + 0x70500
+	MsgMasterUpdateNodeSetCapcityReq       MsgType = MsgMasterAPIAccessReq + 0x70600
+	MsgMasterUpdateNodeSetIdReq            MsgType = MsgMasterAPIAccessReq + 0x70700
+	MsgMasterUpdateDomainDataUseRatioReq   MsgType = MsgMasterAPIAccessReq + 0x70800
+	MsgMasterUpdateZoneExcludeRatioReq     MsgType = MsgMasterAPIAccessReq + 0x70900
+	MsgMasterRecommissionDiskReq           MsgType = MsgMasterAPIAccessReq + 0x70a00
+
+	// Master API user management
+	MsgMasterUserCreateReq          MsgType = MsgMasterAPIAccessReq + 0x80100
+	MsgMasterUserDeleteReq          MsgType = MsgMasterAPIAccessReq + 0x80200
+	MsgMasterUserUpdateReq          MsgType = MsgMasterAPIAccessReq + 0x80300
+	MsgMasterUserUpdatePolicyReq    MsgType = MsgMasterAPIAccessReq + 0x80400
+	MsgMasterUserRemovePolicyReq    MsgType = MsgMasterAPIAccessReq + 0x80500
+	MsgMasterUserDeleteVolPolicyReq MsgType = MsgMasterAPIAccessReq + 0x80600
+	MsgMasterUserTransferVolReq     MsgType = MsgMasterAPIAccessReq + 0x80700
+
+	// Master API zone management
+	MsgMasterUpdateZoneReq MsgType = MsgMasterAPIAccessReq + 0x90100
 )
 
 // HTTPAuthReply uniform response structure
@@ -222,6 +290,74 @@ var MsgType2ResourceMap = map[MsgType]string{
 	MsgAuthOSGetCapsReq:      "auth:osgetcaps",
 
 	MsgMasterFetchVolViewReq: "master:getvol",
+
+	//Master API cluster management
+	MsgMasterClusterFreezeReq:    "master:clusterfreeze",
+	MsgMasterAddRaftNodeReq:      "master:addraftnode",
+	MsgMasterRemoveRaftNodeReq:   "master:removeraftnode",
+	MsgMasterSetNodeInfoReq:      "master:setnodeinfo",
+	MsgMasterSetNodeRdOnlyReq:    "master:sernoderdonly",
+	MsgMasterAutoDecommissionReq: "master:autodecommission",
+
+	// Master API volume management
+	MsgMasterCreateVolReq: "master:createvol",
+	MsgMasterDeleteVolReq: "master:deletevol",
+	MsgMasterUpdateVolReq: "master:updatevol",
+	MsgMasterVolShrinkReq: "master:volshrink",
+	MsgMasterVolExpandReq: "master:volexpand",
+
+	// Master API meta partition management
+	MsgMasterLoadMetaPartitionReq:         "master:loadmetapartition",
+	MsgMasterDecommissionMetaPartitionReq: "master:decommissionmetapartition",
+	MsgMasterChangeMetaPartitionLeaderReq: "master:changemetapartitionleader",
+	MsgMasterCreateMetaPartitionReq:       "master:createmetapartition",
+	MsgMasterAddMetaReplicaReq:            "master:addmetareplica",
+	MsgMasterDeleteMetaReplicaReq:         "master:deletemetareplica",
+	MsgMasterQosUpdateReq:                 "master:qosupdate",
+	MsgMasterQosUpdateZoneLimitReq:        "master:qosupdatezonelimit",
+	MsgMasterQosUpdateMasterLimitReq:      "master:qosupdatemasterlimit",
+	MsgMasterQosUpdateClientParamReq:      "master:qosupdateclientparam",
+
+	// Master API data partition management
+	MsgMasterCreateDataPartitionReq:       "master:createdatapartition",
+	MsgMasterDataPartitionChangeLeaderReq: "master:changedatapartitionleader",
+	MsgMasterLoadDataPartitionReq:         "master:loaddatapartition",
+	MsgMasterDecommissionDataPartitionReq: "master:decommissiondatapartition",
+	MsgMasterAddDataReplicaReq:            "master:adddatareplica",
+	MsgMasterDeleteDataReplicaReq:         "master:removedatareplica",
+	MsgMasterSetDpRdOnlyReq:               "master:setdprdonly",
+	MsgMasterReportLackDataPartitions:     "master:reportLackDataPartitions",
+
+	// Master API meta node management
+	MsgMasterAddMetaNodeReq:          "master:addmetanode",
+	MsgMasterDecommissionMetaNodeReq: "master:decommissionmetanode",
+	MsgMasterMigrateMetaNodeReq:      "master:migratemetanode",
+	MsgMasterSetMetaNodeThresholdReq: "master:setmetanodethreshold",
+	MsgMasterUpdateMetaNodeReq:       "master:updatemetanode",
+
+	// Master API data node management
+	MsgMasterAddDataNodeReq:                "master:adddatannode",
+	MsgMasterDecommissionDataNodeReq:       "master:decommissiondatannode",
+	MsgMasterMigrateDataNodeReq:            "master:migratedatannode",
+	MsgMasterCancelDecommissionDataNodeReq: "master:canceldecommissiondatannode",
+	MsgMasterDecommissionDiskReq:           "master:decommissiondisk",
+	MsgMasterUpdateNodeSetCapcityReq:       "master:updatenodesetcapcity",
+	MsgMasterUpdateNodeSetIdReq:            "master:updatenodesetid",
+	MsgMasterUpdateDomainDataUseRatioReq:   "master:updatedomaindatauseratio",
+	MsgMasterUpdateZoneExcludeRatioReq:     "master:updatezoneexcluderatio",
+	MsgMasterRecommissionDiskReq:           "master:recommissiondisk",
+
+	// Master API user management
+	MsgMasterUserCreateReq:          "master:usercreate",
+	MsgMasterUserDeleteReq:          "master:userdelete",
+	MsgMasterUserUpdateReq:          "master:userupdate",
+	MsgMasterUserUpdatePolicyReq:    "master:userupdatepolicy",
+	MsgMasterUserRemovePolicyReq:    "master:userremotepolicy",
+	MsgMasterUserDeleteVolPolicyReq: "master:userdeletevolpolicy",
+	MsgMasterUserTransferVolReq:     "master:usertransfervol",
+
+	// Master API zone management
+	MsgMasterUpdateZoneReq: "master:updatezone",
 }
 
 // AuthGetTicketReq defines the message from client to authnode
@@ -273,8 +409,9 @@ type AuthAPIAccessReq struct {
 
 // AuthAPIAccessResp defines the response for creating an key in authnode
 type AuthAPIAccessResp struct {
-	APIResp APIAccessResp    `json:"api_resp"`
-	KeyInfo keystore.KeyInfo `json:"key_info"`
+	APIResp   APIAccessResp    `json:"api_resp"`
+	KeyInfo   keystore.KeyInfo `json:"key_info"`
+	AuthIDKey string           `json:"auth_id_key"`
 }
 
 // AuthRaftNodeInfo defines raft node information
@@ -538,6 +675,45 @@ func CheckAPIAccessCaps(ticket *cryptoutil.Ticket, rscType string, mp MsgType, a
 		err = fmt.Errorf("checkTicketCaps failed: %s", err.Error())
 		return
 	}
+	return
+}
+
+func GenAuthIDKey(id string, authKey []byte) (authIDKey string, err error) {
+	type AuthIDKey struct {
+		ID      string `json:"id"`
+		AuthKey []byte `json:"auth_key"`
+	}
+	tmpAuthIDKey := AuthIDKey{
+		ID:      id,
+		AuthKey: authKey,
+	}
+	var jAuthIDKey []byte
+	if jAuthIDKey, err = json.Marshal(tmpAuthIDKey); err != nil {
+		err = fmt.Errorf("json marshal authIDKey failed %s", err.Error())
+		return
+	}
+	authIDKey = cryptoutil.Base64Encode(jAuthIDKey)
+	return
+}
+
+func ExtractIDAndAuthKey(authIDKey string) (id string, authKey []byte, err error) {
+	type AuthIDKey struct {
+		ID      string `json:"id"`
+		AuthKey string `json:"auth_key"`
+	}
+	var jAuthIDKey []byte
+	jAuthIDKey, err = cryptoutil.Base64Decode(authIDKey)
+	if err != nil {
+		err = fmt.Errorf("decode authIDKey failed %s", err.Error())
+		return
+	}
+	tmpAuthIDKey := &AuthIDKey{}
+	if err = json.Unmarshal(jAuthIDKey, &tmpAuthIDKey); err != nil {
+		err = fmt.Errorf("json unmarshal authIDKey failed %s", err.Error())
+		return
+	}
+	id = tmpAuthIDKey.ID
+	authKey = []byte(tmpAuthIDKey.AuthKey)
 	return
 }
 

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -16,7 +16,7 @@ package proto
 
 import "github.com/cubefs/cubefs/util/errors"
 
-//err
+// err
 var (
 	ErrSuc                    = errors.New("success")
 	ErrInternalError          = errors.New("internal error")
@@ -63,6 +63,7 @@ var (
 	ErrDuplicateKey                            = errors.New("duplicate key")
 	ErrAccessKeyNotExists                      = errors.New("access key not exists")
 	ErrInvalidTicket                           = errors.New("invalid ticket")
+	ErrInvalidClientIDKey                      = errors.New("invalid clientIDKey")
 	ErrExpiredTicket                           = errors.New("expired ticket")
 	ErrMasterAPIGenRespError                   = errors.New("master API generate response error")
 	ErrDuplicateUserID                         = errors.New("duplicate user id")
@@ -133,6 +134,7 @@ const (
 	ErrCodeAuthReqRedirectError
 	ErrCodeAccessKeyNotExists
 	ErrCodeInvalidTicket
+	ErrCodeInvalidClientIDKey
 	ErrCodeExpiredTicket
 	ErrCodeMasterAPIGenRespError
 	ErrCodeDuplicateUserID
@@ -196,6 +198,7 @@ var Err2CodeMap = map[error]int32{
 	ErrAuthOSCapsOpGenRespError:        ErrCodeAuthOSCapsOpGenRespError,
 	ErrAccessKeyNotExists:              ErrCodeAccessKeyNotExists,
 	ErrInvalidTicket:                   ErrCodeInvalidTicket,
+	ErrInvalidClientIDKey:              ErrCodeInvalidClientIDKey,
 	ErrExpiredTicket:                   ErrCodeExpiredTicket,
 	ErrMasterAPIGenRespError:           ErrCodeMasterAPIGenRespError,
 	ErrDuplicateUserID:                 ErrCodeDuplicateUserID,
@@ -265,6 +268,7 @@ var code2ErrMap = map[int32]error{
 	ErrCodeAuthOSCapsOpGenRespError:        ErrAuthOSCapsOpGenRespError,
 	ErrCodeAccessKeyNotExists:              ErrAccessKeyNotExists,
 	ErrCodeInvalidTicket:                   ErrInvalidTicket,
+	ErrCodeInvalidClientIDKey:              ErrInvalidClientIDKey,
 	ErrCodeExpiredTicket:                   ErrExpiredTicket,
 	ErrCodeMasterAPIGenRespError:           ErrMasterAPIGenRespError,
 	ErrCodeDuplicateUserID:                 ErrDuplicateUserID,

--- a/sdk/auth/client.go
+++ b/sdk/auth/client.go
@@ -65,7 +65,8 @@ func (c *AuthClient) request(clientID, clientKey string, key []byte, data interf
 	if c.enableHTTPS {
 		urlProto = "https://"
 		if certFile, err = loadCertfile(c.certFile); err != nil {
-			log.LogWarnf("load cert file failed: %v", err)
+			err = fmt.Errorf("load cert file failed: %v, certFile[%v]", err, c.certFile)
+			log.LogWarnf("%v", err)
 			return
 		}
 		client, err = cryptoutil.CreateClientX(&certFile)

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -171,81 +171,89 @@ func (api *AdminAPI) DiagnoseMetaPartition() (diagnosis *proto.MetaPartitionDiag
 	return
 }
 
-func (api *AdminAPI) LoadDataPartition(volName string, partitionID uint64) (err error) {
+func (api *AdminAPI) LoadDataPartition(volName string, partitionID uint64, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminLoadDataPartition)
 	request.addParam("id", strconv.Itoa(int(partitionID)))
 	request.addParam("name", volName)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) CreateDataPartition(volName string, count int) (err error) {
+func (api *AdminAPI) CreateDataPartition(volName string, count int, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminCreateDataPartition)
 	request.addParam("name", volName)
 	request.addParam("count", strconv.Itoa(count))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) DecommissionDataPartition(dataPartitionID uint64, nodeAddr string, raftForce bool) (err error) {
+func (api *AdminAPI) DecommissionDataPartition(dataPartitionID uint64, nodeAddr string, raftForce bool, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminDecommissionDataPartition)
 	request.addParam("id", strconv.FormatUint(dataPartitionID, 10))
 	request.addParam("addr", nodeAddr)
 	request.addParam("raftForceDel", strconv.FormatBool(raftForce))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) DecommissionMetaPartition(metaPartitionID uint64, nodeAddr string) (err error) {
+func (api *AdminAPI) DecommissionMetaPartition(metaPartitionID uint64, nodeAddr, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminDecommissionMetaPartition)
 	request.addParam("id", strconv.FormatUint(metaPartitionID, 10))
 	request.addParam("addr", nodeAddr)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) DeleteDataReplica(dataPartitionID uint64, nodeAddr string) (err error) {
+func (api *AdminAPI) DeleteDataReplica(dataPartitionID uint64, nodeAddr, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminDeleteDataReplica)
 	request.addParam("id", strconv.FormatUint(dataPartitionID, 10))
 	request.addParam("addr", nodeAddr)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) AddDataReplica(dataPartitionID uint64, nodeAddr string) (err error) {
+func (api *AdminAPI) AddDataReplica(dataPartitionID uint64, nodeAddr, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminAddDataReplica)
 	request.addParam("id", strconv.FormatUint(dataPartitionID, 10))
 	request.addParam("addr", nodeAddr)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) DeleteMetaReplica(metaPartitionID uint64, nodeAddr string) (err error) {
+func (api *AdminAPI) DeleteMetaReplica(metaPartitionID uint64, nodeAddr string, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminDeleteMetaReplica)
 	request.addParam("id", strconv.FormatUint(metaPartitionID, 10))
 	request.addParam("addr", nodeAddr)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) AddMetaReplica(metaPartitionID uint64, nodeAddr string) (err error) {
+func (api *AdminAPI) AddMetaReplica(metaPartitionID uint64, nodeAddr string, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminAddMetaReplica)
 	request.addParam("id", strconv.FormatUint(metaPartitionID, 10))
 	request.addParam("addr", nodeAddr)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -262,6 +270,17 @@ func (api *AdminAPI) DeleteVolume(volName, authKey string) (err error) {
 	return
 }
 
+func (api *AdminAPI) DeleteVolumeWithAuthNode(volName, authKey, clientIDKey string) (err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminDeleteVol)
+	request.addParam("name", volName)
+	request.addParam("authKey", authKey)
+	request.addParam("clientIDKey", clientIDKey)
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) UpdateVolume(
 	vv *proto.SimpleVolView,
 	txTimeout int64,
@@ -269,7 +288,8 @@ func (api *AdminAPI) UpdateVolume(
 	txForceReset bool,
 	txConflictRetryNum int64,
 	txConflictRetryInterval int64,
-	txOpLimit int) (err error) {
+	txOpLimit int,
+	clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminUpdateVol)
 	request.addParam("name", vv.Name)
 	request.addParam("description", vv.Description)
@@ -290,6 +310,7 @@ func (api *AdminAPI) UpdateVolume(
 	request.addParam("replicaNum", strconv.FormatUint(uint64(vv.DpReplicaNum), 10))
 	request.addParam("enableQuota", strconv.FormatBool(vv.EnableQuota))
 	request.addParam("deleteLockTime", strconv.FormatInt(vv.DeleteLockTime, 10))
+	request.addParam("clientIDKey", clientIDKey)
 
 	if txMask != "" {
 		request.addParam("enableTxMask", txMask)
@@ -329,22 +350,24 @@ func (api *AdminAPI) PutDataPartitions(volName string, dpsView []byte) (err erro
 	return
 }
 
-func (api *AdminAPI) VolShrink(volName string, capacity uint64, authKey string) (err error) {
+func (api *AdminAPI) VolShrink(volName string, capacity uint64, authKey, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminVolShrink)
 	request.addParam("name", volName)
 	request.addParam("authKey", authKey)
 	request.addParam("capacity", strconv.FormatUint(capacity, 10))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey string) (err error) {
+func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminVolExpand)
 	request.addParam("name", volName)
 	request.addParam("authKey", authKey)
 	request.addParam("capacity", strconv.FormatUint(capacity, 10))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -354,7 +377,8 @@ func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey string) 
 func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, deleteLockTime int64, crossZone, normalZonesFirst bool, business string,
 	mpCount, replicaNum, size, volType int, followerRead bool, zoneName, cacheRuleKey string, ebsBlkSize,
 	cacheCapacity, cacheAction, cacheThreshold, cacheTTL, cacheHighWater, cacheLowWater, cacheLRUInterval int,
-	dpReadOnlyWhenVolFull bool, txMask string, txTimeout uint32, txConflictRetryNum int64, txConflictRetryInterval int64, optEnableQuota string) (err error) {
+	dpReadOnlyWhenVolFull bool, txMask string, txTimeout uint32, txConflictRetryNum int64, txConflictRetryInterval int64, optEnableQuota string,
+	clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminCreateVol)
 	request.addParam("name", volName)
 	request.addParam("owner", owner)
@@ -380,6 +404,7 @@ func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, delet
 	request.addParam("cacheLRUInterval", strconv.Itoa(cacheLRUInterval))
 	request.addParam("dpReadOnlyWhenVolFull", strconv.FormatBool(dpReadOnlyWhenVolFull))
 	request.addParam("enableQuota", optEnableQuota)
+	request.addParam("clientIDKey", clientIDKey)
 	if txMask != "" {
 		request.addParam("enableTxMask", txMask)
 	}
@@ -499,10 +524,11 @@ func (api *AdminAPI) GetClusterInfo() (ci *proto.ClusterInfo, err error) {
 	return
 }
 
-func (api *AdminAPI) CreateMetaPartition(volName string, inodeStart uint64) (err error) {
+func (api *AdminAPI) CreateMetaPartition(volName string, inodeStart uint64, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminCreateMetaPartition)
 	request.addParam("name", volName)
 	request.addParam("start", strconv.FormatUint(inodeStart, 10))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -523,9 +549,10 @@ func (api *AdminAPI) ListVols(keywords string) (volsInfo []*proto.VolInfo, err e
 	return
 }
 
-func (api *AdminAPI) IsFreezeCluster(isFreeze bool) (err error) {
+func (api *AdminAPI) IsFreezeCluster(isFreeze bool, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminClusterFreeze)
 	request.addParam("enable", strconv.FormatBool(isFreeze))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
@@ -541,16 +568,18 @@ func (api *AdminAPI) SetForbidMpDecommission(disable bool) (err error) {
 	return
 }
 
-func (api *AdminAPI) SetMetaNodeThreshold(threshold float64) (err error) {
+func (api *AdminAPI) SetMetaNodeThreshold(threshold float64, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminSetMetaNodeThreshold)
 	request.addParam("threshold", strconv.FormatFloat(threshold, 'f', 6, 64))
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate, loadFactor, maxDpCntLimit string) (err error) {
+func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate,
+	loadFactor, maxDpCntLimit, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminSetNodeInfo)
 	request.addParam("batchCount", batchCount)
 	request.addParam("markDeleteRate", markDeleteRate)
@@ -558,6 +587,7 @@ func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSle
 	request.addParam("autoRepairRate", autoRepairRate)
 	request.addParam("loadFactor", loadFactor)
 	request.addParam("maxDpCntLimit", maxDpCntLimit)
+	request.addParam("clientIDKey", clientIDKey)
 
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return

--- a/sdk/master/api_node.go
+++ b/sdk/master/api_node.go
@@ -38,10 +38,36 @@ func (api *NodeAPI) AddDataNode(serverAddr, zoneName string) (id uint64, err err
 	return
 }
 
+func (api *NodeAPI) AddDataNodeWithAuthNode(serverAddr, zoneName, clientIDKey string) (id uint64, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AddDataNode)
+	request.addParam("addr", serverAddr)
+	request.addParam("zoneName", zoneName)
+	request.addParam("clientIDKey", clientIDKey)
+	var data []byte
+	if data, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	id, err = strconv.ParseUint(string(data), 10, 64)
+	return
+}
+
 func (api *NodeAPI) AddMetaNode(serverAddr, zoneName string) (id uint64, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AddMetaNode)
 	request.addParam("addr", serverAddr)
 	request.addParam("zoneName", zoneName)
+	var data []byte
+	if data, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	id, err = strconv.ParseUint(string(data), 10, 64)
+	return
+}
+
+func (api *NodeAPI) AddMetaNodeWithAuthNode(serverAddr, zoneName, clientIDKey string) (id uint64, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AddMetaNode)
+	request.addParam("addr", serverAddr)
+	request.addParam("zoneName", zoneName)
+	request.addParam("clientIDKey", clientIDKey)
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -105,10 +131,11 @@ func (api *NodeAPI) ResponseDataNodeTask(task *proto.AdminTask) (err error) {
 	return
 }
 
-func (api *NodeAPI) DataNodeDecommission(nodeAddr string, count int) (err error) {
+func (api *NodeAPI) DataNodeDecommission(nodeAddr string, count int, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.DecommissionDataNode)
 	request.addParam("addr", nodeAddr)
 	request.addParam("count", strconv.Itoa(count))
+	request.addParam("clientIDKey", clientIDKey)
 	request.addHeader("isTimeOut", "false")
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -116,34 +143,37 @@ func (api *NodeAPI) DataNodeDecommission(nodeAddr string, count int) (err error)
 	return
 }
 
-func (api *NodeAPI) MetaNodeDecommission(nodeAddr string, count int) (err error) {
+func (api *NodeAPI) MetaNodeDecommission(nodeAddr string, count int, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.DecommissionMetaNode)
 	request.addParam("addr", nodeAddr)
 	request.addParam("count", strconv.Itoa(count))
 	request.addHeader("isTimeOut", "false")
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *NodeAPI) MetaNodeMigrate(srcAddr, targetAddr string, count int) (err error) {
+func (api *NodeAPI) MetaNodeMigrate(srcAddr, targetAddr string, count int, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.MigrateMetaNode)
 	request.addParam("srcAddr", srcAddr)
 	request.addParam("targetAddr", targetAddr)
 	request.addParam("count", strconv.Itoa(count))
 	request.addHeader("isTimeOut", "false")
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *NodeAPI) DataNodeMigrate(srcAddr, targetAddr string, count int) (err error) {
+func (api *NodeAPI) DataNodeMigrate(srcAddr, targetAddr string, count int, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodGet, proto.MigrateDataNode)
 	request.addParam("srcAddr", srcAddr)
 	request.addParam("targetAddr", targetAddr)
 	request.addParam("count", strconv.Itoa(count))
+	request.addParam("clientIDKey", clientIDKey)
 	request.addHeader("isTimeOut", "false")
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return

--- a/sdk/master/api_user.go
+++ b/sdk/master/api_user.go
@@ -15,8 +15,9 @@ type UserAPI struct {
 	mc *MasterClient
 }
 
-func (api *UserAPI) CreateUser(param *proto.UserCreateParam) (userInfo *proto.UserInfo, err error) {
+func (api *UserAPI) CreateUser(param *proto.UserCreateParam, clientIDKey string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserCreate)
+	request.addParam("clientIDKey", clientIDKey)
 	var reqBody []byte
 	if reqBody, err = json.Marshal(param); err != nil {
 		return
@@ -33,17 +34,19 @@ func (api *UserAPI) CreateUser(param *proto.UserCreateParam) (userInfo *proto.Us
 	return
 }
 
-func (api *UserAPI) DeleteUser(userID string) (err error) {
+func (api *UserAPI) DeleteUser(userID string, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserDelete)
 	request.addParam("user", userID)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *UserAPI) UpdateUser(param *proto.UserUpdateParam) (userInfo *proto.UserInfo, err error) {
+func (api *UserAPI) UpdateUser(param *proto.UserUpdateParam, clientIDKey string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserUpdate)
+	request.addParam("clientIDKey", clientIDKey)
 	var reqBody []byte
 	if reqBody, err = json.Marshal(param); err != nil {
 		return
@@ -129,8 +132,9 @@ func (api *UserAPI) GetUserInfo(userID string) (userInfo *proto.UserInfo, err er
 	return
 }
 
-func (api *UserAPI) UpdatePolicy(param *proto.UserPermUpdateParam) (userInfo *proto.UserInfo, err error) {
+func (api *UserAPI) UpdatePolicy(param *proto.UserPermUpdateParam, clientIDKey string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserUpdatePolicy)
+	request.addParam("clientIDKey", clientIDKey)
 	var reqBody []byte
 	if reqBody, err = json.Marshal(param); err != nil {
 		return
@@ -147,8 +151,9 @@ func (api *UserAPI) UpdatePolicy(param *proto.UserPermUpdateParam) (userInfo *pr
 	return
 }
 
-func (api *UserAPI) RemovePolicy(param *proto.UserPermRemoveParam) (userInfo *proto.UserInfo, err error) {
+func (api *UserAPI) RemovePolicy(param *proto.UserPermRemoveParam, clientIDKey string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserRemovePolicy)
+	request.addParam("clientIDKey", clientIDKey)
 	var reqBody []byte
 	if reqBody, err = json.Marshal(param); err != nil {
 		return
@@ -165,17 +170,19 @@ func (api *UserAPI) RemovePolicy(param *proto.UserPermRemoveParam) (userInfo *pr
 	return
 }
 
-func (api *UserAPI) DeleteVolPolicy(vol string) (err error) {
+func (api *UserAPI) DeleteVolPolicy(vol, clientIDKey string) (err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserDeleteVolPolicy)
 	request.addParam("name", vol)
+	request.addParam("clientIDKey", clientIDKey)
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}
 	return
 }
 
-func (api *UserAPI) TransferVol(param *proto.UserTransferVolParam) (userInfo *proto.UserInfo, err error) {
+func (api *UserAPI) TransferVol(param *proto.UserTransferVolParam, clientIDKey string) (userInfo *proto.UserInfo, err error) {
 	var request = newAPIRequest(http.MethodPost, proto.UserTransferVol)
+	request.addParam("clientIDKey", clientIDKey)
 	var reqBody []byte
 	if reqBody, err = json.Marshal(param); err != nil {
 		return

--- a/sdk/master/client.go
+++ b/sdk/master/client.go
@@ -47,10 +47,11 @@ type MasterCLientWithResolver struct {
 
 type MasterClient struct {
 	sync.RWMutex
-	masters    []string
-	useSSL     bool
-	leaderAddr string
-	timeout    time.Duration
+	masters     []string
+	useSSL      bool
+	leaderAddr  string
+	timeout     time.Duration
+	clientIDKey string
 
 	adminAPI  *AdminAPI
 	clientAPI *ClientAPI
@@ -80,6 +81,10 @@ func (c *MasterClient) Leader() (addr string) {
 	return
 }
 
+func (c *MasterClient) ClientIDKey() string {
+	return c.clientIDKey
+}
+
 func (c *MasterClient) AdminAPI() *AdminAPI {
 	return c.adminAPI
 }
@@ -107,6 +112,12 @@ func (c *MasterClient) SetLeader(addr string) {
 func (c *MasterClient) SetTimeout(timeout uint16) {
 	c.Lock()
 	c.timeout = time.Duration(timeout) * time.Second
+	c.Unlock()
+}
+
+func (c *MasterClient) SetClientIDKey(clientIDKey string) {
+	c.Lock()
+	c.clientIDKey = clientIDKey
 	c.Unlock()
 }
 

--- a/util/keystore/keystore.go
+++ b/util/keystore/keystore.go
@@ -27,11 +27,11 @@ type KeyInfo struct {
 }
 
 // DumpJSONFile dump KeyInfo to file in json format
-func (u *KeyInfo) DumpJSONFile(filename string) (err error) {
+func (u *KeyInfo) DumpJSONFile(filename string, authIdKey string) (err error) {
 	var (
 		data string
 	)
-	if data, err = u.DumpJSONStr(); err != nil {
+	if data, err = u.DumpJSONStr(authIdKey); err != nil {
 		return
 	}
 
@@ -49,7 +49,7 @@ func (u *KeyInfo) DumpJSONFile(filename string) (err error) {
 }
 
 // DumpJSONStr dump KeyInfo to string in json format
-func (u *KeyInfo) DumpJSONStr() (r string, err error) {
+func (u *KeyInfo) DumpJSONStr(authIdKey string) (r string, err error) {
 	dumpInfo := struct {
 		ID        string `json:"id"`
 		AuthKey   []byte `json:"auth_key"`
@@ -58,6 +58,7 @@ func (u *KeyInfo) DumpJSONStr() (r string, err error) {
 		Ts        int64  `json:"create_ts"`
 		Role      string `json:"role"`
 		Caps      string `json:"caps"`
+		AuthIdKey string `json:"auth_id_key"`
 	}{
 		u.ID,
 		u.AuthKey,
@@ -66,6 +67,7 @@ func (u *KeyInfo) DumpJSONStr() (r string, err error) {
 		u.Ts,
 		u.Role,
 		string(u.Caps),
+		authIdKey,
 	}
 	data, err := json.MarshalIndent(dumpInfo, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Currently, the config of the fuse client has the master address, and some body can send http requests to the master through this address, including deleting mp/dp whitout permission control.

We should add more permission control to the following http requests which can manage cluster:
//Master API cluster management
proto.AdminClusterFreeze
proto.AddRaftNode
proto.RemoveRaftNode
proto.AdminSetNodeInfo
proto.AdminSetNodeRdOnly

// Master API volume management
proto.AdminCreateVol
proto.AdminDeleteVol
proto.AdminUpdateVol
proto.AdminVolShrink
proto.AdminVolExpand

// Master API meta partition management
proto.AdminLoadMetaPartition
proto.AdminDecommissionMetaPartition
proto.AdminChangeMetaPartitionLeader
proto.AdminCreateMetaPartition
proto.AdminAddMetaReplica
proto.AdminDeleteMetaReplica
proto.QosUpdate
proto.QosUpdateZoneLimit
proto.QosUpdateMasterLimit
proto.QosUpdateClientParam

// Master API data partition management
proto.AdminCreateDataPartition
proto.AdminDataPartitionChangeLeader
proto.AdminLoadDataPartition
proto.AdminDecommissionDataPartition
proto.AdminAddDataReplica
proto.AdminDeleteDataReplica
proto.AdminSetDpRdOnly

// Master API meta node management
proto.AddMetaNode
proto.DecommissionMetaNode
proto.MigrateMetaNode
proto.AdminSetMetaNodeThreshold
proto.AdminUpdateMetaNode

// Master API data node management
proto.AddDataNode
proto.DecommissionDataNode
proto.MigrateDataNode
proto.CancelDecommissionDataNode
proto.DecommissionDisk
proto.AdminUpdateNodeSetCapcity
proto.AdminUpdateNodeSetId
proto.AdminUpdateDomainDataUseRatio
proto.AdminUpdateZoneExcludeRatio
proto.RecommissionDisk

// Master API user management
proto.UserCreate
proto.UserDelete
proto.UserUpdate
proto.UserUpdatePolicy
proto.UserRemovePolicy
proto.UserDeleteVolPolicy
proto.UserTransferVol

// Master API zone management
proto.UpdateZone

Base on the origin auth node framework, the authentication process is represented below.
![authentication_process](https://user-images.githubusercontent.com/44452470/227422813-82c031a3-ee4c-4e22-80b8-29cb0e08814c.png)


