### PR TITLE
fix(master): fix api_service_test.go

### DIFF
--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -45,6 +45,7 @@ const (
 	mds4Addr          = "127.0.0.1:9104"
 	mds5Addr          = "127.0.0.1:9105"
 	mds6Addr          = "127.0.0.1:9106"
+	mds7Addr          = "127.0.0.1:9107"
 
 	mms1Addr      = "127.0.0.1:8101"
 	mms2Addr      = "127.0.0.1:8102"
@@ -52,6 +53,7 @@ const (
 	mms4Addr      = "127.0.0.1:8104"
 	mms5Addr      = "127.0.0.1:8105"
 	mms6Addr      = "127.0.0.1:8106"
+	mms7Addr      = "127.0.0.1:8107"
 	commonVolName = "commonVol"
 	testZone1     = "zone1"
 	testZone2     = "zone2"
@@ -104,10 +106,11 @@ func createDefaultMasterServerForTest() *Server {
 	addMetaServer(mms4Addr, testZone2)
 	addMetaServer(mms5Addr, testZone2)
 	addMetaServer(mms6Addr, testZone2)
-	time.Sleep(1 * time.Second)
+	// we should wait 5 seoncds for master to prepare state
+	time.Sleep(5 * time.Second)
 	testServer.cluster.checkDataNodeHeartbeat()
 	testServer.cluster.checkMetaNodeHeartbeat()
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 	testServer.cluster.scheduleToUpdateStatInfo()
 	// set load factor
 	err = testServer.cluster.setClusterLoadFactor(100)
@@ -453,7 +456,7 @@ func TestUpdateVol(t *testing.T) {
 	setParam(descriptionKey, proto.AdminUpdateVol, req, desc, t)
 	checkParam(zoneNameKey, proto.AdminUpdateVol, req, "default", testZone1, t)
 	checkParam(authenticateKey, proto.AdminUpdateVol, req, "tt", true, t)
-	checkParam(followerReadKey, proto.AdminUpdateVol, req, "test", false, t)
+	checkParam(followerReadKey, proto.AdminUpdateVol, req, "test", true, t)
 	checkParam(ebsBlkSizeKey, proto.AdminUpdateVol, req, "-1", blkSize, t)
 	checkParam(cacheActionKey, proto.AdminUpdateVol, req, "3", proto.RWCache, t)
 	checkParam(cacheCapacity, proto.AdminUpdateVol, req, "1027", cacheCap, t)
@@ -676,7 +679,7 @@ func TestSetNodeMaxDpCntLimit(t *testing.T) {
 
 func TestAddDataReplica(t *testing.T) {
 	partition := commonVol.dataPartitions.partitions[0]
-	dsAddr := "127.0.0.1:9106"
+	dsAddr := mds7Addr
 	addDataServer(dsAddr, "zone2")
 	reqURL := fmt.Sprintf("%v%v?id=%v&addr=%v", hostAddr, proto.AdminAddDataReplica, partition.PartitionID, dsAddr)
 	process(reqURL, t)
@@ -703,7 +706,7 @@ func TestAddDataReplica(t *testing.T) {
 func TestRemoveDataReplica(t *testing.T) {
 	partition := commonVol.dataPartitions.partitions[0]
 	partition.isRecover = false
-	dsAddr := "127.0.0.1:9106"
+	dsAddr := mds7Addr
 	reqURL := fmt.Sprintf("%v%v?id=%v&addr=%v", hostAddr, proto.AdminDeleteDataReplica, partition.PartitionID, dsAddr)
 	process(reqURL, t)
 	partition.RLock()

--- a/master/meta_node_test.go
+++ b/master/meta_node_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMetaNode(t *testing.T) {
 	// /metaNode/add and /metaNode/response processed by mock meta server
-	addr := mms6Addr
+	addr := mms7Addr
 	addMetaServer(addr, testZone2)
 	server.cluster.checkMetaNodeHeartbeat()
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When I run `go test` it failed.

My shell code is:
```shell
cd master
go test -run "^(TestSetMetaNodeThreshold|TestSetDisableAutoAlloc|TestGetCluster|TestGetIpAndClusterName|TestDisk|TestMarkDeleteVol|TestSetVolCapacity|TestPreloadDp|TestUpdateVol|TestGetVolSimpleInfo|TestCreateVol|TestCreateMetaPartition|TestCreateDataPartition|TestGetDataPartition|TestLoadDataPartition|TestDataPartitionDecommission|TestGetMetaPartitions|TestGetDataPartitions|TestGetTopo|TestGetMetaNode|TestGetNodeInfo|TestSetNodeMaxDpCntLimit|TestAddDataReplica|TestRemoveDataReplica|TestAddMetaReplica|TestRemoveMetaReplica|TestClusterStat|TestListVols|TestCreateUser|TestGetUser|TestUpdateUser|TestGetAKInfo|TestUpdatePolicy|TestRemovePolicy|TestTransferVol|TestDeleteVolPolicy|TestListUser|TestDeleteUser|TestListUsersOfVol)$"
```

First, there is a panic on my computer:
```log
2023/06/10 04:03:50 heartbeatPort[5901],replicaPort[5902]
2023/06/10 04:03:50 127.0.0.1:8080
2023/06/10 04:03:50 retainLogs= 20000
2023/06/10 04:03:50 peers[["nodeID":"1","peerID":"0","priority":"0","type":"PeerNormal","heartbeatPort":"5901","ReplicaPort":"5902"]],tickInterval[500],electionTick[6]
[1:127.0.0.1:8080] 127.0.0.1:8080
data node [127.0.0.1:9101] report heartbeat to master,err:<nil>
data node [127.0.0.1:9102] report heartbeat to master,err:<nil>
data node [127.0.0.1:9103] report heartbeat to master,err:<nil>
data node [127.0.0.1:9104] report heartbeat to master,err:<nil>
data node [127.0.0.1:9105] report heartbeat to master,err:<nil>
data node [127.0.0.1:9106] report heartbeat to master,err:<nil>
remote[127.0.0.1:46900],local[127.0.0.1:8101]
remote [127.0.0.1:46900] req [OpMetaNodeHeartbeat]
meta node [127.0.0.1:8101] heartbeat,err:<nil>
remote[127.0.0.1:52578],local[127.0.0.1:8102]
remote [127.0.0.1:52578] req [OpMetaNodeHeartbeat]
meta node [127.0.0.1:8102] heartbeat,err:<nil>
remote[127.0.0.1:41652],local[127.0.0.1:8103]
remote [127.0.0.1:41652] req [OpMetaNodeHeartbeat]
meta node [127.0.0.1:8103] heartbeat,err:<nil>
remote[127.0.0.1:55032],local[127.0.0.1:8104]
remote [127.0.0.1:55032] req [OpMetaNodeHeartbeat]
panic: action[createVol], clusterID[cubefs] name:commonVol, err:action[createVol] initMetaPartitions failed,err[action[initMetaPartitions] vol[commonVol] init meta partition failed,mpCount[0],expectCount[3],err[[vol.go 1138] [topology.go 1690] zone[zone2],err[no node set available for creating a meta partition]]] 

goroutine 1 [running]:
github.com/cubefs/cubefs/master.createDefaultMasterServerForTest()
	/home/nature/cubefs/master/api_service_test.go:137 +0x416
github.com/cubefs/cubefs/master.init()
	/home/nature/cubefs/master/api_service_test.go:65 +0xea
exit status 2
FAIL	github.com/cubefs/cubefs/master	7.705s
```

The reason is `time.Sleep(1 * time.Second)`, change it to `time.Sleep(5 * time.Second)`.

After that, run `go test` but still panic:
```log
panic: listen tcp 127.0.0.1:9106: bind: address already in use

goroutine 2801 [running]:
github.com/cubefs/cubefs/master/mocktest.(*MockDataServer).start(0xc000548f00)
	/home/nature/cubefs/master/mocktest/data_server.go:87 +0xfc
created by github.com/cubefs/cubefs/master/mocktest.(*MockDataServer).Start
	/home/nature/cubefs/master/mocktest/data_server.go:63 +0x5b
exit status 2
FAIL	github.com/cubefs/cubefs/master	91.349s
```

The reason is `TestAddDataReplica` and `TestRemoveDataReplica` listen address `127.0.0.1:9106`.

Fix them, run again:
```log
--- FAIL: TestUpdateVol (20.09s)
    api_service_test.go:287: {"code":0,"msg":"success","data":"create vol[updateVol] successfully, has allocate [10] data partitions"} http://127.0.0.1:8080/admin/createVol?owner=cfs&zoneName=zone2&capacity=300&cacheCap=80&replicaNum=1&name=updateVol&volType=1
    api_service_test.go:287: {"code":0,"msg":"success","data":{"ID":18,"Name":"updateVol","Owner":"cfs","ZoneName":"zone2","DpReplicaNum":1,"MpReplicaNum":3,"InodeCount":0,"DentryCount":0,"MaxMetaPartitionID":12,"Status":0,"Capacity":300,"RwDpCnt":10,"MpCnt":3,"DpCnt":10,"FollowerRead":true,"NeedToLowerReplica":false,"Authenticate":false,"CrossZone":false,"DefaultPriority":false,"DomainOn":false,"CreateTime":"2023-06-10 04:15:34","EnableToken":false,"EnablePosixAcl":false,"EnableTransaction":"off","TxTimeout":1,"Description":"","DpSelectorName":"","DpSelectorParm":"","DefaultZonePrior":false,"DpReadOnlyWhenVolFull":false,"VolType":1,"ObjBlockSize":8388608,"CacheCapacity":80,"CacheAction":0,"CacheThreshold":10485760,"CacheHighWater":80,"CacheLowWater":40,"CacheLruInterval":5,"CacheTtl":30,"CacheRule":"","PreloadCapacity":0,"Uids":null}} http://127.0.0.1:8080/admin/getVol?name=updateVol
    api_service_test.go:287: {"code":2,"msg":"[operate_util.go 186] parameter name not found","data":null} http://127.0.0.1:8080/vol/update?capacity=300&cacheCap=80&replicaNum=1&name=&volType=1&owner=cfs&zoneName=zone2
    api_service_test.go:287: {"code":2,"msg":"name can only be number and letters","data":null} http://127.0.0.1:8080/vol/update?capacity=300&cacheCap=80&replicaNum=1&name=tt&volType=1&owner=cfs&zoneName=zone2
    api_service_test.go:287: {"code":32,"msg":"client and server auth key do not match","data":null} http://127.0.0.1:8080/vol/update?zoneName=zone2&capacity=300&cacheCap=80&replicaNum=1&authKey=&name=updateVol&volType=1&owner=cfs
    api_service_test.go:287: {"code":0,"msg":"success","data":{"ID":18,"Name":"updateVol","Owner":"cfs","ZoneName":"zone2","DpReplicaNum":1,"MpReplicaNum":3,"InodeCount":0,"DentryCount":0,"MaxMetaPartitionID":12,"Status":0,"Capacity":300,"RwDpCnt":10,"MpCnt":3,"DpCnt":10,"FollowerRead":true,"NeedToLowerReplica":false,"Authenticate":false,"CrossZone":false,"DefaultPriority":false,"DomainOn":false,"CreateTime":"2023-06-10 04:15:34","EnableToken":false,"EnablePosixAcl":false,"EnableTransaction":"off","TxTimeout":1,"Description":"","DpSelectorName":"","DpSelectorParm":"","DefaultZonePrior":false,"DpReadOnlyWhenVolFull":false,"VolType":1,"ObjBlockSize":8388608,"CacheCapacity":80,"CacheAction":0,"CacheThreshold":10485760,"CacheHighWater":80,"CacheLowWater":40,"CacheLruInterval":5,"CacheTtl":30,"CacheRule":"","PreloadCapacity":0,"Uids":null}} http://127.0.0.1:8080/admin/getVol?name=updateVol
    api_service_test.go:287: {"code":2,"msg":"parse [capacity] is not valid uint [0], err strconv.ParseUint: parsing \"tt\": invalid syntax","data":null} http://127.0.0.1:8080/vol/update?authKey=7b2f1bf38b87d32470c4557c7ff02e75&name=updateVol&volType=1&owner=cfs&zoneName=zone2&capacity=tt&cacheCap=80&replicaNum=1
    api_service_test.go:287: {"code":0,"msg":"success","data":"update vol[updateVol] successfully"} http://127.0.0.1:8080/vol/update?replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&name=updateVol&owner=cfs&capacity=1024&description=hello_test&volType=1&zoneName=zone2&cacheCap=80
    api_service_test.go:287: {"code":1,"msg":"action[updateVol], clusterID[cubefs] name:updateVol, err:action[checkZoneName] the zonename[default] not found ","data":null} http://127.0.0.1:8080/vol/update?owner=cfs&capacity=1024&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&name=updateVol&zoneName=default&cacheCap=80&description=hello_test&volType=1
    api_service_test.go:287: {"code":2,"msg":"parse [authenticate] is not a bool val [false]","data":null} http://127.0.0.1:8080/vol/update?volType=1&zoneName=zone1&cacheCap=80&description=hello_test&authenticate=tt&name=updateVol&owner=cfs&capacity=1024&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75
    api_service_test.go:287: {"code":2,"msg":"parse [followerRead] is not a bool val [false]","data":null} http://127.0.0.1:8080/vol/update?volType=1&zoneName=zone1&cacheCap=80&description=hello_test&authenticate=true&name=updateVol&owner=cfs&capacity=1024&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=test
    api_service_test.go:287: {"code":2,"msg":"parse [ebsBlkSize] is not valid int [-1], err \u003cnil\u003e","data":null} http://127.0.0.1:8080/vol/update?authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&name=updateVol&owner=cfs&capacity=1024&replicaNum=1&authenticate=true&ebsBlkSize=-1&volType=1&zoneName=zone1&cacheCap=80&description=hello_test
    api_service_test.go:287: {"code":2,"msg":"cache action is illegal (3)","data":null} http://127.0.0.1:8080/vol/update?volType=1&zoneName=zone1&cacheCap=80&description=hello_test&authenticate=true&ebsBlkSize=6144&cacheAction=3&name=updateVol&owner=cfs&capacity=1024&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false
    api_service_test.go:287: {"code":2,"msg":"replica or follower read status error","data":null} http://127.0.0.1:8080/vol/update?authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&name=updateVol&owner=cfs&capacity=1024&replicaNum=1&authenticate=true&ebsBlkSize=6144&cacheAction=2&volType=1&zoneName=zone1&cacheCap=1027&description=hello_test
    api_service_test.go:287: {"code":2,"msg":"parse [cacheCap] is not valid uint [0], err strconv.ParseUint: parsing \"-1\": invalid syntax","data":null} http://127.0.0.1:8080/vol/update?authenticate=true&ebsBlkSize=6144&cacheAction=2&volType=1&zoneName=zone1&cacheCap=-1&description=hello_test&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&name=updateVol&owner=cfs&capacity=1024&replicaNum=1
    api_service_test.go:287: {"code":2,"msg":"replica or follower read status error","data":null} http://127.0.0.1:8080/vol/update?authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&name=updateVol&owner=cfs&capacity=101&replicaNum=1&authenticate=true&ebsBlkSize=6144&cacheAction=2&volType=1&zoneName=zone1&cacheCap=102&description=hello_test
    api_service_test.go:287: {"code":2,"msg":"parse [cacheThreshold] is not valid int [-1], err \u003cnil\u003e","data":null} http://127.0.0.1:8080/vol/update?zoneName=zone1&description=hello_test&authenticate=true&ebsBlkSize=6144&owner=cfs&capacity=1024&volType=1&cacheCap=102&cacheAction=2&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=-1
    api_service_test.go:287: {"code":2,"msg":"parse [cacheTTL] is not valid int [0], err strconv.Atoi: parsing \"tt\": invalid syntax","data":null} http://127.0.0.1:8080/vol/update?ebsBlkSize=6144&zoneName=zone1&description=hello_test&authenticate=true&owner=cfs&capacity=1024&cacheTTL=tt&volType=1&cacheCap=102&cacheAction=2&followerRead=false&cacheThreshold=7168&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75
    api_service_test.go:287: {"code":2,"msg":"parse [cacheHighWater] is not valid int [0], err strconv.Atoi: parsing \"high\": invalid syntax","data":null} http://127.0.0.1:8080/vol/update?cacheCap=102&cacheAction=2&cacheTTL=7&volType=1&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=7168&name=updateVol&description=hello_test&authenticate=true&ebsBlkSize=6144&cacheHighWater=high&zoneName=zone1&capacity=1024&owner=cfs
    api_service_test.go:287: {"code":2,"msg":"low(40) or high water(91) can't be large than 90, low than 0","data":null} http://127.0.0.1:8080/vol/update?replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=7168&name=updateVol&description=hello_test&authenticate=true&ebsBlkSize=6144&cacheHighWater=91&zoneName=zone1&capacity=1024&owner=cfs&cacheCap=102&cacheAction=2&cacheTTL=7&volType=1
    api_service_test.go:287: {"code":2,"msg":"low water(78) must be less than high water(70)","data":null} http://127.0.0.1:8080/vol/update?authenticate=true&ebsBlkSize=6144&cacheHighWater=70&cacheLowWater=78&zoneName=zone1&description=hello_test&owner=cfs&capacity=1024&cacheAction=2&cacheTTL=7&volType=1&cacheCap=102&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=7168&name=updateVol&replicaNum=1
    api_service_test.go:287: {"code":2,"msg":"low water(93) must be less than high water(70)","data":null} http://127.0.0.1:8080/vol/update?cacheHighWater=70&cacheLowWater=93&zoneName=zone1&description=hello_test&authenticate=true&ebsBlkSize=6144&owner=cfs&capacity=1024&volType=1&cacheCap=102&cacheAction=2&cacheTTL=7&cacheThreshold=7168&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false
    api_service_test.go:287: {"code":2,"msg":"parse [cacheLRUInterval] is not valid int [-1], err \u003cnil\u003e","data":null} http://127.0.0.1:8080/vol/update?cacheLowWater=40&cacheLRUInterval=-1&zoneName=zone1&description=hello_test&authenticate=true&ebsBlkSize=6144&cacheHighWater=70&owner=cfs&capacity=1024&volType=1&cacheCap=102&cacheAction=2&cacheTTL=7&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=7168
    api_service_test.go:287: {"code":2,"msg":"replica or follower read status error","data":null} http://127.0.0.1:8080/vol/update?owner=cfs&capacity=1024&cacheRuleKey=test&volType=1&cacheCap=102&cacheAction=2&cacheTTL=7&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=7168&cacheLRUInterval=6&zoneName=zone1&description=hello_test&authenticate=true&ebsBlkSize=6144&cacheHighWater=70&cacheLowWater=40
    api_service_test.go:294: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:294
        	            				/home/nature/cubefs/master/vol_test.go:188
        	            				/home/nature/cubefs/master/api_service_test.go:469
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:287: {"code":0,"msg":"success","data":{"ID":18,"Name":"updateVol","Owner":"cfs","ZoneName":"zone2","DpReplicaNum":1,"MpReplicaNum":3,"InodeCount":0,"DentryCount":0,"MaxMetaPartitionID":12,"Status":0,"Capacity":1024,"RwDpCnt":10,"MpCnt":3,"DpCnt":10,"FollowerRead":true,"NeedToLowerReplica":false,"Authenticate":false,"CrossZone":false,"DefaultPriority":false,"DomainOn":false,"CreateTime":"2023-06-10 04:15:34","EnableToken":false,"EnablePosixAcl":false,"EnableTransaction":"off","TxTimeout":1,"Description":"hello_test","DpSelectorName":"","DpSelectorParm":"","DefaultZonePrior":false,"DpReadOnlyWhenVolFull":false,"VolType":1,"ObjBlockSize":8388608,"CacheCapacity":80,"CacheAction":0,"CacheThreshold":10485760,"CacheHighWater":80,"CacheLowWater":40,"CacheLruInterval":5,"CacheTtl":30,"CacheRule":"","PreloadCapacity":0,"Uids":null}} http://127.0.0.1:8080/admin/getVol?name=updateVol
    api_service_test.go:475: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:475
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:476: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:476
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:479: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:479
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:480: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:480
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:481: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:481
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:482: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:482
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:483: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:483
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:484: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:484
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:486: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:486
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:487: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:487
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:287: {"code":2,"msg":"replica or follower read status error","data":null} http://127.0.0.1:8080/vol/update?cacheLowWater=40&cacheLRUInterval=6&zoneName=zone1&description=hello_test&authenticate=true&ebsBlkSize=6144&cacheHighWater=70&owner=cfs&capacity=1024&cacheRuleKey=test&volType=1&cacheCap=102&cacheAction=2&cacheTTL=7&emptyCacheRule=true&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheThreshold=7168
    api_service_test.go:294: 
        	Error Trace:	/home/nature/cubefs/master/api_service_test.go:294
        	            				/home/nature/cubefs/master/vol_test.go:188
        	            				/home/nature/cubefs/master/api_service_test.go:500
        	            				/home/nature/cubefs/master/api_service_test.go:490
        	Error:      	Should be true
        	Test:       	TestUpdateVol
    api_service_test.go:287: {"code":0,"msg":"success","data":{"ID":18,"Name":"updateVol","Owner":"cfs","ZoneName":"zone2","DpReplicaNum":1,"MpReplicaNum":3,"InodeCount":0,"DentryCount":0,"MaxMetaPartitionID":12,"Status":0,"Capacity":1024,"RwDpCnt":10,"MpCnt":3,"DpCnt":10,"FollowerRead":true,"NeedToLowerReplica":false,"Authenticate":false,"CrossZone":false,"DefaultPriority":false,"DomainOn":false,"CreateTime":"2023-06-10 04:15:34","EnableToken":false,"EnablePosixAcl":false,"EnableTransaction":"off","TxTimeout":1,"Description":"hello_test","DpSelectorName":"","DpSelectorParm":"","DefaultZonePrior":false,"DpReadOnlyWhenVolFull":false,"VolType":1,"ObjBlockSize":8388608,"CacheCapacity":80,"CacheAction":0,"CacheThreshold":10485760,"CacheHighWater":80,"CacheLowWater":40,"CacheLruInterval":5,"CacheTtl":30,"CacheRule":"","PreloadCapacity":0,"Uids":null}} http://127.0.0.1:8080/admin/getVol?name=updateVol
    api_service_test.go:287: {"code":0,"msg":"success","data":"delete vol[updateVol] successfully,from[127.0.0.1:33360]"} http://127.0.0.1:8080/vol/delete?name=updateVol&authKey=7b2f1bf38b87d32470c4557c7ff02e75
    api_service_test.go:287: {"code":2,"msg":"replica or follower read status error","data":null} http://127.0.0.1:8080/vol/update?cacheThreshold=7168&emptyCacheRule=true&name=updateVol&replicaNum=1&authKey=7b2f1bf38b87d32470c4557c7ff02e75&followerRead=false&cacheHighWater=70&cacheLowWater=40&cacheLRUInterval=6&zoneName=zone1&description=hello_test&authenticate=true&ebsBlkSize=6144&owner=cfs&capacity=1024&cacheRuleKey=test&volType=1&cacheCap=102&cacheAction=2&cacheTTL=7
200
```

Then I modify `TestUpdateVol`, it works now:
```log
PASS
ok  	github.com/cubefs/cubefs/master	93.444s
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#1903 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
