### PR TITLE
[Enhancement]reuse 3rd-party source tarballs if exists on building blobstore

### DIFF
--- a/blobstore/build.sh
+++ b/blobstore/build.sh
@@ -27,8 +27,8 @@ check=--no-check-certificate
 
 pushd ${INSTALLDIR}
 if [ ! -f lib/libz.a ]; then
-    rm -rf zlib-${ZLIB_VER}*
-    wget https://github.com/madler/zlib/archive/refs/tags/v${ZLIB_VER}.tar.gz -O ./zlib-${ZLIB_VER}.tar.gz ${check}
+    rm -rf zlib-${ZLIB_VER}
+    test -e zlib-${ZLIB_VER}.tar.gz || wget https://github.com/madler/zlib/archive/refs/tags/v${ZLIB_VER}.tar.gz -O ./zlib-${ZLIB_VER}.tar.gz ${check}
     if [ $? -ne 0 ]; then
         exit 1
     fi
@@ -45,8 +45,8 @@ if [ ! -f lib/libz.a ]; then
 fi
 
 if [ ! -f lib/libbz2.a ]; then
-    rm -rf bzip2-bzip2-${BZIP2_VER}*
-    wget https://gitlab.com/bzip2/bzip2/-/archive/bzip2-${BZIP2_VER}/bzip2-bzip2-${BZIP2_VER}.tar.gz
+    rm -rf bzip2-bzip2-${BZIP2_VER}
+    test -e bzip2-bzip2-${BZIP2_VER}.tar.gz || wget https://gitlab.com/bzip2/bzip2/-/archive/bzip2-${BZIP2_VER}/bzip2-bzip2-${BZIP2_VER}.tar.gz
     if [ $? -ne 0 ]; then
         exit 1
     fi
@@ -62,8 +62,8 @@ if [ ! -f lib/libbz2.a ]; then
 fi
 
 if [ ! -f lib/libzstd.a ]; then
-    rm -rf zstd-${ZSTD_VER}*
-    wget https://github.com/facebook/zstd/archive/v${ZSTD_VER}.tar.gz -O zstd-${ZSTD_VER}.tar.gz ${check}
+    rm -rf zstd-${ZSTD_VER}
+    test -e zstd-${ZSTD_VER}.tar.gz || wget https://github.com/facebook/zstd/archive/v${ZSTD_VER}.tar.gz -O zstd-${ZSTD_VER}.tar.gz ${check}
     if [ $? -ne 0 ]; then
         exit 1
     fi
@@ -79,8 +79,8 @@ if [ ! -f lib/libzstd.a ]; then
 fi
 
 if [ ! -f lib/liblz4.a ]; then
-    rm -rf lz4-${LZ4_VER}*
-    wget https://github.com/lz4/lz4/archive/v${LZ4_VER}.tar.gz -O lz4-${LZ4_VER}.tar.gz ${check}
+    rm -rf lz4-${LZ4_VER}
+    test -e lz4-${LZ4_VER}.tar.gz || wget https://github.com/lz4/lz4/archive/v${LZ4_VER}.tar.gz -O lz4-${LZ4_VER}.tar.gz ${check}
     if [ $? -ne 0 ]; then
         exit 1
     fi
@@ -96,8 +96,8 @@ if [ ! -f lib/liblz4.a ]; then
 fi
 
 if [ ! -f lib/libsnappy.a ]; then
-    rm -rf snappy-${SNAPPY_VER}*
-    wget https://github.com/google/snappy/archive/${SNAPPY_VER}.tar.gz -O snappy-${SNAPPY_VER}.tar.gz ${check}
+    rm -rf snappy-${SNAPPY_VER}
+    test -e snappy-${SNAPPY_VER}.tar.gz || wget https://github.com/google/snappy/archive/${SNAPPY_VER}.tar.gz -O snappy-${SNAPPY_VER}.tar.gz ${check}
     if [ $? -ne 0 ]; then
         exit 1
     fi
@@ -117,8 +117,8 @@ if [ ! -f lib/libsnappy.a ]; then
 fi
 
 if [ ! -f lib/librocksdb.a ]; then
-    rm -rf ${INSTALLDIR}/include/rocksdb rocksdb-${ROCKSDB_VER}*
-    wget https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VER}.tar.gz -O rocksdb-${ROCKSDB_VER}.tar.gz ${check}
+    rm -rf ${INSTALLDIR}/include/rocksdb rocksdb-${ROCKSDB_VER}/
+    test -e rocksdb-${ROCKSDB_VER}.tar.gz || wget https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VER}.tar.gz -O rocksdb-${ROCKSDB_VER}.tar.gz ${check}
     if [ $? -ne 0 ]; then
         exit 1
     fi


### PR DESCRIPTION
# build(compiler-cli): reuse 3rd-party source tarball if exists on building blobstore

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

To re-use source tarballs if exists to decrease build time.

With this enhancement, developers can download 3rd-party source tarballs to `.deps/` to accelerate the build process if there is a poor network to GitHub.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
