### PR TITLE
fix(master): mps dead lock may cause master cann't accept request for…

### DIFF
--- a/master/vol.go
+++ b/master/vol.go
@@ -492,12 +492,13 @@ func (vol *Vol) checkSplitMetaPartition(c *Cluster, metaPartitionInodeIdStep uin
 	maxPartitionID := vol.maxPartitionID()
 
 	vol.mpsLock.RLock()
-	defer vol.mpsLock.RUnlock()
-
 	partition, ok := vol.MetaPartitions[maxPartitionID]
 	if !ok {
+		vol.mpsLock.RUnlock()
 		return
 	}
+	vol.mpsLock.RUnlock()
+
 	liveReplicas := partition.getLiveReplicas()
 	foundReadonlyReplica := false
 	var readonlyReplica *MetaReplica


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Reduce the read lock scope in SplitMetaPartition，and which avoid deallock happend while call function addMetaPartition

