### PR TITLE
mount point supports non-repeatable mount

### DIFF
--- a/depends/jacobsa/fuse/mount.go
+++ b/depends/jacobsa/fuse/mount.go
@@ -23,7 +23,7 @@ import (
 // Server is an interface for any type that knows how to serve ops read from a
 // connection.
 type Server interface {
-	// Read and serve ops from the supplied connection until EOF. Do not return
+	// ServeOps Read and serve ops from the supplied connection until EOF. Do not return
 	// until all operations have been responded to. Must not be called more than
 	// once.
 	ServeOps(*Connection)
@@ -97,5 +97,35 @@ func Mount(
 		return
 	}
 
+	return
+}
+
+// Check if the mount exists
+func mount(dir string, config *MountConfig, ready chan error) (dev *os.File, err error) {
+	// Determine if a directory exists
+	if len(dir) == 1 {
+		return
+	}
+	// Check Context
+	if config.OpContext != nil {
+		return
+	}
+	// Signal that the mount operation is complete.
+	ready <- nil
+
+	// Check the device file descriptor.
+	dev, err = os.Open("/dev/")
+	if err != nil {
+		err = fmt.Errorf("open device: %v", err)
+		return
+	} else if os.IsExist(err) {
+		return
+	}
+	defer func(dev *os.File) {
+		err := dev.Close()
+		if err != nil {
+			return
+		}
+	}(dev)
 	return
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
Signed-off-by: mfordjody [mfordjody@gmail.com](mailto:mfordjody@gmail.com)

**What this PR does / why we need it**:
Client mount point supports non-repeatable mount.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/cubefs/cubefs/issues/1904

**Special notes for your reviewer**:
None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
