### PR TITLE
[Feature]: The blobstore-cli supports setting background task switch #1898

### DIFF
--- a/blobstore/cli/clustermgr/config.go
+++ b/blobstore/cli/clustermgr/config.go
@@ -128,4 +128,5 @@ func addCmdConfig(cmd *grumble.Command) {
 			return nil
 		},
 	})
+	addCmdConfigBackground(configCommand)
 }

--- a/blobstore/cli/clustermgr/config_background.go
+++ b/blobstore/cli/clustermgr/config_background.go
@@ -1,0 +1,173 @@
+// Copyright 2022 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package clustermgr
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/desertbit/grumble"
+
+	"github.com/cubefs/cubefs/blobstore/api/clustermgr"
+	"github.com/cubefs/cubefs/blobstore/cli/common"
+	"github.com/cubefs/cubefs/blobstore/cli/common/flags"
+	"github.com/cubefs/cubefs/blobstore/cli/common/fmt"
+	"github.com/cubefs/cubefs/blobstore/common/rpc"
+)
+
+const notSet = "<not set>"
+
+var BackgroundTaskTypes = []string{"disk_repair", "balance", "disk_drop", "volume_inspect", "shard_repair", "blob_delete"}
+var BackgroundTaskTypeString = "[" + strings.Join(BackgroundTaskTypes, ", ") + "]"
+
+func addCmdConfigBackground(cmd *grumble.Command) {
+	backgroundCommand := &grumble.Command{
+		Name:     "background",
+		Help:     "background task switch",
+		LongHelp: "Background task switch control for clustermgr, currently supported: " + BackgroundTaskTypeString,
+	}
+	cmd.AddCommand(backgroundCommand)
+
+	backgroundCommand.AddCommand(&grumble.Command{
+		Name:     "status",
+		Help:     "show status of a background task switch",
+		LongHelp: "Show status of a specific background task type, currently supported: " + BackgroundTaskTypeString,
+		Args: func(a *grumble.Args) {
+			a.String("task", "background task type")
+		},
+		Run: cmdListBackgroundStatus,
+		Flags: func(f *grumble.Flags) {
+			flags.VerboseRegister(f)
+			clusterFlags(f)
+		},
+	})
+	backgroundCommand.AddCommand(&grumble.Command{
+		Name:     "enable",
+		Help:     "enable background task",
+		LongHelp: "Enable a specific background task type, currently supported: " + BackgroundTaskTypeString,
+		Args: func(a *grumble.Args) {
+			a.String("task", "background task type")
+		},
+		Flags: clusterFlags,
+		Run: func(c *grumble.Context) error {
+			return cmdEnableDisableBackgroundTask(c, true)
+		},
+	})
+	backgroundCommand.AddCommand(&grumble.Command{
+		Name:     "disable",
+		Help:     "disable background task",
+		LongHelp: "Disable a specific background task type, currently supported: " + BackgroundTaskTypeString,
+		Args: func(a *grumble.Args) {
+			a.String("task", "background task type")
+		},
+		Flags: clusterFlags,
+		Run: func(c *grumble.Context) error {
+			return cmdEnableDisableBackgroundTask(c, false)
+		},
+	})
+}
+
+func cmdEnableDisableBackgroundTask(c *grumble.Context, en bool) error {
+	key := c.Args.String("task")
+
+	found := false
+	for _, kind := range BackgroundTaskTypes {
+		if kind == key {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("Unsupported background task type: %s", key)
+	}
+
+	value := "true"
+	act, acted := "enable", "enabled"
+	if !en {
+		value = "false"
+		act, acted = "disable", "disabled"
+	}
+
+	cli := newCMClient(c.Flags)
+	ctx := common.CmdContext()
+	oldV, err := cli.GetConfig(ctx, key)
+	if err != nil {
+		if rpc.DetectStatusCode(err) != http.StatusNotFound &&
+			!common.Confirm("To "+act+" background task of : "+common.Loaded.Sprint(key)+" ?") {
+			return err
+		}
+	}
+
+	if oldV == value {
+		fmt.Printf("Background task of type `%s` has already been %s.", key, acted)
+		return nil
+	}
+
+	if "" == oldV {
+		oldV = notSet
+	}
+
+	fmt.Printf("Current status of background task of `%s`:\n", key)
+	showConfig(key, oldV, true)
+
+	if common.Confirm(fmt.Sprintf(
+		"To %s background task `%s` from `%s` --> `%s` ?", act, common.Loaded.Sprint(key),
+		common.Danger.Sprint(oldV), common.Normal.Sprint(value))) {
+		err := cli.SetConfig(ctx, &clustermgr.ConfigSetArgs{
+			Key:   key,
+			Value: value,
+		})
+		if nil != err {
+			if e, ok := err.(*rpc.Error); ok {
+				return fmt.Errorf(e.Code)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func cmdListBackgroundStatus(c *grumble.Context) error {
+	key := c.Args.String("task")
+
+	found := false
+	for _, kind := range BackgroundTaskTypes {
+		if kind == key {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("Unsupported background task type: %s", key)
+	}
+
+	cli := newCMClient(c.Flags)
+	ctx := common.CmdContext()
+	verbose := flags.Verbose(c.Flags)
+
+	fmt.Printf("Current status of background task `%s`:\n", key)
+	value, err := cli.GetConfig(ctx, key)
+	if err != nil {
+		if rpc.DetectStatusCode(err) == http.StatusNotFound {
+			showConfig(key, notSet, verbose)
+			return nil
+		}
+		return err
+	}
+	showConfig(key, value, verbose)
+	return nil
+}

--- a/docs-zh/source/maintenance/admin-api/blobstore/cm.md
+++ b/docs-zh/source/maintenance/admin-api/blobstore/cm.md
@@ -96,7 +96,7 @@ curl "http://127.0.0.1:9998/stat"
 添加节点，指定节点类型，地址和id。
 
 ```bash
-curl -X POST --header 'Content-Type: application/json' -d '{"peer_id": 1, "host": "127.0.0.1:10110","node_host": "127.0.0.1:9998", "member_type": 2}' "http://127.0.0.1:9998/member/add" 
+curl -X POST --header 'Content-Type: application/json' -d '{"peer_id": 1, "host": "127.0.0.1:10110","node_host": "127.0.0.1:9998", "member_type": 2}' "http://127.0.0.1:9998/member/add"
 ```
 
 **参数列表**
@@ -275,16 +275,22 @@ curl "http://127.0.0.1:9998/volume/get?vid=1"
 
 ```bash
 curl http://127.0.0.1:9998/config/get?key=balance
+# 或者使用 blobstore-cli
+blobstore-cli cm config background status balance
 ```
 
 开启任务
 
 ```bash
 curl -X POST http://127.0.0.1:9998/config/set -d '{"key":"balance","value":"true"}' --header 'Content-Type: application/json'
+# 或者使用 blobstore-cli
+blobstore-cli cm config background enable balance
 ```
 
 关闭任务
 
 ```bash
 curl -X POST http://127.0.0.1:9998/config/set -d '{"key":"balance","value":"false"}' --header 'Content-Type: application/json'
+# 或者使用 blobstore-cli
+blobstore-cli cm config background disable balance
 ```

--- a/docs/source/maintenance/admin-api/blobstore/cm.md
+++ b/docs/source/maintenance/admin-api/blobstore/cm.md
@@ -96,7 +96,7 @@ curl "http://127.0.0.1:9998/stat"
 Add a node by specifying the node type, address, and ID.
 
 ```bash
-curl -X POST --header 'Content-Type: application/json' -d '{"peer_id": 1, "host": "127.0.0.1:10110","node_host": "127.0.0.1:9998", "member_type": 2}' "http://127.0.0.1:9998/member/add" 
+curl -X POST --header 'Content-Type: application/json' -d '{"peer_id": 1, "host": "127.0.0.1:10110","node_host": "127.0.0.1:9998", "member_type": 2}' "http://127.0.0.1:9998/member/add"
 ```
 
 **Parameter List**
@@ -275,16 +275,22 @@ View task status
 
 ```bash
 curl http://127.0.0.1:9998/config/get?key=balance
+# or use blobstore-cli
+blobstore-cli cm config background status balance
 ```
 
 Enable task
 
 ```bash
 curl -X POST http://127.0.0.1:9998/config/set -d '{"key":"balance","value":"true"}' --header 'Content-Type: application/json'
+# or use blobstore-cli
+blobstore-cli cm config background enable balance
 ```
 
 Disable task
 
 ```bash
 curl -X POST http://127.0.0.1:9998/config/set -d '{"key":"balance","value":"false"}' --header 'Content-Type: application/json'
+# or use blobstore-cli
+blobstore-cli cm config background disable balance
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support new feature requested in issue #1898 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1898 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- `blobstore-cli` now support `enable` or `disable` background task switches
```
