### PR TITLE
fix(rpc): fixup panic if auditlog bodylimit is negative

### DIFF
--- a/blobstore/common/rpc/auditlog/auditlog.go
+++ b/blobstore/common/rpc/auditlog/auditlog.go
@@ -48,12 +48,14 @@ type jsonAuditlog struct {
 }
 
 func Open(module string, cfg *Config) (ph rpc.ProgressHandler, logFile LogCloser, err error) {
-	if cfg.BodyLimit == 0 {
+	if cfg.BodyLimit < 0 {
+		cfg.BodyLimit = 0
+	} else if cfg.BodyLimit == 0 {
 		cfg.BodyLimit = defaultReadBodyBuffLength
-	}
-	if cfg.BodyLimit > maxReadBodyBuffLength {
+	} else if cfg.BodyLimit > maxReadBodyBuffLength {
 		cfg.BodyLimit = maxReadBodyBuffLength
 	}
+
 	if cfg.ChunkBits == 0 {
 		cfg.ChunkBits = defaultFileChunkBits
 	}
@@ -65,6 +67,7 @@ func Open(module string, cfg *Config) (ph rpc.ProgressHandler, logFile LogCloser
 		Backup:            cfg.Backup,
 	}
 
+	logFile = noopLogCloser{}
 	if cfg.LogDir != "" {
 		logFile, err = largefile.OpenLargeFileLog(largeLogConfig, cfg.RotateNew)
 		if err != nil {

--- a/blobstore/common/rpc/auditlog/proto.go
+++ b/blobstore/common/rpc/auditlog/proto.go
@@ -22,7 +22,8 @@ type Config struct {
 	// ChunkBits means one audit log file size
 	// eg: chunkbits=20 means one log file will hold 1<<10 size
 	ChunkBits uint `json:"chunkbits"`
-	BodyLimit int  `json:"bodylimit"`
+	// BodyLimit negative means no body-cache, 0 means default buffer size.
+	BodyLimit int `json:"bodylimit"`
 	// rotate new audit log file every start time
 	RotateNew     bool   `json:"rotate_new"`
 	LogFileSuffix string `json:"log_file_suffix"`
@@ -40,6 +41,13 @@ type LogCloser interface {
 	Close() error
 	Log([]byte) error
 }
+
+type noopLogCloser struct{}
+
+var _ LogCloser = noopLogCloser{}
+
+func (noopLogCloser) Close() error     { return nil }
+func (noopLogCloser) Log([]byte) error { return nil }
 
 type MetricSender interface {
 	Send(raw []byte) error


### PR DESCRIPTION
return noop log closer if not config log dir

close #2116
