### PR TITLE
enhance(fsck): add commands to obtain the inode's fullpath and summar…

### DIFF
--- a/fsck/cmd/common.go
+++ b/fsck/cmd/common.go
@@ -33,6 +33,7 @@ var (
 	inodeUpdateDumpFileName    string = "inode.dump.update"
 	obsoleteInodeDumpFileName  string = "inode.dump.obsolete"
 	obsoleteDentryDumpFileName string = "dentry.dump.obsolete"
+	pathDumpFileName           string = "path.dump"
 )
 
 type Inode struct {
@@ -46,6 +47,10 @@ type Inode struct {
 
 	Dens  []*Dentry
 	Valid bool
+	Files uint64
+	Dirs  uint64
+	Bytes uint64
+	Path  string
 }
 
 func (i *Inode) String() string {

--- a/fsck/cmd/getInfo.go
+++ b/fsck/cmd/getInfo.go
@@ -15,22 +15,59 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/cubefs/cubefs/proto"
-	"github.com/spf13/cobra"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/errors"
 )
+
+const (
+	MaxFollowPathTaskNum = 120
+)
+
+type Summary struct {
+	files uint64
+	dirs  uint64
+	bytes uint64
+}
 
 func newInfoCmd() *cobra.Command {
 	var c = &cobra.Command{
 		Use:   "get",
-		Short: "get inode's info",
+		Short: "get info of specified inode",
+		Args:  cobra.MinimumNArgs(0),
+	}
+
+	c.AddCommand(
+		newGetLocationsCmd(),
+		newGetPathCmd(),
+		newGetSummaryCmd(),
+	)
+
+	return c
+}
+
+func newGetLocationsCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "locations",
+		Short: "get inode's locations",
 		Args:  cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := getInodeInfo(); err != nil {
+			if err := getInodeLocations(); err != nil {
 				fmt.Println(err)
 			}
 		},
@@ -39,7 +76,36 @@ func newInfoCmd() *cobra.Command {
 	return c
 }
 
-func getInodeInfo() (err error) {
+func newGetPathCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "path",
+		Short: "get inode's path",
+		Args:  cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := getInodePath(); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+
+	return c
+}
+
+func newGetSummaryCmd() *cobra.Command {
+	var c = &cobra.Command{
+		Use:   "summary",
+		Short: "get inode's summary",
+		Args:  cobra.MinimumNArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := getInodeSummary(); err != nil {
+				fmt.Println(err)
+			}
+		},
+	}
+	return c
+}
+
+func getInodeLocations() (err error) {
 	mps, err := getMetaPartitions(MasterAddr, VolName)
 	if err != nil {
 		return err
@@ -51,7 +117,7 @@ func getInodeInfo() (err error) {
 			if er != nil {
 				return er
 			}
-			dumpInodeInfo(InodeID, mp, res)
+			dumpInodeLocations(InodeID, mp, res)
 			break
 		}
 	}
@@ -100,7 +166,7 @@ func getExtentsByInode(ino uint64, mp *proto.MetaPartitionView) (res *proto.GetE
 	return
 }
 
-func dumpInodeInfo(ino uint64, mp *proto.MetaPartitionView, res *proto.GetExtentsResponse) {
+func dumpInodeLocations(ino uint64, mp *proto.MetaPartitionView, res *proto.GetExtentsResponse) {
 	fmt.Printf("Inode: %v\n", ino)
 	fmt.Printf("Generation: %v\n", res.Generation)
 	fmt.Printf("Size: %v\n", res.Size)
@@ -167,4 +233,387 @@ func getDataPartitions(addr, name string) ([]*proto.DataPartitionResponse, error
 	}
 
 	return dpv.DataPartitions, nil
+}
+
+func getInodePath() (err error) {
+	imap := make(map[uint64]*Inode)
+	if err = buildInodeMap(imap); err != nil {
+		return
+	}
+	if InodeID != 0 {
+		fmt.Printf("Inode: %v, Valid: %v\n", InodeID, imap[InodeID].Valid)
+		fmt.Printf("Path: %v\n", imap[InodeID].Path)
+	} else {
+		// dump all inode path
+		err = dumpAllInodePath(imap, fmt.Sprintf("%s_%s", VolName, pathDumpFileName))
+		if err != nil {
+			return err
+		}
+	}
+	return
+}
+
+func buildInodeMap(imap map[uint64]*Inode) (err error) {
+	mps, err := getMetaPartitions(MasterAddr, VolName)
+	if err != nil {
+		return err
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	errs := make([]error, 0)
+	wg.Add(len(mps))
+	for _, m := range mps {
+		mp := m
+		go func() {
+			defer wg.Done()
+			if e := getInodesFromMp(mp, imap, &mu); e != nil {
+				mu.Lock()
+				errs = append(errs, e)
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(errs) > 0 {
+		return errs[0]
+	}
+
+	wg.Add(len(mps))
+	for _, m := range mps {
+		mp := m
+		go func() {
+			defer wg.Done()
+			if e := getDentriesFromMp(mp, imap, &mu); e != nil {
+				mu.Lock()
+				errs = append(errs, e)
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(errs) > 0 {
+		return errs[0]
+	}
+
+	root, ok := imap[1]
+	if !ok {
+		err = fmt.Errorf("No root inode")
+		return
+	}
+
+	var taskNum int32 = 0
+	wg.Add(1)
+	atomic.AddInt32(&taskNum, 1)
+	traversePath(imap, root, &wg, &taskNum, true)
+	wg.Wait()
+
+	root.Path = "/"
+
+	return
+}
+
+func getInodesFromMp(mp *proto.MetaPartitionView, imap map[uint64]*Inode, mu *sync.Mutex) (err error) {
+	resp, err := http.Get(fmt.Sprintf("http://%s:%s/getInodeSnapshot?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], MetaPort, mp.PartitionID))
+	if err != nil {
+		return fmt.Errorf("Get request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Invalid status code: %v", resp.StatusCode)
+	}
+
+	reader := bufio.NewReaderSize(resp.Body, 4*1024*1024)
+	inoBuf := make([]byte, 4)
+	for {
+		inoBuf = inoBuf[:4]
+		// first read length
+		_, err = io.ReadFull(reader, inoBuf)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+				return
+			}
+			err = errors.NewErrorf("[loadInode] ReadHeader: %s", err.Error())
+			return
+		}
+		length := binary.BigEndian.Uint32(inoBuf)
+
+		// next read body
+		if uint32(cap(inoBuf)) >= length {
+			inoBuf = inoBuf[:length]
+		} else {
+			inoBuf = make([]byte, length)
+		}
+		_, err = io.ReadFull(reader, inoBuf)
+		if err != nil {
+			err = errors.NewErrorf("[loadInode] ReadBody: %s", err.Error())
+			return
+		}
+		inode := &Inode{Dens: make([]*Dentry, 0)}
+		if err = decodeInode(inoBuf, inode); err != nil {
+			err = errors.NewErrorf("[loadInode] Unmarshal: %s", err.Error())
+			return
+		}
+
+		mu.Lock()
+		imap[inode.Inode] = inode
+		mu.Unlock()
+	}
+}
+
+func getDentriesFromMp(mp *proto.MetaPartitionView, imap map[uint64]*Inode, mu *sync.Mutex) (err error) {
+	resp, err := http.Get(fmt.Sprintf("http://%s:%s/getDentrySnapshot?pid=%d", strings.Split(mp.LeaderAddr, ":")[0], MetaPort, mp.PartitionID))
+	if err != nil {
+		return fmt.Errorf("Get request failed: %v %v", resp, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("Invalid status code: %v", resp.StatusCode)
+	}
+
+	reader := bufio.NewReaderSize(resp.Body, 4*1024*1024)
+	dentryBuf := make([]byte, 4)
+	for {
+		dentryBuf = dentryBuf[:4]
+		// First Read 4byte header length
+		_, err = io.ReadFull(reader, dentryBuf)
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+				return
+			}
+			err = errors.NewErrorf("[loadDentry] ReadHeader: %s", err.Error())
+			return
+		}
+
+		length := binary.BigEndian.Uint32(dentryBuf)
+
+		// next read body
+		if uint32(cap(dentryBuf)) >= length {
+			dentryBuf = dentryBuf[:length]
+		} else {
+			dentryBuf = make([]byte, length)
+		}
+		_, err = io.ReadFull(reader, dentryBuf)
+		if err != nil {
+			err = errors.NewErrorf("[loadDentry]: ReadBody: %s", err.Error())
+			return
+		}
+		den := &Dentry{}
+		if err = decodeDentry(dentryBuf, den); err != nil {
+			err = errors.NewErrorf("[loadDentry] Unmarshal: %s", err.Error())
+			return
+		}
+
+		inode, ok := imap[den.ParentId]
+		if ok {
+			inode.Dens = append(inode.Dens, den)
+		}
+	}
+}
+
+func traversePath(imap map[uint64]*Inode, inode *Inode, wg *sync.WaitGroup, taskNum *int32, newTask bool) {
+	defer func() {
+		if newTask {
+			atomic.AddInt32(taskNum, -1)
+			wg.Done()
+		}
+	}()
+	inode.Valid = true
+	// there is no down path for file inode
+	if inode.Type == 0 || len(inode.Dens) == 0 {
+		return
+	}
+
+	for _, den := range inode.Dens {
+		childInode, ok := imap[den.Inode]
+		if !ok {
+			continue
+		}
+		den.Valid = true
+		childInode.Path = inode.Path + "/" + den.Name
+		if proto.IsRegular(childInode.Type) {
+			inode.Bytes += childInode.Size
+			inode.Files++
+		} else if proto.IsDir(childInode.Type) {
+			inode.Dirs++
+		} else if proto.IsSymlink(childInode.Type) {
+			inode.Files++
+		}
+		if atomic.LoadInt32(taskNum) < MaxFollowPathTaskNum {
+			wg.Add(1)
+			atomic.AddInt32(taskNum, 1)
+			go traversePath(imap, childInode, wg, taskNum, true)
+		} else {
+			traversePath(imap, childInode, wg, taskNum, false)
+		}
+	}
+}
+
+func dumpAllInodePath(imap map[uint64]*Inode, name string) error {
+	fp, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	for _, inode := range imap {
+		context := fmt.Sprintf("Inode: %v, Valid: %v, Path: %v\n", inode.Inode, inode.Valid, inode.Path)
+		if _, err = fp.WriteString(context); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getInodeSummary() (err error) {
+	imap := make(map[uint64]*Inode)
+	if err = buildInodeMap(imap); err != nil {
+		return
+	}
+
+	start := time.Now()
+	inode := imap[InodeID]
+	if proto.IsRegular(inode.Type) {
+		fmt.Printf("Inode: %v, Valid: %v\n", InodeID, inode.Valid)
+		fmt.Printf("Path(is file): %v, Bytes: %v\n", inode.Path, inode.Bytes)
+	} else if proto.IsDir(inode.Type) {
+		files, dirs, bytes := dirSummary(imap, inode)
+		fmt.Printf("Summary cost: %v\n", time.Since(start))
+		fmt.Printf("Inode: %v, Valid: %v\n", InodeID, inode.Valid)
+		fmt.Printf("Path(is dir): %v, Files: %v, Dirs: %v, Bytes: %v\n", inode.Path, files, dirs, bytes)
+	} else {
+		return fmt.Errorf("inode type: %v not support", inode.Type)
+	}
+	return
+}
+
+func dirSummary(imap map[uint64]*Inode, inode *Inode) (files, dirs, bytes uint64) {
+	if len(inode.Dens) == 0 {
+		return
+	}
+	files = inode.Files
+	dirs = inode.Dirs
+	bytes = inode.Bytes
+	for _, den := range inode.Dens {
+		if proto.IsDir(den.Type) {
+			f, d, b := dirSummary(imap, imap[den.Inode])
+			files += f
+			dirs += d
+			bytes += b
+		}
+	}
+	return
+}
+
+func decodeDentry(raw []byte, d *Dentry) (err error) {
+	var (
+		keyLen uint32
+		valLen uint32
+	)
+	buff := bytes.NewBuffer(raw)
+	if err = binary.Read(buff, binary.BigEndian, &keyLen); err != nil {
+		return
+	}
+	keyBytes := make([]byte, keyLen)
+	if _, err = buff.Read(keyBytes); err != nil {
+		return
+	}
+	keyBuff := bytes.NewBuffer(keyBytes)
+	if err = binary.Read(keyBuff, binary.BigEndian, &d.ParentId); err != nil {
+		return
+	}
+	d.Name = string(keyBuff.Bytes())
+	if err = binary.Read(buff, binary.BigEndian, &valLen); err != nil {
+		return
+	}
+	valBytes := make([]byte, valLen)
+	if _, err = buff.Read(valBytes); err != nil {
+		return
+	}
+	valBuff := bytes.NewBuffer(valBytes)
+	if err = binary.Read(valBuff, binary.BigEndian, &d.Inode); err != nil {
+		return
+	}
+	err = binary.Read(valBuff, binary.BigEndian, &d.Type)
+	return
+}
+
+func decodeInode(raw []byte, ino *Inode) (err error) {
+	var (
+		keyLen uint32
+		valLen uint32
+	)
+	buff := bytes.NewBuffer(raw)
+	if err = binary.Read(buff, binary.BigEndian, &keyLen); err != nil {
+		return
+	}
+	keyBytes := make([]byte, keyLen)
+	if _, err = buff.Read(keyBytes); err != nil {
+		return
+	}
+
+	ino.Inode = binary.BigEndian.Uint64(keyBytes)
+
+	if err = binary.Read(buff, binary.BigEndian, &valLen); err != nil {
+		return
+	}
+	valBytes := make([]byte, valLen)
+	if _, err = buff.Read(valBytes); err != nil {
+		return
+	}
+	err = unmarshalValue(valBytes, ino)
+	return
+}
+
+func unmarshalValue(val []byte, i *Inode) (err error) {
+	buff := bytes.NewBuffer(val)
+
+	if err = binary.Read(buff, binary.BigEndian, &i.Type); err != nil {
+		return
+	}
+	var tmp1 uint32
+	var tmp2 uint64
+	if err = binary.Read(buff, binary.BigEndian, &tmp1); err != nil {
+		return
+	}
+	if err = binary.Read(buff, binary.BigEndian, &tmp1); err != nil {
+		return
+	}
+	if err = binary.Read(buff, binary.BigEndian, &i.Size); err != nil {
+		return
+	}
+	if err = binary.Read(buff, binary.BigEndian, &tmp2); err != nil {
+		return
+	}
+	if err = binary.Read(buff, binary.BigEndian, &i.CreateTime); err != nil {
+		return
+	}
+	if err = binary.Read(buff, binary.BigEndian, &i.AccessTime); err != nil {
+		return
+	}
+	if err = binary.Read(buff, binary.BigEndian, &i.ModifyTime); err != nil {
+		return
+	}
+	// read symLink
+	symSize := uint32(0)
+	if err = binary.Read(buff, binary.BigEndian, &symSize); err != nil {
+		return
+	}
+	if symSize > 0 {
+		tmpLink := make([]byte, symSize)
+		if _, err = io.ReadFull(buff, tmpLink); err != nil {
+			return
+		}
+	}
+
+	if err = binary.Read(buff, binary.BigEndian, &i.NLink); err != nil {
+		return
+	}
+	return
 }

--- a/fsck/usage.md
+++ b/fsck/usage.md
@@ -10,5 +10,8 @@
 ./fsck clean inode --vol "<volName>" --inode-list "inodes.txt" --dentry-list "dens.txt"
 ./fsck clean dentry --master "127.0.0.1:17010" --vol "<volName>" --mport "17220"
 ./fsck clean dentry --vol "<volName>" --inode-list "inodes.txt" --dentry-list "dens.txt"
-./fsck get --inode <inodeID> --master "127.0.0.1:17010" --vol "<volName>" --mport "17220"
+./fsck get locations --inode <inodeID> --master "127.0.0.1:17010" --vol "<volName>" --mport "17220"
+./fsck get path --inode <inodeID> --master "127.0.0.1:17010" --vol "<volName>" --mport "17220"
+./fsck get path --master "127.0.0.1:17010" --vol "<volName>" --mport "17220"
+./fsck get summary --inode <inodeID> --master "127.0.0.1:17010" --vol "<volName>" --mport "17220"
 ```

--- a/metanode/api_handler_test.go
+++ b/metanode/api_handler_test.go
@@ -1,0 +1,162 @@
+package metanode
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	PROF_PORT                = 8220
+	METAPARTITION_ID         = 1
+	INVALID_METAPARTITION_ID = 1000
+)
+
+var server = createMetaNodeServerForTest()
+
+func createMetaNodeServerForTest() (m *MetaNode) {
+	var err error
+	m = &MetaNode{}
+
+	go func() {
+		err = http.ListenAndServe(fmt.Sprintf(":%v", PROF_PORT), nil)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	if err = m.registerAPIHandler(); err != nil {
+		return
+	}
+
+	return
+}
+
+func createMetaPartition(rootDir string, t *testing.T) (mp *metaPartition) {
+	mpC := &MetaPartitionConfig{
+		PartitionId:   METAPARTITION_ID,
+		VolName:       "test_vol",
+		Start:         0,
+		End:           100,
+		PartitionType: 1,
+		Peers:         nil,
+		RootDir:       rootDir,
+	}
+	metaM := &metadataManager{
+		nodeId:     1,
+		zoneName:   "test",
+		raftStore:  nil,
+		partitions: make(map[uint64]MetaPartition),
+		metaNode:   &MetaNode{},
+	}
+
+	partition := NewMetaPartition(mpC, metaM)
+	require.NotNil(t, partition)
+
+	metaM.partitions[METAPARTITION_ID] = partition
+	server.metadataManager = metaM
+
+	mp, ok := partition.(*metaPartition)
+	require.True(t, ok)
+	msg := &storeMsg{
+		command:        1,
+		applyIndex:     0,
+		inodeTree:      mp.inodeTree,
+		dentryTree:     mp.dentryTree,
+		extendTree:     mp.extendTree,
+		multipartTree:  mp.multipartTree,
+		txTree:         mp.txProcessor.txManager.txTree,
+		txRbInodeTree:  mp.txProcessor.txResource.txRbInodeTree,
+		txRbDentryTree: mp.txProcessor.txResource.txRbDentryTree,
+	}
+	mp.uidManager = NewUidMgr(mpC.VolName, mpC.PartitionId)
+	mp.mqMgr = NewQuotaManager(mpC.VolName, mpC.PartitionId)
+
+	ino := NewInode(1, 0)
+	mp.inodeTree.ReplaceOrInsert(ino, true)
+	dentry := &Dentry{ParentId: 0, Name: "/", Inode: 1}
+	mp.dentryTree.ReplaceOrInsert(dentry, true)
+
+	err := mp.store(msg)
+	require.NoError(t, err)
+	return
+}
+
+func httpReqHandle(url string, t *testing.T) (data []byte) {
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("err is %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status code[%v]", resp.StatusCode)
+		return
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("err is %v", err)
+		return
+	}
+
+	return body
+}
+
+func getSnapshot(t *testing.T, snapshotFile string, url string) {
+	testPath := "/tmp/testMetaNodeApiHandler/"
+	os.RemoveAll(testPath)
+	defer os.RemoveAll(testPath)
+
+	mp := createMetaPartition(testPath, t)
+	require.NotNil(t, mp)
+
+	file, err := os.Open(path.Join(mp.config.RootDir, snapshotDir, snapshotFile))
+	require.NoError(t, err)
+	defer file.Close()
+
+	hash1 := md5.New()
+	_, err = io.Copy(hash1, file)
+	require.NoError(t, err)
+
+	hash2 := md5.Sum(httpReqHandle(url, t))
+
+	require.Equal(t, hex.EncodeToString(hash1.Sum(nil)[:16]), hex.EncodeToString(hash2[:]))
+}
+
+func TestGetInodeSnapshot(t *testing.T) {
+	url := fmt.Sprintf("http://127.0.0.1:%v%v?pid=%v",
+		PROF_PORT, "/getInodeSnapshot", METAPARTITION_ID)
+	fmt.Printf(url)
+	fmt.Printf("\n")
+	getSnapshot(t, inodeFile, url)
+}
+
+func TestGetDentrySnapshot(t *testing.T) {
+	url := fmt.Sprintf("http://127.0.0.1:%v%v?pid=%v",
+		PROF_PORT, "/getDentrySnapshot", METAPARTITION_ID)
+	fmt.Printf(url)
+	getSnapshot(t, dentryFile, url)
+}
+
+func TestWithWrongMetaPartitionID(t *testing.T) {
+	testPath := "/tmp/testMetaNodeApiHandler/"
+	os.RemoveAll(testPath)
+	defer os.RemoveAll(testPath)
+
+	mp := createMetaPartition(testPath, t)
+	require.NotNil(t, mp)
+
+	url := fmt.Sprintf("http://127.0.0.1:%v%v?pid=%v",
+		PROF_PORT, "/getInodeSnapshot", 2)
+
+	data := httpReqHandle(url, t)
+	require.Contains(t, string(data), "unknown meta partition")
+}


### PR DESCRIPTION
In this pr, we added the following commands:
1. Change the command  "_get --inode <InodeID>_" to "_get locations --inode <InodeID>_"
2. Add command "_get path --inode <InodeID>_" to obtain the full path with a inodeID
3. Add command "_get path_" to dump the full path of all inodes
4. Add command "_get summary --inode <InodeID>_" to obtain the summary information of the directory

**Note: we use the inode and dentry information from the snapshot file, so it is not up to date**

We tested commands 2 and 4 on a volume with 50 million files, each of which took about 150 seconds.
In the future, we will make it a resident memory mode so that we can quickly query the full path and summary information with a inodeID.