### PR TITLE
fix(client): randomwrite request should not be limited by uid and dir…

### DIFF
--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -413,16 +413,22 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.Wri
 	defer func() {
 		metric.SetWithLabels(err, map[string]string{exporter.Vol: f.super.volname})
 	}()
-	var size int
-	if proto.IsHot(f.super.volType) {
-		f.super.ec.GetStreamer(ino).SetParentInode(f.parentIno)
+
+	checkFunc := func() error {
 		if ok := f.super.ec.UidIsLimited(req.Uid); ok {
 			return ParseError(syscall.ENOSPC)
 		}
 		if limited := f.super.mw.IsQuotaLimited(f.info.QuotaIds); limited {
 			return ParseError(syscall.ENOSPC)
 		}
-		size, err = f.super.ec.Write(ino, int(req.Offset), req.Data, flags)
+		return nil
+	}
+	var size int
+	if proto.IsHot(f.super.volType) {
+		f.super.ec.GetStreamer(ino).SetParentInode(f.parentIno)
+		if size, err = f.super.ec.Write(ino, int(req.Offset), req.Data, flags, checkFunc); err == ParseError(syscall.ENOSPC) {
+			return
+		}
 	} else {
 		atomic.StoreInt32(&f.idle, 0)
 		size, err = f.fWriter.Write(ctx, int(req.Offset), req.Data, flags)

--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -1421,7 +1421,7 @@ func (c *client) truncate(f *file, size int) error {
 func (c *client) write(f *file, offset int, data []byte, flags int) (n int, err error) {
 	if proto.IsHot(c.volType) {
 		c.ec.GetStreamer(f.ino).SetParentInode(f.pino) // set the parent inode
-		n, err = c.ec.Write(f.ino, offset, data, flags)
+		n, err = c.ec.Write(f.ino, offset, data, flags, nil)
 	} else {
 		n, err = f.fileWriter.Write(c.ctx(c.id, f.ino), offset, data, flags)
 	}

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -1308,7 +1308,7 @@ func (v *Volume) streamWrite(inode uint64, reader io.Reader, h hash.Hash) (size 
 			return
 		}
 		if readN > 0 {
-			if writeN, err = v.ec.Write(inode, offset, buf[:readN], 0); err != nil {
+			if writeN, err = v.ec.Write(inode, offset, buf[:readN], 0, nil); err != nil {
 				log.LogErrorf("streamWrite: data write tmp file fail, inode(%v) offset(%v) err(%v)", inode, offset, err)
 				exporter.Warning(fmt.Sprintf("write data fail: volume(%v) inode(%v) offset(%v) size(%v) err(%v)",
 					v.name, inode, offset, readN, err))
@@ -2694,7 +2694,7 @@ func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective stri
 			if proto.IsCold(v.volType) {
 				writeN, err = ebsWriter.WriteWithoutPool(tctx, writeOffset, buf[:readN])
 			} else {
-				writeN, err = v.ec.Write(tInodeInfo.Inode, writeOffset, buf[:readN], 0)
+				writeN, err = v.ec.Write(tInodeInfo.Inode, writeOffset, buf[:readN], 0, nil)
 			}
 			if err != nil {
 				log.LogErrorf("CopyFile: write target path from source fail, volume(%v) path(%v) inode(%v) target offset(%v) err(%v)",

--- a/preload/sdk/preloadsdk.go
+++ b/preload/sdk/preloadsdk.go
@@ -473,7 +473,7 @@ func (c *PreLoadClient) preloadFileWorker(id int64, jobs <-chan fileInfo, wg *sy
 				log.LogWarnf("Read (%v) wrong size:(%v)", objExtent, n)
 				continue
 			}
-			_, err = c.ec.Write(ino, int(objExtent.FileOffset), buf, 0)
+			_, err = c.ec.Write(ino, int(objExtent.FileOffset), buf, 0, nil)
 			//in preload mode,onece extend_hander set to error, streamer is set to error
 			// so write should failed immediately
 			if err != nil {

--- a/sdk/data/blobstore/reader.go
+++ b/sdk/data/blobstore/reader.go
@@ -387,7 +387,7 @@ func (reader *Reader) asyncCache(ctx context.Context, cacheKey string, objExtent
 	}
 
 	if reader.needCacheL2() {
-		reader.ec.Write(reader.ino, int(objExtentKey.FileOffset), buf, proto.FlagsCache)
+		reader.ec.Write(reader.ino, int(objExtentKey.FileOffset), buf, proto.FlagsCache, nil)
 		log.LogDebugf("TRACE blobStore asyncCache(L2) Exit. cacheKey=%v", cacheKey)
 		return
 	}

--- a/sdk/data/blobstore/reader_test.go
+++ b/sdk/data/blobstore/reader_test.go
@@ -502,7 +502,7 @@ func MockCheckDataPartitionExistFalse(client *stream.ExtentClient, partitionID u
 }
 
 func MockWriteTrue(client *stream.ExtentClient, inode uint64, offset int, data []byte,
-	flags int) (write int, err error) {
+	flags int, checkFunc func() error) (write int, err error) {
 	return len(data), nil
 }
 

--- a/sdk/data/blobstore/writer.go
+++ b/sdk/data/blobstore/writer.go
@@ -511,7 +511,7 @@ func (writer *Writer) asyncCache(ino uint64, offset int, data []byte) {
 	}()
 
 	log.LogDebugf("TRACE asyncCache Enter,fileOffset(%v) len(%v)", offset, len(data))
-	write, err := writer.ec.Write(ino, offset, data, proto.FlagsCache)
+	write, err := writer.ec.Write(ino, offset, data, proto.FlagsCache, nil)
 	log.LogDebugf("TRACE asyncCache Exit,write(%v) err(%v)", write, err)
 
 }

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -437,7 +437,7 @@ func (client *ExtentClient) SetFileSize(inode uint64, size int) {
 }
 
 // Write writes the data.
-func (client *ExtentClient) Write(inode uint64, offset int, data []byte, flags int) (write int, err error) {
+func (client *ExtentClient) Write(inode uint64, offset int, data []byte, flags int, checkFunc func() error) (write int, err error) {
 	prefix := fmt.Sprintf("Write{ino(%v)offset(%v)size(%v)}", inode, offset, len(data))
 	s := client.GetStreamer(inode)
 	if s == nil {
@@ -450,7 +450,7 @@ func (client *ExtentClient) Write(inode uint64, offset int, data []byte, flags i
 		s.GetExtents()
 	})
 
-	write, err = s.IssueWriteRequest(offset, data, flags)
+	write, err = s.IssueWriteRequest(offset, data, flags, checkFunc)
 	if err != nil {
 		err = errors.Trace(err, prefix)
 		log.LogError(errors.Stack(err))


### PR DESCRIPTION
randomwrite request should not be limited by uid and dir quota

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

develop-3.3.0

**Special notes for your reviewer**:
use callback in case of transfer of multiple params and function
