### PR TITLE
[Feature]: support showing migrating process

### DIFF
--- a/blobstore/common/errors/scheduler.go
+++ b/blobstore/common/errors/scheduler.go
@@ -26,6 +26,7 @@ var (
 	ErrIllegalTaskType       = errors.New("illegal task type")
 	ErrCanNotDropped         = errors.New("disk can not dropped")
 	ErrUnexpectMigrationTask = errors.New("unexpect migration task")
+	ErrIllegalDiskID         = errors.New("illegal disk id")
 
 	// error code
 	ErrNothingTodo = Error(CodeNotingTodo)


### PR DESCRIPTION
**What this PR does / why we need it**:
* Support showing offline or repair task progress with blobstore-cli

The final result is displayed below:
```
[===========================>                      ] MigratedTasksCnt: 2/TotalTasksCnt: 4
```

**Which issue this PR fixes** 
fixes #1900 
