### PR TITLE
feat: implement configurable interval and dispersed start time for mpPersistDataInternal

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -725,6 +725,8 @@ func formatMetaNodeDetail(mn *proto.MetaNodeInfo, rowTable bool) string {
 	sb.WriteString(fmt.Sprintf("  Partition count     : %v\n", mn.MetaPartitionCount))
 	sb.WriteString(fmt.Sprintf("  Persist partitions  : %v\n", mn.PersistenceMetaPartitions))
 	sb.WriteString(fmt.Sprintf("  CpuUtil             : %.1f%%\n", mn.CpuUtil))
+	sb.WriteString(fmt.Sprintf("  PersistDataInternal : %v\n", mn.PersistDataInternalSec))
+
 	return sb.String()
 }
 

--- a/docs-zh/source/maintenance/configs/metanode.md
+++ b/docs-zh/source/maintenance/configs/metanode.md
@@ -2,26 +2,26 @@
 
 ## 配置说明
 
-| 配置项               | 类型    | 描述                                               | 必需  |
-|-------------------|-------|--------------------------------------------------|-----|
-| role              | 字符串   | 进程角色： *MetaNode*                                 | 是   |
-| listen            | 字符串   | 监听和接受请求的端口                                       | 是   |
-| prof              | 字符串   | 调试和管理员API接口                                      | 是   |
-| logLevel          | 字符串   | 日志级别，默认: *error*                                 | 否   |
-| metadataDir       | 字符串   | 元数据快照存储目录                                        | 是   |
-| logDir            | 字符串   | 日志存储目录                                           | 是   |
-| raftDir           | 字符串   | raft wal日志目录                                     | 是   |
-| raftHeartbeatPort | 字符串   | raft心跳通信端口                                       | 是   |
-| raftReplicaPort   | 字符串   | raft数据传输端口                                       | 是   |
-| consulAddr        | 字符串   | prometheus注册接口                                   | 否   |
-| exporterPort      | 字符串   | prometheus获取监控数据端口                               | 否   |
-| masterAddr        | 字符串   | master服务地址                                       | 是   |
-| totalMem          | 字符串   | 最大可用内存，此值需高于master配置中metaNodeReservedMem的值，单位：字节 | 是   |
-| localIP           | 字符串   | 本机ip地址,如果不填写该选项，则使用和master通信的ip地址                | 否   |
-| zoneName          | 字符串   | 指定区域，默认分配至`default`区域                            | 否   |
-| deleteBatchCount  | int64 | 一次性批量删除多少inode节点，默认`500`                         | 否   |
+| 配置项                    | 类型     | 描述                                               | 必需  |
+|------------------------|--------|--------------------------------------------------|-----|
+| role                   | string | 进程角色： *MetaNode*                                 | 是   |
+| listen                 | string | 监听和接受请求的端口                                       | 是   |
+| prof                   | string | 调试和管理员API接口                                      | 是   |
+| logLevel               | string | 日志级别，默认: *error*                                 | 否   |
+| metadataDir            | string | 元数据快照存储目录                                        | 是   |
+| logDir                 | string | 日志存储目录                                           | 是   |
+| raftDir                | string | raft wal日志目录                                     | 是   |
+| raftHeartbeatPort      | string | raft心跳通信端口                                       | 是   |
+| raftReplicaPort        | string | raft数据传输端口                                       | 是   |
+| consulAddr             | string | prometheus注册接口                                   | 否   |
+| exporterPort           | string | prometheus获取监控数据端口                               | 否   |
+| masterAddr             | string | master服务地址                                       | 是   |
+| totalMem               | string | 最大可用内存，此值需高于master配置中metaNodeReservedMem的值，单位：字节 | 是   |
+| localIP                | string | 本机ip地址,如果不填写该选项，则使用和master通信的ip地址                | 否   |
+| zoneName               | string | 指定区域，默认分配至`default`区域                            | 否   |
+| deleteBatchCount       | int64  | 一次性批量删除多少inode节点，默认`500`                         | 否   |
+| persistDataInternalSec | int64  | 元数据快照定时快照的时间间隔，不小于300秒，默认`300`，单位为秒              | 否   |
 
-Properties
 
 ## 配置示例
 

--- a/docs/source/maintenance/configs/metanode.md
+++ b/docs/source/maintenance/configs/metanode.md
@@ -2,24 +2,25 @@
 
 ## Configuration Description
 
