### PR TITLE
[Enhancement] make `CXXFLAGS` customizable for building `rocksdb` in `cubefs`

### DIFF
--- a/blobstore/common/errors/scheduler.go
+++ b/blobstore/common/errors/scheduler.go
@@ -26,6 +26,7 @@ var (
 	ErrIllegalTaskType       = errors.New("illegal task type")
 	ErrCanNotDropped         = errors.New("disk can not dropped")
 	ErrUnexpectMigrationTask = errors.New("unexpect migration task")
+	ErrIllegalDiskID         = errors.New("illegal disk id")
 
 	// error code
 	ErrNothingTodo = Error(CodeNotingTodo)

--- a/build/build.sh
+++ b/build/build.sh
@@ -173,10 +173,10 @@ build_rocksdb() {
         [ "-$LUA_PATH" != "-" ]  && unset LUA_PATH
         MAJOR=$(echo __GNUC__ | $(which gcc) -E -xc - | tail -n 1)
         if [ ${MAJOR} -ge 10 ] ; then
-          CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move' \
+          CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move'" ${CXXFLAGS}" \
 		make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
         elif [ ${MAJOR} -ge 8 ] ; then
-	  CXXFLAGS='-Wno-error=class-memaccess' \
+	  CXXFLAGS='-Wno-error=class-memaccess'" ${CXXFLAGS}" \
 		      make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
 	else
 		      make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -515,6 +515,13 @@ func (s *DataNode) startRaftServer(cfg *config.Config) (err error) {
 
 	s.parseRaftConfig(cfg)
 
+	if s.clusterUuidEnable {
+		if err = config.CheckOrStoreClusterUuid(s.raftDir, s.clusterUuid, false); err != nil {
+			log.LogErrorf("CheckOrStoreClusterUuid failed: %v", err)
+			return fmt.Errorf("CheckOrStoreClusterUuid failed: %v", err)
+		}
+	}
+
 	constCfg := config.ConstConfig{
 		Listen:           s.port,
 		RaftHeartbetPort: s.raftHeartbeat,

--- a/docs-zh/source/faq/build.md
+++ b/docs-zh/source/faq/build.md
@@ -23,14 +23,14 @@
            JAVA_LDFLAGS="$JAVA_LDFLAGS -lzstd"
        fi
    ```
-  
+
 
 ## rocksdb编译问题
 
 编译纠删码子系统显示报错 `fatal error: rocksdb/c.h: no such file or directory...`
-- 首先确认`.deps/include/rocksdb`目录下是否存在报错所指向的文件， 
+- 首先确认`.deps/include/rocksdb`目录下是否存在报错所指向的文件，
 - 如果存在 可`source env.sh`后再次尝试，如果没有该文件或者仍然报错，可将`.deps`目录下rocksdb相关的文件全部清理，然后重新编译。
-   
+
 ## cannot find -lbz2
 
 编译时候如果报错 `/usr/bin/ld: cannot find -lbz2`，确认是否安装`bzip2-devel`（版本1.0.6及以上）
@@ -38,3 +38,17 @@
 ## cannot find -lz
 
 编译时候如果报错 `/usr/bin/ld: cannot find -lz`，确认是否安装`zlib-devel`（版本1.2.7及以上）
+
+## `cc1plus: all warnings being treated as errors` 构建`rocksdb`时报错
+
+- 对于`blobstore`模块来说，进入目录`blobstore`后，在`blobstore/env.sh`文件中添加以下新的环境变量后执行`source env.sh`后继续编译:
+
+```bash
+export DISABLE_WARNING_AS_ERROR=true
+```
+
+- 对于`cubefs`根目录而言，请在根目录下的`env.sh`中添加导出环境变量：
+
+```bash
+export CXXFLAGS=-Wno-error
+```

--- a/docs-zh/source/maintenance/admin-api/metanode/dentry.md
+++ b/docs-zh/source/maintenance/admin-api/metanode/dentry.md
@@ -3,7 +3,7 @@
 ## 获取Dentry信息
 
 ``` bash
-curl -v 'http://10.196.59.202:17210/getDentry?pid=100&name="aa.txt"&parentIno=1024'
+curl -v 'http://10.196.59.202:17220/getDentry?pid=100&name="aa.txt"&parentIno=1024'
 ```
 
 | Parameter | Type    | Description               |
@@ -15,7 +15,7 @@ curl -v 'http://10.196.59.202:17210/getDentry?pid=100&name="aa.txt"&parentIno=10
 ## 获取指定目录下全部文件
 
 ``` bash
-curl -v 'http://10.196.59.202:17210/getDirectory?pid=100&parentIno=1024'
+curl -v 'http://10.196.59.202:17220/getDirectory?pid=100&parentIno=1024'
 ```
 
 | Parameter | Type    | Description  |
@@ -27,7 +27,7 @@ curl -v 'http://10.196.59.202:17210/getDirectory?pid=100&parentIno=1024'
 ## 获取指定分片的全部目录信息
 
 ``` bash
-curl -v 'http://10.196.59.202:17210/getAllDentry?pid=100'
+curl -v 'http://10.196.59.202:17220/getAllDentry?pid=100'
 ```
 
 | Parameter | Type    | Description  |

--- a/docs/source/faq/build.md
+++ b/docs/source/faq/build.md
@@ -37,3 +37,17 @@ To resolve the error message "/usr/bin/ld: cannot find -lbz2" during compilation
 ## cannot find -lz
 
 To resolve the error message "/usr/bin/ld: cannot find -lz" during compilation, you should check if the "zlib-devel" package is installed with a version of 1.2.7 or higher.
+
+## `cc1plus: all warnings being treated as errors` on building `rocksdb`
+
+- when building `blobstore`, just enter sub-folder `blobstore` and add following content to the end of `blobstore/env.sh` before executing `source env.sh`:
+
+```bash
+export DISABLE_WARNING_AS_ERROR=true
+```
+
+- when building `cubefs` itself, just add following content at the end of `env.sh` before executing `source env.sh`:
+
+```bash
+export CXXFLAGS=-Wno-error
+```

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	masterSDK "github.com/cubefs/cubefs/sdk/master"
+	"github.com/google/uuid"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -76,6 +77,8 @@ type Cluster struct {
 	masterClient                 *masterSDK.MasterClient
 	checkDataReplicasEnable      bool
 	fileStatsEnable              bool
+	clusterUuid                  string
+	clusterUuidEnable            bool
 }
 
 type followerReadManager struct {
@@ -3437,4 +3440,15 @@ func mergeDataPartitionArr(newDps, oldDps []*DataPartition) []*DataPartition {
 		}
 	}
 	return ret
+}
+
+func (c *Cluster) generateClusterUuid() (err error) {
+	cid := "CID-" + uuid.NewString()
+	c.clusterUuid = cid
+	if err := c.syncPutCluster(); err != nil {
+		c.clusterUuid = ""
+		return errors.NewErrorf(fmt.Sprintf("syncPutCluster failed %v", err.Error()))
+
+	}
+	return
 }

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -195,6 +195,15 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.AdminGetFileStats).
 		HandlerFunc(m.getFileStats)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminSetClusterUuidEnable).
+		HandlerFunc(m.setClusterUuidEnable)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminGetClusterUuid).
+		HandlerFunc(m.getClusterUuid)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminGenerateClusterUuid).
+		HandlerFunc(m.generateClusterUuid)
 
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminGetClusterValue).

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -51,6 +51,8 @@ type clusterValue struct {
 	DecommissionLimit           uint64
 	CheckDataReplicasEnable     bool
 	FileStatsEnable             bool
+	ClusterUuid                 string
+	ClusterUuidEnable           bool
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -72,6 +74,8 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		DecommissionLimit:           c.DecommissionLimit,
 		CheckDataReplicasEnable:     c.checkDataReplicasEnable,
 		FileStatsEnable:             c.fileStatsEnable,
+		ClusterUuid:                 c.clusterUuid,
+		ClusterUuidEnable:           c.clusterUuidEnable,
 	}
 	return cv
 }
@@ -876,6 +880,8 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.cfg.QosMasterAcceptLimit = cv.QosLimitUpload
 		c.DecommissionLimit = cv.DecommissionLimit //dont update nodesets limit for nodesets are not loaded
 		c.fileStatsEnable = cv.FileStatsEnable
+		c.clusterUuid = cv.ClusterUuid
+		c.clusterUuidEnable = cv.ClusterUuidEnable
 
 		if c.cfg.QosMasterAcceptLimit < QosMasterAcceptCnt {
 			c.cfg.QosMasterAcceptLimit = QosMasterAcceptCnt

--- a/metanode/raft_server.go
+++ b/metanode/raft_server.go
@@ -15,12 +15,14 @@
 package metanode
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/cubefs/cubefs/raftstore"
 	"github.com/cubefs/cubefs/util/config"
 	"github.com/cubefs/cubefs/util/errors"
+	"github.com/cubefs/cubefs/util/log"
 )
 
 // StartRaftServer initializes the address resolver and the raftStore server instance.
@@ -33,6 +35,13 @@ func (m *MetaNode) startRaftServer(cfg *config.Config) (err error) {
 		if err = os.MkdirAll(m.raftDir, 0755); err != nil {
 			err = errors.NewErrorf("create raft server dir: %s", err.Error())
 			return
+		}
+	}
+
+	if m.clusterUuidEnable {
+		if err = config.CheckOrStoreClusterUuid(m.raftDir, m.clusterUuid, false); err != nil {
+			log.LogErrorf("CheckOrStoreClusterUuid failed: %v", err)
+			return fmt.Errorf("CheckOrStoreClusterUuid failed: %v", err)
 		}
 	}
 

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -68,6 +68,9 @@ const (
 	AdminSetFileStats                         = "/admin/setFileStatsEnable"
 	AdminGetFileStats                         = "/admin/getFileStatsEnable"
 	AdminGetClusterValue                      = "/admin/getClusterValue"
+	AdminSetClusterUuidEnable                 = "/admin/setClusterUuidEnable"
+	AdminGetClusterUuid                       = "/admin/getClusterUuid"
+	AdminGenerateClusterUuid                  = "/admin/generateClusterUuid"
 	//graphql master api
 	AdminClusterAPI = "/api/cluster"
 	AdminUserAPI    = "/api/user"
@@ -294,6 +297,8 @@ type ClusterInfo struct {
 	DirChildrenNumLimit         uint32
 	EbsAddr                     string
 	ServicePath                 string
+	ClusterUuid                 string
+	ClusterUuidEnable           bool
 }
 
 // CreateDataPartitionRequest defines the request to create a data partition.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. make `CXXFLAGS` customizable for building `cubefs` to prevent from failure from `cc1plus: all warnings are treated as errors`
2. add `FAQ` tips to solve `all warnings are treated as errors` issue on buiding `cubefs/blobstore`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
