### PR TITLE
docs: Fix missing closing parenthesis in design document

### DIFF
--- a/docs-zh/source/design/metanode.md
+++ b/docs-zh/source/design/metanode.md
@@ -6,7 +6,7 @@
 
 ## 元数据内部设计
 
-每个元数据可以包含成百上千的元数据分片，每个分片由`InodeTree（BTree）`和`DentryTree（BTree`组成。
+每个元数据可以包含成百上千的元数据分片，每个分片由`InodeTree（BTree）`和`DentryTree（BTree）`组成。
 
 每个`inode`代表文件系统中的一个文件或目录， 每个`dentry`代表一个目录项，`dentry`由`parentId`和`name`组成。
 


### PR DESCRIPTION
I noticed that there was a missing closing parenthesis in the design document . This PR fixes the issue by adding the missing parenthesis.

## Changes:

- Add missing closing parenthesis to the design document in the relevant section.

Please let me know if there are any additional changes required or if you have any questions.

Thank you for considering my contribution!