### PR TITLE
fix(cfsauto): fix build time for cfsauto -V option

### DIFF
--- a/autofs/README.md
+++ b/autofs/README.md
@@ -5,7 +5,7 @@ automount tool for [cubefs](https://github.com/cubefs/cubefs)
 ## build
 
 ```bash
-go build -v -ldflags="-X main.buildVersion=1.1" -o /usr/local/bin
+go build -v -ldflags="-X main.buildVersion=1.1 -X 'main.buildDate=$(date '+%Y-%m-%d %H:%M:%S')'" -o /usr/local/bin
 ```
 
 ## quick start
@@ -22,6 +22,12 @@ cfsauto
 ### version
 
 cfsauto -V
+
+example:
+
+```bash
+Version: 1.1, BuildDate: 2023-05-18 15:08:00
+```
 
 
 ## LDAP automount example

--- a/autofs/main.go
+++ b/autofs/main.go
@@ -5,11 +5,10 @@ import (
 	"github.com/spf13/cobra"
 	"log"
 	"os"
-	"time"
 )
 
 var buildVersion = "DebugVersion"
-var buildDate = time.Now().String()
+var buildDate = "BuildDate"
 
 var logFile *os.File
 


### PR DESCRIPTION
fix(cfsauto): fix build time for cfsauto -V option

for example:

```bash
go build -v -ldflags="-X main.buildVersion=1.1 -X 'main.buildDate=$(date '+%Y-%m-%d %H:%M:%S')'"
./cfsauto -V
# Version: 1.1, BuildDate: 2023-05-18 15:22:58
```

Please check the README.md file under autofs direction for more details.

