### PR TITLE
fix(fsck): The clean command not initialize bufferPool causing the pr…

### DIFF
--- a/fsck/cmd/clean.go
+++ b/fsck/cmd/clean.go
@@ -32,6 +32,10 @@ import (
 	"github.com/cubefs/cubefs/util/ump"
 )
 
+const (
+	BuffersTotalLimit = 1024 * 1024 // 1M
+)
+
 var gMetaWrapper *meta.MetaWrapper
 
 func newCleanCmd() *cobra.Command {
@@ -116,6 +120,8 @@ func Clean(opt string) error {
 	if err != nil {
 		return fmt.Errorf("NewMetaWrapper failed: %v", err)
 	}
+
+	proto.InitBufferPool(BuffersTotalLimit)
 
 	switch opt {
 	case "inode":


### PR DESCRIPTION
<img width="886" alt="image" src="https://github.com/cubefs/cubefs/assets/2844826/339f33b9-8798-4536-9e79-42cc7a85a184">


If we run the clean command to trigger evictInode, it will throw exception.
The reason is that the bufferPool not initialized.