-| Configuration Item | Type   | Description                                                                                                                     | Required |
-|--------------------|--------|---------------------------------------------------------------------------------------------------------------------------------|----------|
-| role               | string | Process role: *MetaNode*                                                                                                        | Yes      |
-| listen             | string | Port for listening and accepting requests                                                                                       | Yes      |
-| prof               | string | Debugging and administrator API interface                                                                                       | Yes      |
-| logLevel           | string | Log level, default: *error*                                                                                                     | No       |
-| metadataDir        | string | Directory for storing metadata snapshots                                                                                        | Yes      |
-| logDir             | string | Directory for storing logs                                                                                                      | Yes      |
-| raftDir            | string | Directory for storing Raft WAL logs                                                                                             | Yes      |
-| raftHeartbeatPort  | string | Raft heartbeat communication port                                                                                               | Yes      |
-| raftReplicaPort    | string | Raft data transmission port                                                                                                     | Yes      |
-| consulAddr         | string | Prometheus registration interface                                                                                               | No       |
-| exporterPort       | string | Port for Prometheus to obtain monitoring data                                                                                   | No       |
-| masterAddr         | string | Address of the master service                                                                                                   | Yes      |
-| totalMem           | string | Maximum available memory. This value must be higher than the value of metaNodeReservedMem in the master configuration, in bytes | Yes      |
-| localIP            | string | IP address of the local machine. If this option is not specified, the IP address used for communication with the master is used | No       |
-| zoneName           | string | Specify the zone. By default, it is assigned to the `default` zone                                                              | No       |
-| deleteBatchCount   | int64  | Number of inode nodes to be deleted in batches at one time, default is `500`                                                    | No       |
+| Configuration Item     | Type   | Description                                                                                                                     | Required |
+|------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------|----------|
+| role                   | string | Process role: *MetaNode*                                                                                                        | Yes      |
+| listen                 | string | Port for listening and accepting requests                                                                                       | Yes      |
+| prof                   | string | Debugging and administrator API interface                                                                                       | Yes      |
+| logLevel               | string | Log level, default: *error*                                                                                                     | No       |
+| metadataDir            | string | Directory for storing metadata snapshots                                                                                        | Yes      |
+| logDir                 | string | Directory for storing logs                                                                                                      | Yes      |
+| raftDir                | string | Directory for storing Raft WAL logs                                                                                             | Yes      |
+| raftHeartbeatPort      | string | Raft heartbeat communication port                                                                                               | Yes      |
+| raftReplicaPort        | string | Raft data transmission port                                                                                                     | Yes      |
+| consulAddr             | string | Prometheus registration interface                                                                                               | No       |
+| exporterPort           | string | Port for Prometheus to obtain monitoring data                                                                                   | No       |
+| masterAddr             | string | Address of the master service                                                                                                   | Yes      |
+| totalMem               | string | Maximum available memory. This value must be higher than the value of metaNodeReservedMem in the master configuration, in bytes | Yes      |
+| localIP                | string | IP address of the local machine. If this option is not specified, the IP address used for communication with the master is used | No       |
+| zoneName               | string | Specify the zone. By default, it is assigned to the `default` zone                                                              | No       |
+| deleteBatchCount       | int64  | Number of inode nodes to be deleted in batches at one time, default is `500`                                                    | No       |
+| persistDataInternalSec | int64  | Time interval for schedule of metadata snapshots, should not be less than 300 seconds, default is `300`, measured in seconds    | No       |
 
 ## Configuration Example
 

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -3640,6 +3640,7 @@ func (m *Server) getMetaNode(w http.ResponseWriter, r *http.Request) {
 		NodeSetID:                 metaNode.NodeSetID,
 		PersistenceMetaPartitions: metaNode.PersistenceMetaPartitions,
 		CpuUtil:                   metaNode.CpuUtil.Load(),
+		PersistDataInternalSec:    metaNode.PersistDataInternalSec,
 	}
 	sendOkReply(w, r, newSuccessHTTPReply(metaNodeInfo))
 }

