### PR TITLE
[Enhancement] add request monitor for client

### DIFF
--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -108,7 +108,7 @@ func NewFile(s *Super, i *proto.InodeInfo, flag uint32, pino uint64, filename st
 	return &File{super: s, info: i, parentIno: pino, name: filename}
 }
 
-//get file parentPath
+// get file parentPath
 func (f *File) getParentPath() string {
 	filepath := ""
 	if f.parentIno == f.super.rootIno {
@@ -204,9 +204,10 @@ func (f *File) Forget() {
 func (f *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (handle fs.Handle, err error) {
 	bgTime := stat.BeginStat()
 	var needBCache bool
-
+	runningStat := f.super.runningMonitor.AddClientOp("fileopen", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Open", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	ino := f.info.Inode
@@ -276,9 +277,9 @@ func (f *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 
 // Release handles the release request.
 func (f *File) Release(ctx context.Context, req *fuse.ReleaseRequest) (err error) {
-
 	ino := f.info.Inode
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filerelease", req.Hdr().Pid)
 
 	defer func() {
 		stat.EndStat("Release", err, bgTime, 1)
@@ -286,6 +287,7 @@ func (f *File) Release(ctx context.Context, req *fuse.ReleaseRequest) (err error
 		if DisableMetaCache {
 			f.super.ic.Delete(ino)
 		}
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	log.LogDebugf("TRACE Release enter: ino(%v) req(%v)", ino, req)
@@ -311,9 +313,11 @@ func (f *File) Release(ctx context.Context, req *fuse.ReleaseRequest) (err error
 // Read handles the read request.
 func (f *File) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) (err error) {
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("fileread", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Read", err, bgTime, 1)
 		stat.StatBandWidth("Read", uint32(req.Size))
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	log.LogDebugf("TRACE Read enter: ino(%v) offset(%v) reqsize(%v) req(%v)", f.info.Inode, req.Offset, req.Size, req)
@@ -362,9 +366,11 @@ func (f *File) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadR
 // Write handles the write request.
 func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) (err error) {
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filewrite", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Write", err, bgTime, 1)
 		stat.StatBandWidth("Write", uint32(len(req.Data)))
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	ino := f.info.Inode
@@ -456,8 +462,10 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.Wri
 // Flush only when fsyncOnClose is enabled.
 func (f *File) Flush(ctx context.Context, req *fuse.FlushRequest) (err error) {
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filesync", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Flush", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	if !f.super.fsyncOnClose {
@@ -504,6 +512,10 @@ func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
 
 	log.LogDebugf("TRACE Fsync enter: ino(%v)", f.info.Inode)
 	start := time.Now()
+	runningStat := f.super.runningMonitor.AddClientOp("filefsnyc", req.Hdr().Pid)
+	defer func() {
+		f.super.runningMonitor.SubClientOp(runningStat, err)
+	}()
 	if proto.IsHot(f.super.volType) {
 		err = f.super.ec.Flush(f.info.Inode)
 	} else {
@@ -524,8 +536,10 @@ func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
 func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
 	var err error
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filesetattr", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Setattr", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	ino := f.info.Inode
@@ -583,8 +597,10 @@ func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse
 func (f *File) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error) {
 	var err error
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filereadlink", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Readlink", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	ino := f.info.Inode
@@ -601,8 +617,10 @@ func (f *File) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string,
 func (f *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
 	var err error
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filegetxattr", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Getxattr", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	if !f.super.enableXattr {
@@ -633,8 +651,10 @@ func (f *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fu
 func (f *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
 	var err error
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filelistxattr", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Listxattr", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	if !f.super.enableXattr {
@@ -660,8 +680,10 @@ func (f *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *
 func (f *File) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
 	var err error
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("filesetxattr", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Setxattr", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	if !f.super.enableXattr {
@@ -683,8 +705,10 @@ func (f *File) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
 func (f *File) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
 	var err error
 	bgTime := stat.BeginStat()
+	runningStat := f.super.runningMonitor.AddClientOp("fileremovexattr", req.Hdr().Pid)
 	defer func() {
 		stat.EndStat("Removexattr", err, bgTime, 1)
+		f.super.runningMonitor.SubClientOp(runningStat, err)
 	}()
 
 	if !f.super.enableXattr {

--- a/client/fs/running_monitor.go
+++ b/client/fs/running_monitor.go
@@ -1,0 +1,264 @@
+// Copyright 2018 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fs
+
+import (
+	"github.com/cubefs/cubefs/util/exporter"
+	"github.com/cubefs/cubefs/util/log"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	IdxTotal = 3
+)
+
+var opNameMap = map[string]uint8{
+	"create":          1,
+	"mkdir":           2,
+	"remove":          3,
+	"lookup":          4,
+	"readdir":         5,
+	"rename":          6,
+	"setattr":         7,
+	"mknod":           8,
+	"symlink":         9,
+	"link":            10,
+	"getxattr":        11,
+	"listxattr":       12,
+	"setxattr":        13,
+	"removexattr":     14,
+	"fileopen":        15,
+	"filerelease":     16,
+	"fileread":        17,
+	"filewrite":       18,
+	"filesync":        19,
+	"filefsnyc":       20,
+	"filesetattr":     21,
+	"filereadlink":    22,
+	"filegetxattr":    23,
+	"filelistxattr":   24,
+	"filesetxattr":    25,
+	"fileremovexattr": 26,
+}
+
+type RunningMonitor struct {
+	enable                bool
+	curCheckIdx           int
+	clientOpRunningCntMap [IdxTotal]*sync.Map
+	clientOpTimeOut       int64
+	mu                    [IdxTotal]sync.RWMutex
+	stopC                 chan struct{}
+}
+
+type RunningStat struct {
+	startTime *time.Time
+	pid       uint32
+	opIdx     uint8
+}
+
+func NewRunningMonitor(clientOpTimeOut int64) (rm *RunningMonitor) {
+	rm = new(RunningMonitor)
+	rm.enable = false
+	for i := 0; i < IdxTotal; i++ {
+		rm.clientOpRunningCntMap[i] = new(sync.Map)
+	}
+	if clientOpTimeOut > 0 {
+		rm.enable = true
+		rm.clientOpTimeOut = clientOpTimeOut
+		rm.stopC = make(chan struct{})
+	}
+	return
+}
+
+func (rm *RunningMonitor) Start() {
+	if !rm.enable {
+		return
+	}
+	go func() {
+		log.LogInfof("action[RunningMonitor#start] start")
+		rm.curCheckIdx = calNextIdx(calCheckIdx(time.Now().Unix(), rm.clientOpTimeOut))
+		for {
+			select {
+			case <-rm.stopC:
+				goto end
+			default:
+				for {
+					time.Sleep(time.Millisecond * time.Duration(rm.calTimeToCurCheckIdx()))
+					if rm.curCheckIdx == calCheckIdx(time.Now().Unix(), rm.clientOpTimeOut) {
+						break
+					}
+				}
+				rm.checkClientOpRunningCnt()
+				rm.curCheckIdx = calNextIdx(rm.curCheckIdx)
+			}
+		}
+	end:
+		log.LogInfof("action[RunningMonitor#start] stop")
+	}()
+}
+
+func (rm *RunningMonitor) Stop() {
+	if rm.stopC != nil {
+		close(rm.stopC)
+	}
+}
+
+func (rm *RunningMonitor) calTimeToCurCheckIdx() (waitTime int64) {
+	now := time.Now().Unix() * 1000
+	restfulTime := calRestfulTimeInTimeOut(now, rm.clientOpTimeOut)
+
+	diffIdxCnt := ((rm.curCheckIdx + IdxTotal) - calCheckIdx(now+restfulTime, rm.clientOpTimeOut)) % IdxTotal
+	diffIdxTime := int64(diffIdxCnt) * (rm.clientOpTimeOut * 1000)
+
+	waitTime = restfulTime + diffIdxTime
+	return
+}
+
+func calRestfulTimeInTimeOut(timeStampInMs int64, timeOut int64) (restfulTime int64) {
+	restfulTime = timeOut*1000 - timeStampInMs%(timeOut*1000)
+	return
+}
+
+func (rm *RunningMonitor) checkClientOpRunningCnt() {
+	log.LogDebugf("action[RunningMonitor#checkClientOpRunningCnt] start, curCheckIdx[%v]", rm.curCheckIdx)
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+		log.LogDebugf("action[RunningMonitor#checkClientOpRunningCnt] curCheckIdx[%v] elapsed[%v]ms", rm.curCheckIdx, elapsed.Milliseconds())
+	}()
+	tmpMap := rm.clientOpRunningCntMap[rm.curCheckIdx]
+	rm.mu[rm.curCheckIdx].Lock()
+	rm.clientOpRunningCntMap[rm.curCheckIdx] = new(sync.Map)
+	rm.mu[rm.curCheckIdx].Unlock()
+	tmpMap.Range(func(key, value interface{}) bool {
+		opIdx := key.(uint8)
+		opName := GetOpName(opIdx)
+		pid2RunningCntMap := value.(*sync.Map)
+		var runningTotal int32 = 0
+		pid2RunningCntMap.Range(func(key, value interface{}) bool {
+			pid := key.(uint32)
+			runningCnt := atomic.LoadInt32(value.(*int32))
+			if runningCnt > 0 {
+				runningTotal += runningCnt
+				// report error by log
+				log.LogErrorf("action[RunningMonitor#checkClientOpRunningCnt] pid[%v] op[%v] count[%v] run time out, clientOpTimeOut[%v]", pid, opName, runningCnt, rm.clientOpTimeOut)
+			}
+
+			return true
+		})
+		runTimeOutCntGaugeVec := exporter.NewGaugeVecFromMap("op_run_time_out_count", "", []string{"op"})
+		if runTimeOutCntGaugeVec != nil {
+			runTimeOutCntGaugeVec.AddWithLabelValues(float64(runningTotal), opName)
+		}
+		return true
+	})
+}
+
+func GetOpIdx(name string) (opIdx uint8) {
+	var ok bool
+	opIdx, ok = opNameMap[name]
+	if !ok {
+		opIdx = 0
+	}
+	return
+}
+
+func GetOpName(opIdx uint8) (name string) {
+	for k, v := range opNameMap {
+		if v == opIdx {
+			name = k
+			return
+		}
+	}
+	return "undefinedOp"
+}
+
+func GetOpNum() (opNum int) {
+	opNum = len(opNameMap)
+	return
+}
+
+func (rm *RunningMonitor) AddClientOp(name string, pid uint32) (runningStat *RunningStat) {
+	now := time.Now()
+	runningStat = new(RunningStat)
+	runningStat.startTime = &now
+	runningStat.pid = pid
+	runningStat.opIdx = GetOpIdx(name)
+
+	if rm.enable {
+		idx := calWorkIdx(runningStat.startTime.Unix(), rm.clientOpTimeOut)
+		rm.mu[idx].RLock()
+		value, _ := rm.clientOpRunningCntMap[idx].LoadOrStore(runningStat.opIdx, new(sync.Map))
+		rm.mu[idx].RUnlock()
+		pid2RunningCntMap := value.(*sync.Map)
+
+		store, _ := pid2RunningCntMap.LoadOrStore(runningStat.pid, new(int32))
+		runningCnt := store.(*int32)
+		atomic.AddInt32(runningCnt, 1)
+	}
+	return
+}
+
+func (rm *RunningMonitor) SubClientOp(runningStat *RunningStat, err error) {
+	now := time.Now()
+	rm.addClientFailOp(runningStat, err)
+
+	if rm.enable {
+		if now.Unix()-runningStat.startTime.Unix() < rm.clientOpTimeOut {
+			idx := calWorkIdx(runningStat.startTime.Unix(), rm.clientOpTimeOut)
+			rm.mu[idx].RLock()
+			value, _ := rm.clientOpRunningCntMap[idx].LoadOrStore(runningStat.opIdx, new(sync.Map))
+			rm.mu[idx].RUnlock()
+			pid2RunningCntMap := value.(*sync.Map)
+
+			store, _ := pid2RunningCntMap.LoadOrStore(runningStat.pid, new(int32))
+			runningCnt := store.(*int32)
+			atomic.AddInt32(runningCnt, -1)
+		}
+	}
+	return
+}
+
+func (rm *RunningMonitor) addClientFailOp(runningStat *RunningStat, err error) {
+	if err != nil {
+		if err == io.EOF {
+			return
+		}
+		parsedError := ParseError(err)
+		runFailGaugeVec := exporter.NewGaugeVecFromMap("op_run_fail_count", "", []string{"op", "err"})
+		if runFailGaugeVec != nil {
+			runFailGaugeVec.AddWithLabelValues(1, GetOpName(runningStat.opIdx), parsedError.ErrnoName())
+		}
+	}
+}
+
+func calWorkIdx(timeStampInSecond int64, timeOut int64) (idx int) {
+	idxInTotal := timeStampInSecond % (timeOut * IdxTotal)
+	idx = int(idxInTotal / timeOut)
+	return
+}
+
+func calNextIdx(curIdx int) (nextIdx int) {
+	nextIdx = (curIdx + 1) % IdxTotal
+	return
+}
+
+func calCheckIdx(timeStampInSecond int64, timeOut int64) (checkIdx int) {
+	checkIdx = calNextIdx(calWorkIdx(timeStampInSecond, timeOut))
+	return
+}

--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -83,6 +83,7 @@ type Super struct {
 	bcacheFilterFiles   string
 	bcacheCheckInterval int64
 	bcacheBatchCnt      int64
+	runningMonitor      *RunningMonitor
 
 	readThreads  int
 	writeThreads int
@@ -161,6 +162,8 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	s.bcacheBatchCnt = opt.BcacheBatchCnt
 	s.closeC = make(chan struct{}, 1)
 	s.taskPool = []common.TaskPool{common.New(DefaultTaskPoolSize, DefaultTaskPoolSize), common.New(DefaultTaskPoolSize, DefaultTaskPoolSize)}
+	s.runningMonitor = NewRunningMonitor(opt.ClientOpTimeOut)
+	s.runningMonitor.Start()
 
 	if s.mw.EnableSummary {
 		s.sc = NewSummaryCache(DefaultSummaryExpiration, MaxSummaryCache)

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -88,7 +88,8 @@ const (
 	DynamicUDSNameFormat = "/tmp/CubeFS-fdstore-%v.sock"
 	DefaultUDSName       = "/tmp/CubeFS-fdstore.sock"
 
-	DefaultLogPath = "/var/log/chubaofs"
+	DefaultLogPath            = "/var/log/chubaofs"
+	DefaultMinClientOpTimeOut = 60
 )
 
 var (
@@ -732,6 +733,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.MaxStreamerLimit = GlobalMountOptions[proto.MaxStreamerLimit].GetInt64()
 	opt.EnableAudit = GlobalMountOptions[proto.EnableAudit].GetBool()
 	opt.RequestTimeout = GlobalMountOptions[proto.RequestTimeout].GetInt64()
+	opt.ClientOpTimeOut = GlobalMountOptions[proto.ClientOpTimeOut].GetInt64()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))
@@ -740,6 +742,15 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	if opt.BuffersTotalLimit < 0 {
 		return nil, errors.New(fmt.Sprintf("invalid fields, BuffersTotalLimit(%v) must larger or equal than 0", opt.BuffersTotalLimit))
 	}
+
+	if opt.ClientOpTimeOut != 0 && opt.ClientOpTimeOut < DefaultMinClientOpTimeOut {
+		opt.ClientOpTimeOut = DefaultMinClientOpTimeOut
+	}
+
+	if opt.RequestTimeout != 0 && opt.ClientOpTimeOut != 0 && opt.RequestTimeout <= opt.ClientOpTimeOut {
+		return nil, errors.New(fmt.Sprintf("RequestTimeout(%v) must larger than ClientOpTimeOut(%v)", opt.RequestTimeout, opt.ClientOpTimeOut))
+	}
+
 	return opt, nil
 }
 

--- a/client/test/running_monitor_test.go
+++ b/client/test/running_monitor_test.go
@@ -1,0 +1,117 @@
+// Copyright 2018 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package test
+
+import (
+	"github.com/cubefs/cubefs/client/fs"
+	"github.com/cubefs/cubefs/util"
+	"github.com/cubefs/cubefs/util/log"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+)
+
+func random(start int, end int) (randomNum int) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomNum = r.Intn(end-start+1) + start
+	return
+}
+
+func TestRunningMonitor(t *testing.T) {
+
+	if os.Getenv("FullTest") == "" {
+		t.Skip("Skipping testing in normal test")
+	}
+
+	if _, err := log.InitLog("/tmp/cubefs/Logs", "client", log.DebugLevel, nil); err != nil {
+		panic(err)
+	}
+
+	times := 3
+	clientOpTimeOut := 10
+	opNum := random(20000, 20000)
+	oneRoundTime := 1000
+
+	monitor := fs.NewRunningMonitor(int64(clientOpTimeOut))
+	monitor.Start()
+
+	stopTicker := time.NewTicker(time.Duration(clientOpTimeOut*times) * time.Second)
+	for {
+		select {
+		case <-stopTicker.C:
+			stopTicker.Stop()
+			goto end
+		default:
+			start := time.Now()
+			for i := 0; i < opNum; i++ {
+				opName := fs.GetOpName(uint8(random(1, fs.GetOpNum())))
+				pid := random(1000, 999999)
+				runningStat := monitor.AddClientOp(opName, uint32(pid))
+				monitor.SubClientOp(runningStat, nil)
+			}
+			elapsed := time.Since(start)
+			log.LogInfof("action[TestRunningMonitor] elapsed[%v]ms", elapsed.Milliseconds())
+			sleepTime := util.Max(oneRoundTime-int(elapsed.Milliseconds()), 0)
+			time.Sleep(time.Duration(sleepTime) * time.Millisecond)
+		}
+	}
+end:
+	time.Sleep(time.Duration(clientOpTimeOut*3) * time.Second)
+	monitor.Stop()
+	time.Sleep(time.Duration(clientOpTimeOut) * time.Second)
+}
+
+func TestRunningMonitorInHighLoad(t *testing.T) {
+
+	if os.Getenv("FullTest") == "" {
+		t.Skip("Skipping testing in normal test")
+	}
+
+	if _, err := log.InitLog("/tmp/cubefs/Logs", "client", log.DebugLevel, nil); err != nil {
+		panic(err)
+	}
+
+	times := 3
+	clientOpTimeOut := 60
+
+	monitor := fs.NewRunningMonitor(int64(clientOpTimeOut))
+	monitor.Start()
+
+	stopTicker := time.NewTicker(time.Duration(clientOpTimeOut*times) * time.Second)
+	for {
+		select {
+		case <-stopTicker.C:
+			stopTicker.Stop()
+			goto end
+		default:
+			start := time.Now()
+			for i := 0; i < fs.GetOpNum(); i++ {
+				for j := 1000; j < 999999; j++ {
+					opName := fs.GetOpName(uint8(i))
+					pid := j
+					runningStat := monitor.AddClientOp(opName, uint32(pid))
+					monitor.SubClientOp(runningStat, nil)
+				}
+			}
+			elapsed := time.Since(start)
+			log.LogInfof("action[TestRunningMonitorInHighLoad] elapsed[%v]ms", elapsed.Milliseconds())
+		}
+	}
+end:
+	time.Sleep(time.Duration(clientOpTimeOut*3) * time.Second)
+	monitor.Stop()
+	time.Sleep(time.Duration(clientOpTimeOut) * time.Second)
+}

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -49,6 +49,7 @@ const (
 	EnableSummary
 	EnableUnixPermission
 	RequestTimeout
+	ClientOpTimeOut
 
 	//adls
 	VolType
@@ -155,6 +156,7 @@ func InitMountOptions(opts []MountOption) {
 	opts[BcacheCheckIntervalS] = MountOption{"bcacheCheckIntervalS", "The block cache check interval", "", int64(300)}
 	opts[EnableAudit] = MountOption{"enableAudit", "enable client audit logging", "", false}
 	opts[RequestTimeout] = MountOption{"requestTimeout", "The Request Expiration Time", "", int64(0)}
+	opts[ClientOpTimeOut] = MountOption{"clientOpTimeOut", "client op time out in seconds", "", int64(0)}
 
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
@@ -305,4 +307,5 @@ type MountOptions struct {
 	MaxStreamerLimit     int64
 	EnableAudit          bool
 	RequestTimeout       int64
+	ClientOpTimeOut      int64
 }


### PR DESCRIPTION
Introduction:
In order to report abnormal request(e.g timeout, fail request) in fuse client to user, add request monitor for client in this pr.
This monitor works for all requests by one routine. When detecting a timeout request, it can report the process id and the operation type correctly.

Advantage:
1、less resource consumption because of only one routine
2、locate problem quickly by its reported process id and operation type

Monitor algorithm:
![monitor_op_timeout](https://user-images.githubusercontent.com/44452470/228420062-41cee0cb-9a0b-4c47-ad49-088a167b66b6.png)
1、Time is split to three time window and the time window size is equal to timeout which is set in client config.
2、If timeout is one second, and If a request starts at time window called time window0 whose remainder is zero divided by three in second, the counter called counter0 will add one. If the request ends and doesn't time out, counter0 will subtract one.
3、For counter0, when this time window ends(this second passes in the case), the monitor waits one more time window size and then checks the counter if it's greater than zero. If yes, it means that there are timeout request which starts at time window0. So the monitor report them with their process id and operation type.
4、Similarly, counter1 works at time window1 whose remainder is one divided by three in second, and counter2 works at time window1 whose remainder is two divided by three in second. Thus, the three counter takes turns working and covers all time.

