### PR TITLE
 Feature: add ClusterUUID for mn/dn to identify a cluster upon restart

### DIFF
--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -515,6 +515,13 @@ func (s *DataNode) startRaftServer(cfg *config.Config) (err error) {
 
 	s.parseRaftConfig(cfg)
 
+	if s.clusterUuidEnable {
+		if err = config.CheckOrStoreClusterUuid(s.raftDir, s.clusterUuid, false); err != nil {
+			log.LogErrorf("CheckOrStoreClusterUuid failed: %v", err)
+			return fmt.Errorf("CheckOrStoreClusterUuid failed: %v", err)
+		}
+	}
+
 	constCfg := config.ConstConfig{
 		Listen:           s.port,
 		RaftHeartbetPort: s.raftHeartbeat,

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	masterSDK "github.com/cubefs/cubefs/sdk/master"
+	"github.com/google/uuid"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -76,6 +77,8 @@ type Cluster struct {
 	masterClient                 *masterSDK.MasterClient
 	checkDataReplicasEnable      bool
 	fileStatsEnable              bool
+	clusterUuid                  string
+	clusterUuidEnable            bool
 }
 
 type followerReadManager struct {
@@ -3437,4 +3440,15 @@ func mergeDataPartitionArr(newDps, oldDps []*DataPartition) []*DataPartition {
 		}
 	}
 	return ret
+}
+
+func (c *Cluster) generateClusterUuid() (err error) {
+	cid := "CID-" + uuid.NewString()
+	c.clusterUuid = cid
+	if err := c.syncPutCluster(); err != nil {
+		c.clusterUuid = ""
+		return errors.NewErrorf(fmt.Sprintf("syncPutCluster failed %v", err.Error()))
+
+	}
+	return
 }

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -195,6 +195,15 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.AdminGetFileStats).
 		HandlerFunc(m.getFileStats)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminSetClusterUuidEnable).
+		HandlerFunc(m.setClusterUuidEnable)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminGetClusterUuid).
+		HandlerFunc(m.getClusterUuid)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminGenerateClusterUuid).
+		HandlerFunc(m.generateClusterUuid)
 
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminGetClusterValue).

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -51,6 +51,8 @@ type clusterValue struct {
 	DecommissionLimit           uint64
 	CheckDataReplicasEnable     bool
 	FileStatsEnable             bool
+	ClusterUuid                 string
+	ClusterUuidEnable           bool
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -72,6 +74,8 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		DecommissionLimit:           c.DecommissionLimit,
 		CheckDataReplicasEnable:     c.checkDataReplicasEnable,
 		FileStatsEnable:             c.fileStatsEnable,
+		ClusterUuid:                 c.clusterUuid,
+		ClusterUuidEnable:           c.clusterUuidEnable,
 	}
 	return cv
 }
@@ -876,6 +880,8 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.cfg.QosMasterAcceptLimit = cv.QosLimitUpload
 		c.DecommissionLimit = cv.DecommissionLimit //dont update nodesets limit for nodesets are not loaded
 		c.fileStatsEnable = cv.FileStatsEnable
+		c.clusterUuid = cv.ClusterUuid
+		c.clusterUuidEnable = cv.ClusterUuidEnable
 
 		if c.cfg.QosMasterAcceptLimit < QosMasterAcceptCnt {
 			c.cfg.QosMasterAcceptLimit = QosMasterAcceptCnt

--- a/metanode/raft_server.go
+++ b/metanode/raft_server.go
@@ -15,12 +15,14 @@
 package metanode
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/cubefs/cubefs/raftstore"
 	"github.com/cubefs/cubefs/util/config"
 	"github.com/cubefs/cubefs/util/errors"
+	"github.com/cubefs/cubefs/util/log"
 )
 
 // StartRaftServer initializes the address resolver and the raftStore server instance.
@@ -33,6 +35,13 @@ func (m *MetaNode) startRaftServer(cfg *config.Config) (err error) {
 		if err = os.MkdirAll(m.raftDir, 0755); err != nil {
 			err = errors.NewErrorf("create raft server dir: %s", err.Error())
 			return
+		}
+	}
+
+	if m.clusterUuidEnable {
+		if err = config.CheckOrStoreClusterUuid(m.raftDir, m.clusterUuid, false); err != nil {
+			log.LogErrorf("CheckOrStoreClusterUuid failed: %v", err)
+			return fmt.Errorf("CheckOrStoreClusterUuid failed: %v", err)
 		}
 	}
 

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -68,6 +68,9 @@ const (
 	AdminSetFileStats                         = "/admin/setFileStatsEnable"
 	AdminGetFileStats                         = "/admin/getFileStatsEnable"
 	AdminGetClusterValue                      = "/admin/getClusterValue"
+	AdminSetClusterUuidEnable                 = "/admin/setClusterUuidEnable"
+	AdminGetClusterUuid                       = "/admin/getClusterUuid"
+	AdminGenerateClusterUuid                  = "/admin/generateClusterUuid"
 	//graphql master api
 	AdminClusterAPI = "/api/cluster"
 	AdminUserAPI    = "/api/user"
@@ -294,6 +297,8 @@ type ClusterInfo struct {
 	DirChildrenNumLimit         uint32
 	EbsAddr                     string
 	ServicePath                 string
+	ClusterUuid                 string
+	ClusterUuidEnable           bool
 }
 
 // CreateDataPartitionRequest defines the request to create a data partition.


### PR DESCRIPTION
Currently, metanode/datanode may be added to other clusters due to the incorrect configuration during mn/dn restart.
If more than two metanode are mistakenly added to other clusters, some metapartition may be missing two replicas, resulting in client access errors.

We add the cluster identification function, which generates the unique cluster ID through commands and persists it in the master rocksdb. When metanode and datanode start for the first time, the ID will be obtained from the master and persists to the data directory, and will be checked when the metanode and datanode restart. 

We add a few new commands in this pr:
1. Command to generate uuid;
2. Command to query clusterUUID;
3. Command to enable metanode/datanode to check clusterUUID during startup, the default value is false;
4. Command to generate CLUSTER-VERSION file for metanode (used in the old cluster）
5. Command to generate CLUSTER-VERSION file for datanode (used in the old cluster）

For the newly cluster, we can use the following steps to enable clusterUUID function:
1. After all master startup, using the command to generate clusterUUID;
2. Enable the clusterUUID check function;
3. Start metanode and datanode;

If you want to upgrade this function in an old cluster
1. Generate clusterUUID;
2. Restart metanode with the new code;
3. Use the command to generate CLUSTER-VERSION for metanode;
6. Restart datanode with the new code;
7. Use the command to generate CLUSTER-VERSION for datanode;
8. Enable the clusterUUID check function;