### PR TITLE
feat(master): the cmd 'cfs-cli datapartition check' not involve markD…

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -951,7 +951,11 @@ func (c *Cluster) checkReplicaOfDataPartitions(ignoreDiscardDp bool) (
 				continue
 			}
 
-			if vol.Status != markDelete && proto.IsHot(vol.VolType) {
+			if vol.Status == markDelete {
+				continue
+			}
+
+			if proto.IsHot(vol.VolType) {
 				if dp.getLeaderAddr() == "" && (time.Now().Unix()-dp.LeaderReportTime > c.cfg.DpNoLeaderReportIntervalSec) {
 					noLeaderDPs = append(noLeaderDPs, dp)
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(master): the cmd 'cfs-cli datapartition check' not involve markDelete volumes. 
if the cmd shows dp of markDelete vlumes, it may interferes with operation and maintenance personnel.