### PR TITLE
fix: always return success even write error

### DIFF
--- a/sdk/data/blobstore/writer.go
+++ b/sdk/data/blobstore/writer.go
@@ -169,8 +169,8 @@ func (writer *Writer) doParallelWrite(ctx context.Context, data []byte, offset i
 	}
 	writer.wg.Wait()
 	for i := 0; i < sliceSize; i++ {
-		if wErr, ok := <-writer.err; !ok || err != nil {
-			log.LogErrorf("slice write error,ino(%v) fileoffset(%v) sliceSize(%v) err(%v)", writer.ino, wErr.fileOffset, wErr.size, err)
+		if wErr := <-writer.err; wErr != nil {
+			log.LogErrorf("slice write error,ino(%v) fileoffset(%v) sliceSize(%v) err(%v)", writer.ino, wErr.fileOffset, wErr.size, wErr.err)
 			return 0, wErr.err
 		}
 	}


### PR DESCRIPTION
err is always nil, so this condition can never be reached