### PR TITLE
[Fix] metanode snapshot not scheduled

### DIFF
--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -17,10 +17,8 @@ package datanode
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/cubefs/cubefs/depends/tiglabs/raft"
 	raftproto "github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
@@ -146,16 +144,6 @@ func (dp *DataPartition) HandleLeaderChange(leader uint64) {
 			panic(mesg)
 		}
 	}()
-	if dp.config.NodeID == leader {
-		conn, err := net.DialTimeout("tcp", net.JoinHostPort(LocalIP, serverPort), time.Second)
-		if err != nil {
-			log.LogErrorf(fmt.Sprintf("HandleLeaderChange PartitionID(%v) serverPort not exsit ,error %v", dp.partitionID, err))
-			go dp.raftPartition.TryToLeader(dp.partitionID)
-			return
-		}
-		conn.(*net.TCPConn).SetLinger(0)
-		conn.Close()
-	}
 	if dp.config.NodeID == leader {
 		dp.isRaftLeader = true
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. fix HandleLeaderChange trytoleader wrong use: 
metanode's tcp server is started before start raft (fixed here: https://github.com/cubefs/cubefs/pull/1256/commits/38fb340311781ba9d7cacad34a3fcd765bccea84) , so there is no need to dail server port, what's more trytoleader is wrong used, trytoleader will let this node force compagin and try to become leader , it will do nothing because this node is already became leader. L:407 returned after trytoleader will cause startStoreTick never be triggered....
![image](https://user-images.githubusercontent.com/6017354/236609355-e4ca12c3-167d-4506-b2e5-b9591eedb810.png)

2. scheduleState should use atomic
we met one region didn't dump snapshot, but other regions(include leader) could dump regularly.  i found scheduleState has race condition, which may cause  if condition always false. detail here: https://go.dev/ref/mem

![image](https://user-images.githubusercontent.com/6017354/236609706-06ad11dc-1470-4734-bb5c-22dbe493e4df.png)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