--- a/master/meta_node.go
+++ b/master/meta_node.go
@@ -50,6 +50,7 @@ type MetaNode struct {
 	RdOnly                    bool
 	MigrateLock               sync.RWMutex
 	CpuUtil                   atomicutil.Float64 `json:"-"`
+	PersistDataInternalSec    int64
 }
 
 func newMetaNode(addr, zoneName, clusterID string) (node *MetaNode) {
@@ -141,6 +142,7 @@ func (metaNode *MetaNode) updateMetric(resp *proto.MetaNodeHeartbeatResponse, th
 	}
 	metaNode.ZoneName = resp.ZoneName
 	metaNode.Threshold = threshold
+	metaNode.PersistDataInternalSec = resp.PersistDataInternalSec
 }
 
 func (metaNode *MetaNode) reachesThreshold() bool {

--- a/metanode/const.go
+++ b/metanode/const.go
@@ -177,31 +177,32 @@ const (
 
 // Configuration keys
 const (
-	cfgLocalIP           = "localIP"
-	cfgListen            = "listen"
-	cfgMetadataDir       = "metadataDir"
-	cfgRaftDir           = "raftDir"
-	cfgMasterAddrs       = "masterAddrs" // will be deprecated
-	cfgRaftHeartbeatPort = "raftHeartbeatPort"
-	cfgRaftReplicaPort   = "raftReplicaPort"
-	cfgDeleteBatchCount  = "deleteBatchCount"
-	cfgTotalMem          = "totalMem"
-	cfgMemRatio          = "memRatio"
-	cfgZoneName          = "zoneName"
-	cfgTickInterval      = "tickInterval"
-	cfgRaftRecvBufSize   = "raftRecvBufSize"
-	cfgSmuxPortShift     = "smuxPortShift"     //int
-	cfgSmuxMaxConn       = "smuxMaxConn"       //int
-	cfgSmuxStreamPerConn = "smuxStreamPerConn" //int
-	cfgSmuxMaxBuffer     = "smuxMaxBuffer"     //int
+	cfgLocalIP                = "localIP"
+	cfgListen                 = "listen"
+	cfgMetadataDir            = "metadataDir"
+	cfgRaftDir                = "raftDir"
+	cfgMasterAddrs            = "masterAddrs" // will be deprecated
+	cfgRaftHeartbeatPort      = "raftHeartbeatPort"
+	cfgRaftReplicaPort        = "raftReplicaPort"
+	cfgDeleteBatchCount       = "deleteBatchCount"
+	cfgTotalMem               = "totalMem"
+	cfgMemRatio               = "memRatio"
+	cfgZoneName               = "zoneName"
+	cfgTickInterval           = "tickInterval"
+	cfgRaftRecvBufSize        = "raftRecvBufSize"
+	cfgSmuxPortShift          = "smuxPortShift"     //int
+	cfgSmuxMaxConn            = "smuxMaxConn"       //int
+	cfgSmuxStreamPerConn      = "smuxStreamPerConn" //int
+	cfgSmuxMaxBuffer          = "smuxMaxBuffer"     //int
+	cfgPersistDataInternalSec = "persistDataInternalSec"
 
 	metaNodeDeleteBatchCountKey = "batchCount"
 )
 
 const (
 	// interval of persisting in-memory data
-	intervalToPersistData = time.Minute * 5
-	intervalToSyncCursor  = time.Minute * 1
+	defaultPersistDataInternalSec = 300
+	intervalToSyncCursor          = time.Minute * 1
 
 	defaultDelExtentsCnt     = 100000
 	defaultMaxQuotaGoroutine = 5

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -114,6 +114,7 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 			return true
 		})
 		resp.ZoneName = m.zoneName
+		resp.PersistDataInternalSec = m.metaNode.PersistDataInternalSec
 		resp.Status = proto.TaskSucceeds
 	end:
 		adminTask.Request = nil

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -51,26 +51,27 @@ var (
 // The MetaNode manages the dentry and inode information of the meta partitions on a meta node.
 // The data consistency is ensured by Raft.
 type MetaNode struct {
-	nodeId            uint64
-	listen            string
-	bindIp            bool
-	metadataDir       string // root dir of the metaNode
-	raftDir           string // root dir of the raftStore log
-	metadataManager   MetadataManager
-	localAddr         string
-	clusterId         string
-	raftStore         raftstore.RaftStore
-	raftHeartbeatPort string
-	raftReplicatePort string
-	zoneName          string
-	httpStopC         chan uint8
-	smuxStopC         chan uint8
-	metrics           *MetaNodeMetrics
-	tickInterval      int
-	raftRecvBufSize   int
-	connectionCnt     int64
-	clusterUuid       string
-	clusterUuidEnable bool
+	nodeId                 uint64
+	listen                 string
+	bindIp                 bool
+	metadataDir            string // root dir of the metaNode
+	raftDir                string // root dir of the raftStore log
+	metadataManager        MetadataManager
+	localAddr              string
+	clusterId              string
+	raftStore              raftstore.RaftStore
+	raftHeartbeatPort      string
+	raftReplicatePort      string
+	zoneName               string
+	httpStopC              chan uint8
+	smuxStopC              chan uint8
+	metrics                *MetaNodeMetrics
+	tickInterval           int
+	raftRecvBufSize        int
+	connectionCnt          int64
+	clusterUuid            string
+	clusterUuidEnable      bool
+	PersistDataInternalSec int64
 
 	control common.Control
 }
@@ -202,6 +203,11 @@ func (m *MetaNode) parseConfig(cfg *config.Config) (err error) {
 	m.tickInterval = int(cfg.GetFloat(cfgTickInterval))
 	m.raftRecvBufSize = int(cfg.GetInt(cfgRaftRecvBufSize))
 	m.zoneName = cfg.GetString(cfgZoneName)
+	m.PersistDataInternalSec = cfg.GetInt64(cfgPersistDataInternalSec)
+
+	if m.PersistDataInternalSec < defaultPersistDataInternalSec {
+		m.PersistDataInternalSec = defaultPersistDataInternalSec
+	}
 
 	deleteBatchCount := cfg.GetInt64(cfgDeleteBatchCount)
 	if deleteBatchCount > 1 {

--- a/metanode/partition_store_ticket.go
+++ b/metanode/partition_store_ticket.go
@@ -172,8 +172,9 @@ func resetTimer(timer *time.Timer, ts int64) {
 	timer.Reset(time.Duration(ts+r.Int63n(RandomIntervalS)) * time.Second)
 }
 
-// Avoid devices starting scheduled tasks simultaneously
+// resetTimerWithRandomTime resets the timer with a random duration in max*[1, 2)
+// to avoid devices starting scheduled tasks simultaneously.
 func resetTimerWithRandomTime(timer *time.Timer, maxts int64) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	timer.Reset(time.Duration(float32(maxts)*r.Float32()) * time.Second)
+	timer.Reset(time.Duration(maxts+int64(float32(maxts)*r.Float32())) * time.Second)
 }

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -541,13 +541,14 @@ type MetaPartitionReport struct {
 
 // MetaNodeHeartbeatResponse defines the response to the meta node heartbeat request.
 type MetaNodeHeartbeatResponse struct {
-	ZoneName             string
-	Total                uint64
-	MemUsed              uint64
-	MetaPartitionReports []*MetaPartitionReport
-	Status               uint8
-	Result               string
-	CpuUtil              float64 `json:"cpuUtil"`
+	ZoneName               string
+	Total                  uint64
+	MemUsed                uint64
+	MetaPartitionReports   []*MetaPartitionReport
+	Status                 uint8
+	Result                 string
+	CpuUtil                float64 `json:"cpuUtil"`
+	PersistDataInternalSec int64
 }
 
 // DeleteFileRequest defines the request to delete a file.

--- a/proto/model.go
+++ b/proto/model.go
@@ -43,6 +43,7 @@ type MetaNodeInfo struct {
 	PersistenceMetaPartitions []uint64
 	RdOnly                    bool
 	CpuUtil                   float64 `json:"cpuUtil"`
+	PersistDataInternalSec    int64
 }
 
 // DataNode stores all the information about a data node


### PR DESCRIPTION
What this PR does / why we need it:

When there are too many inodes and dentries in meta partition, this schuedule will cause high cpu costs.
This issue is going to implement an ability to change the mpPersistDataInternal, to lessen cpu costs.

- implemented the feature to introduce a randomized delay of 0 to 30 seconds for the scheduled task
- can configure the partition scheduled task time when metanode starts by editing the configuration file
- When creating a partition, the first execution time will take a random value between [0, persistence time] to ensure that execution does not start simultaneously

We now can use `cfs-cli metanode info [ADDRESS]` to see the current persistDataInternal

## cpu costs before and after

### before the implementation
![image](https://github.com/cubefs/cubefs/assets/86180691/1f2c2860-dbab-4f1d-8006-44c266b2c868)

### after the implementation, and use the default value 300 (5min)
![image](https://github.com/cubefs/cubefs/assets/86180691/81164fd9-a19b-4670-a67c-6c1fa07e7602)

### after the implementation, and set the value to 1200 (20min)
![image](https://github.com/cubefs/cubefs/assets/86180691/c9a213ed-4388-42ee-87e6-59203af393ba)

Which issue this PR fixes
fixes https://github.com/cubefs/cubefs/issues/1919

