### PR TITLE
fix(metanode): fix expired_mp not set raft wal to expired

### DIFF
--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -345,6 +345,7 @@ func (m *MetaNode) newMetaManager() (err error) {
 	conf := MetadataManagerConfig{
 		NodeID:    m.nodeId,
 		RootDir:   m.metadataDir,
+		RaftDir:   m.raftDir,
 		RaftStore: m.raftStore,
 		ZoneName:  m.zoneName,
 	}


### PR DESCRIPTION
close: #2021

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the bug if the same MP migrate back to the crashed metanode will lead to inconsistency in Raft.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2021

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
