### PR TITLE
enhance: only deleted volume be ignored when do dps cache transfer

### DIFF
--- a/master/http_server.go
+++ b/master/http_server.go
@@ -64,13 +64,13 @@ func (m *Server) isClientPartitionsReq(r *http.Request) bool {
 
 func (m *Server) isFollowerRead(r *http.Request) (followerRead bool) {
 	followerRead = false
+
 	if r.URL.Path == proto.ClientDataPartitions && !m.partition.IsRaftLeader() {
 		if volName, err := parseAndExtractName(r); err == nil {
 			log.LogInfof("action[interceptor] followerRead vol[%v]", volName)
-			if m.cluster.followerReadManager.IsVolViewReady(volName) {
-				followerRead = true
-				log.LogInfof("action[interceptor] followerRead [%v], GetName[%v] IsRaftLeader[%v]",
-					followerRead, r.URL.Path, m.partition.IsRaftLeader())
+			if followerRead = m.cluster.followerReadManager.IsVolViewReady(volName); followerRead {
+				log.LogInfof("action[interceptor] vol [%v] followerRead [%v], GetName[%v] IsRaftLeader[%v]",
+					volName, followerRead, r.URL.Path, m.partition.IsRaftLeader())
 				return
 			}
 		}
@@ -124,6 +124,7 @@ func (m *Server) registerAPIMiddleware(route *mux.Router) {
 					return
 				} else if m.leaderInfo.addr != "" {
 					if m.isClientPartitionsReq(r) {
+						log.LogErrorf("action[interceptor] request, method[%v] path[%v] query[%v] status [%v]", r.Method, r.URL.Path, r.URL.Query(), isFollowerRead)
 						http.Error(w, m.leaderInfo.addr, http.StatusBadRequest)
 						return
 					}

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -1218,7 +1218,7 @@ func (c *Cluster) loadMetaNodes() (err error) {
 	return
 }
 
-func (c *Cluster) loadVolsName() (err error, names []string) {
+func (c *Cluster) loadVolsViews() (err error, volViews []*volValue) {
 	result, err := c.fsm.store.SeekForPrefix([]byte(volPrefix))
 	if err != nil {
 		err = fmt.Errorf("action[loadVols],err:%v", err.Error())
@@ -1230,10 +1230,8 @@ func (c *Cluster) loadVolsName() (err error, names []string) {
 			err = fmt.Errorf("action[loadVols],value:%v,unmarshal err:%v", string(value), err)
 			return
 		}
-		if vv.Status == markDelete || !bsProto.IsHot(vv.VolType) && (vv.CacheAction == bsProto.NoCache || vv.CacheCapacity == 0) {
-			continue
-		}
-		names = append(names, vv.Name)
+
+		volViews = append(volViews, vv)
 		log.LogInfof("action[loadVols],vol[%v]", vv.Name)
 	}
 	return


### PR DESCRIPTION
close: #2051

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Do not consider the issue of cold volume anymore, relax the check for empty DP quantity, and assume the master-follower dps synchronization logic is normal by default, which can reduce the complexity of processing reads. Solve the error log caused by datanode requesting cold volume information from the follower. Although retrying can solve the problem, it is not user-friendly

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


