### PR TITLE
[Feature]: The cfs-cli supports setting the maximum number of dp on datanode

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -172,7 +172,10 @@ build_rocksdb() {
 
         [ "-$LUA_PATH" != "-" ]  && unset LUA_PATH
         MAJOR=$(echo __GNUC__ | $(which gcc) -E -xc - | tail -n 1)
-        if [ ${MAJOR} -ge 10 ] ; then
+        if [ ${MAJOR} -ge 12 ] ; then
+          CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move -Wno-error=range-loop-construct' \
+        make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
+        elif [ ${MAJOR} -ge 10 ] ; then
           CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move' \
 		make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
         elif [ ${MAJOR} -ge 8 ] ; then

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2002,6 +2002,7 @@ func (m *Server) getDataNode(w http.ResponseWriter, r *http.Request) {
 		PersistenceDataPartitions: dataNode.PersistenceDataPartitions,
 		BadDisks:                  dataNode.BadDisks,
 		RdOnly:                    dataNode.RdOnly,
+		MaxDpCntLimit:             dataNode.GetDpCntLimit(),
 	}
 
 	sendOkReply(w, r, newSuccessHTTPReply(dataNodeInfo))

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -652,14 +652,22 @@ func TestGetNodeInfo(t *testing.T) {
 }
 
 func TestSetNodeMaxDpCntLimit(t *testing.T) {
-	limit := 4000
+	// change current max data partition count limit to 4000
+	limit := uint32(4000)
 	reqURL := fmt.Sprintf("%v%v?maxDpCntLimit=%v", hostAddr, proto.AdminSetNodeInfo, limit)
 	process(reqURL, t)
+	// query current settings
 	reqURL = fmt.Sprintf("%v%v", hostAddr, proto.AdminGetNodeInfo)
 	reply := process(reqURL, t)
 	data := reply.Data.(map[string]interface{})
 	limitStr := (data[maxDpCntLimitKey]).(string)
 	assert.True(t, fmt.Sprint(limit) == limitStr)
+	// query data node info
+	reqURL = fmt.Sprintf("%v%v?addr=%v", hostAddr, proto.GetDataNode, mds1Addr)
+	reply = process(reqURL, t)
+	data = reply.Data.(map[string]interface{})
+	dataNodeLimit := uint32((data[maxDpCntLimitKey]).(float64))
+	assert.True(t, dataNodeLimit == limit)
 }
 
 func TestAddDataReplica(t *testing.T) {

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -646,6 +646,22 @@ func TestGetMetaNode(t *testing.T) {
 	process(reqURL, t)
 }
 
+func TestGetNodeInfo(t *testing.T) {
+	reqURL := fmt.Sprintf("%v%v", hostAddr, proto.AdminGetNodeInfo)
+	process(reqURL, t)
+}
+
+func TestSetNodeMaxDpCntLimit(t *testing.T) {
+	limit := 4000
+	reqURL := fmt.Sprintf("%v%v?maxDpCntLimit=%v", hostAddr, proto.AdminSetNodeInfo, limit)
+	process(reqURL, t)
+	reqURL = fmt.Sprintf("%v%v", hostAddr, proto.AdminGetNodeInfo)
+	reply := process(reqURL, t)
+	data := reply.Data.(map[string]interface{})
+	limitStr := (data[maxDpCntLimitKey]).(string)
+	assert.True(t, fmt.Sprint(limit) == limitStr)
+}
+
 func TestAddDataReplica(t *testing.T) {
 	partition := commonVol.dataPartitions.partitions[0]
 	dsAddr := "127.0.0.1:9106"

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -201,6 +201,9 @@ func newCluster(name string, leaderInfo *LeaderInfo, fsm *MetadataFsm, partition
 	c.leaderInfo = leaderInfo
 	c.vols = make(map[string]*Vol, 0)
 	c.cfg = cfg
+	if c.cfg.MaxDpCntLimit == 0 {
+		c.cfg.MaxDpCntLimit = defaultMaxDpCntLimit
+	}
 	c.t = newTopology()
 	c.BadDataPartitionIds = new(sync.Map)
 	c.BadMetaPartitionIds = new(sync.Map)
@@ -788,6 +791,7 @@ func (c *Cluster) addDataNode(nodeAddr, zoneName string, nodesetId uint64) (id u
 	}
 
 	dataNode = newDataNode(nodeAddr, zoneName, c.Name)
+	dataNode.DpCntLimit = newDpCountLimiter(&c.cfg.MaxDpCntLimit)
 	zone, err := c.t.getZone(zoneName)
 	if err != nil {
 		zone = c.t.putZoneIfAbsent(newZone(zoneName))
@@ -3037,14 +3041,20 @@ func (c *Cluster) setMetaNodeDeleteWorkerSleepMs(val uint64) (err error) {
 	return
 }
 
+func (c *Cluster) getMaxDpCntLimit() (dpCntInLimit uint64) {
+	dpCntInLimit = atomic.LoadUint64(&c.cfg.MaxDpCntLimit)
+	return
+}
+
 func (c *Cluster) setMaxDpCntLimit(val uint64) (err error) {
+	if val == 0 {
+		val = defaultMaxDpCntLimit
+	}
 	oldVal := atomic.LoadUint64(&c.cfg.MaxDpCntLimit)
 	atomic.StoreUint64(&c.cfg.MaxDpCntLimit, val)
-	maxDpCntOneNode = uint32(val)
 	if err = c.syncPutCluster(); err != nil {
 		log.LogErrorf("action[MaxDpCntLimit] err[%v]", err)
 		atomic.StoreUint64(&c.cfg.MaxDpCntLimit, oldVal)
-		maxDpCntOneNode = uint32(oldVal)
 		err = proto.ErrPersistenceByRaft
 		return
 	}

--- a/master/config.go
+++ b/master/config.go
@@ -75,6 +75,7 @@ const (
 	defaultDiffSpaceUsage                              = 1024 * 1024 * 1024
 	defaultNodeSetGrpStep                              = 1
 	defaultMasterMinQosAccept                          = 20000
+	defaultMaxDpCntLimit                               = 3000
 )
 
 // AddrDatabase is a map that stores the address of a given host (e.g., the leader)
@@ -127,6 +128,7 @@ func newClusterConfig() (cfg *clusterConfig) {
 	cfg.PeriodToLoadALLDataPartitions = defaultPeriodToLoadAllDataPartitions
 	cfg.MetaNodeThreshold = defaultMetaPartitionMemUsageThreshold
 	cfg.ClusterLoadFactor = defaultOverSoldFactor
+	cfg.MaxDpCntLimit = defaultMaxDpCntLimit
 	cfg.metaNodeReservedMem = defaultMetaNodeReservedMem
 	cfg.diffSpaceUsage = defaultDiffSpaceUsage
 	cfg.QosMasterAcceptLimit = defaultMasterMinQosAccept

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -67,6 +67,7 @@ type DataNode struct {
 	DecommissionLimit         int
 	DecommissionTerm          uint64
 	DecommissionCompleteTime  int64
+	DpCntLimit                DpCountLimiter `json:"-"` // max count of data partition in a data node
 }
 
 func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
@@ -80,6 +81,7 @@ func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
 	dataNode.DecommissionStatus = DecommissionInitial
 	dataNode.DecommissionTerm = 0
 	dataNode.DecommissionDpTotal = InvalidDecommissionDpCnt
+	dataNode.DpCntLimit = newDpCountLimiter(nil)
 	return
 }
 
@@ -178,8 +180,12 @@ func (dataNode *DataNode) canAllocDp() bool {
 	return true
 }
 
+func (dataNode *DataNode) GetDpCntLimit() uint32 {
+	return uint32(dataNode.DpCntLimit.GetCntLimit())
+}
+
 func (dataNode *DataNode) dpCntInLimit() bool {
-	return dataNode.DataPartitionCount <= dpCntOneNodeLimit()
+	return dataNode.DataPartitionCount <= dataNode.GetDpCntLimit()
 }
 
 func (dataNode *DataNode) isWriteAbleWithSize(size uint64) (ok bool) {

--- a/master/dp_count_limiter.go
+++ b/master/dp_count_limiter.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package master
+
+import "sync/atomic"
+
+type DpCountLimiter struct {
+	cntLimit *uint64
+}
+
+func newDpCountLimiter(cntLimit *uint64) DpCountLimiter {
+	limiter := DpCountLimiter{
+		cntLimit: cntLimit,
+	}
+	return limiter
+}
+
+func (cntLimiter *DpCountLimiter) GetCntLimit() uint64 {
+	limit := uint64(0)
+	if cntLimiter.cntLimit != nil {
+		limit = atomic.LoadUint64(cntLimiter.cntLimit)
+	}
+	if limit == 0 {
+		limit = defaultMaxDpCntLimit
+	}
+	return limit
+}

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -781,7 +781,6 @@ func (c *Cluster) updateDataNodeDeleteLimitRate(val uint64) {
 
 func (c *Cluster) updateMaxDpCntLimit(val uint64) {
 	atomic.StoreUint64(&c.cfg.MaxDpCntLimit, val)
-	maxDpCntOneNode = uint32(val)
 }
 
 func (c *Cluster) loadZoneValue() (err error) {

--- a/master/server.go
+++ b/master/server.go
@@ -67,8 +67,6 @@ var (
 
 	useConnPool = true //for test
 	gConfig     *clusterConfig
-
-	maxDpCntOneNode = uint32(3000)
 )
 
 var overSoldFactor = defaultOverSoldFactor
@@ -98,14 +96,6 @@ func setOverSoldFactor(factor float32) {
 var (
 	volNameErr = errors.New("name can only start and end with number or letters, and len can't less than 3")
 )
-
-func dpCntOneNodeLimit() uint32 {
-	if maxDpCntOneNode <= 0 {
-		return 3000
-	}
-
-	return maxDpCntOneNode
-}
 
 // Server represents the server in a cluster
 type Server struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -65,6 +65,7 @@ type DataNodeInfo struct {
 	PersistenceDataPartitions []uint64
 	BadDisks                  []string
 	RdOnly                    bool
+	MaxDpCntLimit             uint32 `json:"maxDpCntLimit"`
 }
 
 // MetaPartition defines the structure of a meta partition


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

cfs-cli supports setting the maximum number of dp on datanode.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #1897 

**Special notes for your reviewer**:

@Victor1319 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
