### PR TITLE
enhance(client): improve the client restore process

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -140,6 +140,7 @@ func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) error {
 		return ParseError(err)
 	}
 	fillAttr(info, a)
+	a.ParentIno = d.parentIno
 	log.LogDebugf("TRACE Attr: inode(%v)", info)
 	return nil
 }


### PR DESCRIPTION
The following figure shows the process of upgrading cfs-client. This is a good feature and we want to use it in production environment. 
We tested it for a while and found some problems, especially when the old client processing quit but the new client failed to start up, will cause the test failed.
![image](https://github.com/cubefs/cubefs/assets/2844826/61662423-60e9-465e-aa35-3e7dd4cad5ab)

So we want to improve the process that the old client waits until the new client restored data.
![image](https://github.com/cubefs/cubefs/assets/2844826/a392fb26-f558-4b1b-a422-f3b35f7b71b4)

The main changes are as follow:
1. Restoring the nodecache correctly, including the name attribute
2. The old client continues to suspend after its trySuspend function is completed. After the new client restored data, it sends the shutdown command to make the old client quit.
