### PR TITLE
feat: support the master to uniformly configure the push gateway address of the data reported by the client

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -444,6 +444,15 @@ func main() {
 	defer super.Close()
 
 	syslog.Printf("enable bcache %v", opt.EnableBcache)
+
+	if cfg.GetString(exporter.ConfigKeyPushAddr) == "" {
+		pushAddr, err := getPushAddrFromMaster(opt.Master)
+		if err == nil && pushAddr != "" {
+			syslog.Printf("use remote push addr %v", pushAddr)
+			cfg.SetString(exporter.ConfigKeyPushAddr, pushAddr)
+		}
+	}
+
 	exporter.Init(ModuleName, cfg)
 	exporter.RegistConsul(super.ClusterName(), ModuleName, cfg)
 
@@ -478,6 +487,12 @@ func main() {
 		syslog.Printf("fs Serve returns err(%v)\n", err)
 		os.Exit(1)
 	}
+}
+
+func getPushAddrFromMaster(masterAddr string) (addr string, err error) {
+	var mc = master.NewMasterClientFromString(masterAddr, false)
+	addr, err = mc.AdminAPI().GetMonitorPushAddr()
+	return
 }
 
 func startDaemon() error {

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -129,6 +129,20 @@ func (m *Server) setClusterInfo(w http.ResponseWriter, r *http.Request) {
 		proto.MinDirChildrenNumLimit, math.MaxUint32, quota)))
 }
 
+func (m *Server) getMonitorPushAddr(w http.ResponseWriter, r *http.Request) {
+	var (
+		addr string
+		err  error
+	)
+	metric := exporter.NewTPCnt(apiToMetricsName(proto.AdminGetMonitorPushAddr))
+	defer func() {
+		doStatAndMetric(proto.AdminGetMonitorPushAddr, metric, err, nil)
+	}()
+
+	addr = m.cluster.getMonitorPushAddr()
+	sendOkReply(w, r, newSuccessHTTPReply(addr))
+}
+
 // Set the threshold of the memory usage on each meta node.
 // If the memory usage reaches this threshold, then all the mata partition will be marked as readOnly.
 func (m *Server) setMetaNodeThreshold(w http.ResponseWriter, r *http.Request) {

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -3180,6 +3180,11 @@ func (c *Cluster) setClusterInfo(quota uint32) (err error) {
 	return
 }
 
+func (c *Cluster) getMonitorPushAddr() (addr string) {
+	addr = c.cfg.MonitorPushAddr
+	return
+}
+
 func (c *Cluster) setMetaNodeThreshold(threshold float32) (err error) {
 	oldThreshold := c.cfg.MetaNodeThreshold
 	c.cfg.MetaNodeThreshold = threshold

--- a/master/config.go
+++ b/master/config.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cubefs/cubefs/raftstore"
 )
 
-//config key
+// config key
 const (
 	colonSplit = ":"
 	commaSplit = ","
@@ -45,9 +45,10 @@ const (
 	cfgDomainBuildAsPossible            = "faultDomainBuildAsPossible"
 	cfgmetaPartitionInodeIdStep         = "metaPartitionInodeIdStep"
 	cfgMaxQuotaNumPerVol                = "maxQuotaNumPerVol"
+	cfgMonitorPushAddr                  = "monitorPushAddr"
 )
 
-//default value
+// default value
 const (
 	defaultTobeFreedDataPartitionCount         = 1000
 	defaultSecondsToFreeDataPartitionAfterLoad = 5 * 60 // a data partition can only be freed after loading 5 mins
@@ -121,6 +122,7 @@ type clusterConfig struct {
 	DirChildrenNumLimit                 uint32
 	MetaPartitionInodeIdStep            uint64
 	MaxQuotaNumPerVol                   int
+	MonitorPushAddr                     string
 }
 
 func newClusterConfig() (cfg *clusterConfig) {

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -182,6 +182,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminSetClusterInfo).
 		HandlerFunc(m.setClusterInfo)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminGetMonitorPushAddr).
+		HandlerFunc(m.getMonitorPushAddr)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminClusterFreeze).
 		HandlerFunc(m.setupAutoAllocation)

--- a/master/server.go
+++ b/master/server.go
@@ -322,6 +322,9 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 			return fmt.Errorf("%v,err:%v", proto.ErrInvalidCfg, err.Error())
 		}
 	}
+
+	m.config.MonitorPushAddr = cfg.GetString(cfgMonitorPushAddr)
+
 	return
 }
 

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -27,6 +27,7 @@ const (
 	AdminRemoveApiQpsLimit                    = "/admin/rmApiQpsLimit"
 	AdminGetCluster                           = "/admin/getCluster"
 	AdminSetClusterInfo                       = "/admin/setClusterInfo"
+	AdminGetMonitorPushAddr                   = "/admin/getMonitorPushAddr"
 	AdminGetDataPartition                     = "/dataPartition/get"
 	AdminLoadDataPartition                    = "/dataPartition/load"
 	AdminCreateDataPartition                  = "/dataPartition/create"

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -393,6 +393,16 @@ func (api *AdminAPI) GetVolumeSimpleInfo(volName string) (vv *proto.SimpleVolVie
 	return
 }
 
+func (api *AdminAPI) GetMonitorPushAddr() (addr string, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminGetMonitorPushAddr)
+	var buf []byte
+	if buf, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	err = json.Unmarshal(buf, &addr)
+	return
+}
+
 func (api *AdminAPI) UploadFlowInfo(volName string,
 	flowInfo *proto.ClientReportLimitInfo) (vv *proto.LimitRsp2Client, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.QosUpload)


### PR DESCRIPTION
**What this PR does / why we need it**:
We can configure the push gateway address in the master, and and when the client starts, if they didn't have configuration in it's file, they will try to pull the configuration from master.

Edit master's configuration file, add this line:
```json
{
    "monitorPushAddr": "http://192.168.0.101:8500"
}
```
After master starts, you can get the push gateway address by this option:
```shell
$ curl http://192.168.0.11:17010/admin/getMonitorPushAddr
{"code":0,"msg":"success","data":"http://192.168.0.101:8500"}
```

When client starts, in its log file:
```
2023/06/09 07:54:51 use remote push addr http://192.168.0.101:8500
```
That means the master successfully obtained the configuration from master

**Which issue this PR fixes**
fixes #1912