### PR TITLE
[Enhancement] metanode: GetCurrentTimeUnix use atomic

### DIFF
--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -105,7 +105,7 @@ func (i *Inode) String() string {
 // NewInode returns a new Inode instance with specified Inode ID, name and type.
 // The AccessTime and ModifyTime will be set to the current time.
 func NewInode(ino uint64, t uint32) *Inode {
-	ts := Now.GetCurrentTime().Unix()
+	ts := Now.GetCurrentTimeUnix()
 	i := &Inode{
 		Inode:      ino,
 		Type:       t,
@@ -638,7 +638,7 @@ func (i *Inode) DoReadFunc(fn func()) {
 
 // SetMtime sets mtime to the current time.
 func (i *Inode) SetMtime() {
-	mtime := Now.GetCurrentTime().Unix()
+	mtime := Now.GetCurrentTimeUnix()
 	i.Lock()
 	defer i.Unlock()
 	i.ModifyTime = mtime

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -897,7 +897,7 @@ func (mp *metaPartition) doCacheTTL(cacheTTL int) (err error) {
 }
 
 func (mp *metaPartition) InodeTTLScan(cacheTTL int) {
-	curTime := Now.GetCurrentTime().Unix()
+	curTime := Now.GetCurrentTimeUnix()
 	// begin
 	count := 0
 	needSleep := false
@@ -923,7 +923,7 @@ func (mp *metaPartition) InodeTTLScan(cacheTTL int) {
 				Inode: inode.Inode,
 			}
 			ino := NewInode(req.Inode, 0)
-			curTime = Now.GetCurrentTime().Unix()
+			curTime = Now.GetCurrentTimeUnix()
 			if inode.ModifyTime < curTime {
 				ino.ModifyTime = curTime
 			}

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -74,7 +74,7 @@ func (mp *metaPartition) getInode(ino *Inode) (resp *InodeResponse) {
 		resp.Status = proto.OpNotExistErr
 		return
 	}
-	ctime := Now.GetCurrentTime().Unix()
+	ctime := Now.GetCurrentTimeUnix()
 	/*
 	 * FIXME: not protected by lock yet, since nothing is depending on atime.
 	 * Shall add inode lock in the future.

--- a/metanode/time.go
+++ b/metanode/time.go
@@ -16,6 +16,7 @@ package metanode
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -25,7 +26,8 @@ var Now = NewNowTime()
 // NowTime defines the current time.
 type NowTime struct {
 	sync.RWMutex
-	now time.Time
+	now      time.Time
+	timeUnix int64
 }
 
 // GetCurrentTime returns the current time.
@@ -36,6 +38,11 @@ func (t *NowTime) GetCurrentTime() (now time.Time) {
 	return
 }
 
+// GetCurrentTimeUnix returns the current time unix
+func (t *NowTime) GetCurrentTimeUnix() int64 {
+	return atomic.LoadInt64(&t.timeUnix)
+}
+
 // UpdateTime updates the stored time.
 func (t *NowTime) UpdateTime(now time.Time) {
 	t.Lock()
@@ -43,10 +50,16 @@ func (t *NowTime) UpdateTime(now time.Time) {
 	t.Unlock()
 }
 
+// UpdateTimeUnix updates the stored time unix.
+func (t *NowTime) UpdateTimeUnix(now int64) {
+	atomic.StoreInt64(&t.timeUnix, now)
+}
+
 // NewNowTime returns a new NowTime.
 func NewNowTime() *NowTime {
 	return &NowTime{
-		now: time.Now(),
+		now:      time.Now(),
+		timeUnix: time.Now().Unix(),
 	}
 }
 
@@ -56,6 +69,7 @@ func init() {
 			time.Sleep(time.Second)
 			now := time.Now()
 			Now.UpdateTime(now)
+			Now.UpdateTimeUnix(now.Unix())
 		}
 	}()
 }

--- a/metanode/time_test.go
+++ b/metanode/time_test.go
@@ -1,0 +1,41 @@
+package metanode
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetCurrentTimeUnix(t *testing.T) {
+	t1 := Now.GetCurrentTimeUnix()
+	t2 := Now.GetCurrentTime().Unix()
+	n := time.Now().Unix()
+	if n-t1 > 1 || n-t2 > 1 {
+		t.Errorf("wrong time: %d %d %d", n, t1, t2)
+	}
+
+	time.Sleep(time.Second * 2)
+	t1 = Now.GetCurrentTimeUnix()
+	t2 = Now.GetCurrentTime().Unix()
+	n = time.Now().Unix()
+	if n-t1 > 1 || n-t2 > 1 {
+		t.Errorf("wrong time: %d %d %d", n, t1, t2)
+	}
+}
+
+func BenchmarkGetCurrentTimeUnix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Now.GetCurrentTimeUnix()
+	}
+}
+
+func BenchmarkGetCurrentTime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Now.GetCurrentTime().Unix()
+	}
+}
+
+func BenchmarkGetNowTime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		time.Now().Unix()
+	}
+}

--- a/metanode/time_test.go
+++ b/metanode/time_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package metanode
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
GetCurrentTimeUnix use atomic is much quicker

**benchmark**
```
$ go test -bench="^BenchmarkGet" -run=none
goos: linux
goarch: amd64
pkg: github.com/cubefs/cubefs/metanode
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkGetCurrentTimeUnix-16    	1000000000	         0.3317 ns/op
BenchmarkGetCurrentTime-16        	100000000	        10.98 ns/op
BenchmarkGetNowTime-16            	43397809	        27.76 ns/op
PASS
ok  	github.com/cubefs/cubefs/metanode	2.796s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
