### PR TITLE
[Enhancement] make CXXFLAGS customizable for building rocksdb in cubefs

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -173,10 +173,10 @@ build_rocksdb() {
         [ "-$LUA_PATH" != "-" ]  && unset LUA_PATH
         MAJOR=$(echo __GNUC__ | $(which gcc) -E -xc - | tail -n 1)
         if [ ${MAJOR} -ge 10 ] ; then
-          CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move' \
+          CXXFLAGS='-Wno-error=deprecated-copy -Wno-error=class-memaccess -Wno-error=pessimizing-move'" ${CXXFLAGS}" \
 		make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
         elif [ ${MAJOR} -ge 8 ] ; then
-	  CXXFLAGS='-Wno-error=class-memaccess' \
+	  CXXFLAGS='-Wno-error=class-memaccess'" ${CXXFLAGS}" \
 		      make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }
 	else
 		      make -j ${NPROC} static_lib  && echo "build rocksdb success" || {  echo "build rocksdb failed" ; exit 1; }

--- a/docs-zh/source/faq/build.md
+++ b/docs-zh/source/faq/build.md
@@ -23,14 +23,14 @@
            JAVA_LDFLAGS="$JAVA_LDFLAGS -lzstd"
        fi
    ```
-  
+
 
 ## rocksdb编译问题
 
 编译纠删码子系统显示报错 `fatal error: rocksdb/c.h: no such file or directory...`
-- 首先确认`.deps/include/rocksdb`目录下是否存在报错所指向的文件， 
+- 首先确认`.deps/include/rocksdb`目录下是否存在报错所指向的文件，
 - 如果存在 可`source env.sh`后再次尝试，如果没有该文件或者仍然报错，可将`.deps`目录下rocksdb相关的文件全部清理，然后重新编译。
-   
+
 ## cannot find -lbz2
 
 编译时候如果报错 `/usr/bin/ld: cannot find -lbz2`，确认是否安装`bzip2-devel`（版本1.0.6及以上）
@@ -38,3 +38,17 @@
 ## cannot find -lz
 
 编译时候如果报错 `/usr/bin/ld: cannot find -lz`，确认是否安装`zlib-devel`（版本1.2.7及以上）
+
+## `cc1plus: all warnings being treated as errors` 构建`rocksdb`时报错
+
+- 对于`blobstore`模块来说，进入目录`blobstore`后，在`blobstore/env.sh`文件中添加以下新的环境变量后执行`source env.sh`后继续编译:
+
+```bash
+export DISABLE_WARNING_AS_ERROR=true
+```
+
+- 对于`cubefs`根目录而言，请在根目录下的`env.sh`中添加导出环境变量：
+
+```bash
+export CXXFLAGS=-Wno-error
+```

--- a/docs/source/faq/build.md
+++ b/docs/source/faq/build.md
@@ -37,3 +37,17 @@ To resolve the error message "/usr/bin/ld: cannot find -lbz2" during compilation
 ## cannot find -lz
 
 To resolve the error message "/usr/bin/ld: cannot find -lz" during compilation, you should check if the "zlib-devel" package is installed with a version of 1.2.7 or higher.
+
+## `cc1plus: all warnings being treated as errors` on building `rocksdb`
+
+- when building `blobstore`, just enter sub-folder `blobstore` and add following content to the end of `blobstore/env.sh` before executing `source env.sh`:
+
+```bash
+export DISABLE_WARNING_AS_ERROR=true
+```
+
+- when building `cubefs` itself, just add following content at the end of `env.sh` before executing `source env.sh`:
+
+```bash
+export CXXFLAGS=-Wno-error
+```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

### To make CXXFLAGS customizable to prevent failure from `cc1plus: all warnings are treated as errors` on building `rocksdb`

To make it effective, just add `export CXXFLAGS=-Wno-error` at the end of `env.sh` before executing `source env.sh`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
