### PR TITLE
[Feature]: Master does snapshot optimization

### DIFF
--- a/master/metadata_fsm.go
+++ b/master/metadata_fsm.go
@@ -18,11 +18,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 
 	"github.com/cubefs/cubefs/depends/tiglabs/raft"
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
 	"github.com/cubefs/cubefs/raftstore"
+	"github.com/cubefs/cubefs/util/fileutil"
 	"github.com/cubefs/cubefs/util/log"
 	"github.com/cubefs/cubefs/util/stat"
 )
@@ -179,25 +181,31 @@ func (mf *MetadataFsm) Snapshot() (proto.Snapshot, error) {
 
 // ApplySnapshot implements the interface of raft.StateMachine
 func (mf *MetadataFsm) ApplySnapshot(peers []proto.Peer, iterator proto.SnapIterator) (err error) {
-	log.LogWarnf(fmt.Sprintf("action[ApplySnapshot] reset rocksdb before applying snapshot"))
-	snap := mf.store.RocksDBSnapshot()
+	log.LogWarnf("action[ApplySnapshot] reset rocksdb before applying snapshot")
 	mf.onSnapshot = true
-	it := mf.store.Iterator(snap)
-
 	defer func() {
-		mf.store.ReleaseSnapshot(snap)
-		it.Close()
 		mf.onSnapshot = false
 	}()
-
-	for it.SeekToFirst(); it.Valid(); it.Next() {
-		key := string(it.Key().Data())
-		log.LogInfof("deleting Key: %v Value: %v", key, it.Value().Data())
-		mf.store.Del(key, false)
-	}
-
-	log.LogWarnf(fmt.Sprintf("action[ApplySnapshot] begin,applied[%v]", mf.applied))
 	var data []byte
+	// clear recovery dir
+	recoveryDir := raftstore.GetRocksDBStoreRecoveryDir(mf.store.GetDir())
+	if fileutil.ExistDir(recoveryDir) {
+		if err = os.RemoveAll(recoveryDir); err != nil {
+			log.LogErrorf("failed to remove temp dir %v, error %v", recoveryDir, err.Error())
+			return
+		}
+	}
+	rocksdbOpened := true
+	// open temp rocksdb
+	tempDb, err := raftstore.NewRocksDBStore(recoveryDir, mf.store.GetLruCacheSize(), mf.store.GetWriteBufferSize())
+	if err != nil {
+		log.LogErrorf("failed to open temp rocksdb %v", err.Error())
+		goto errHandler
+	}
+	// close rocksdb
+	mf.store.Close()
+	rocksdbOpened = false
+	log.LogWarnf(fmt.Sprintf("action[ApplySnapshot] begin,applied[%v]", mf.applied))
 	for err == nil {
 		bgTime := stat.BeginStat()
 		if data, err = iterator.Next(); err != nil {
@@ -206,27 +214,47 @@ func (mf *MetadataFsm) ApplySnapshot(peers []proto.Peer, iterator proto.SnapIter
 		stat.EndStat("ApplySnapshot-Next", err, bgTime, 1)
 		cmd := &RaftCmd{}
 		if err = json.Unmarshal(data, cmd); err != nil {
+			tempDb.Close()
 			goto errHandler
 		}
 		bgTime = stat.BeginStat()
-		if _, err = mf.store.Put(cmd.K, cmd.V, false); err != nil {
+		if _, err = tempDb.Put(cmd.K, cmd.V, false); err != nil {
+			tempDb.Close()
 			goto errHandler
 		}
 		stat.EndStat("ApplySnapshot-Put", err, bgTime, 1)
 	}
 	if err != nil && err != io.EOF {
+		tempDb.Close()
 		goto errHandler
 	}
 
-	if err = mf.store.Flush(); err != nil {
+	if err = tempDb.Flush(); err != nil {
 		log.LogError(fmt.Sprintf("action[ApplySnapshot] Flush failed,err:%v", err.Error()))
+		tempDb.Close()
 		goto errHandler
 	}
-
+	tempDb.Close()
+	// commit point
+	if err = os.RemoveAll(mf.store.GetDir()); err != nil {
+		goto errHandler
+	}
+	if err = os.Rename(tempDb.GetDir(), mf.store.GetDir()); err != nil {
+		goto errHandler
+	}
+	// finish snapshot
+	err = mf.store.Open()
+	if err != nil {
+		log.LogErrorf("failed to open rocksdb %v", err.Error())
+		return err
+	}
 	mf.snapshotHandler()
 	log.LogWarnf(fmt.Sprintf("action[ApplySnapshot] success,applied[%v]", mf.applied))
 	return nil
 errHandler:
+	if !rocksdbOpened {
+		mf.store.Open()
+	}
 	log.LogError(fmt.Sprintf("action[ApplySnapshot] failed,err:%v", err.Error()))
 	return err
 }

--- a/master/server.go
+++ b/master/server.go
@@ -143,7 +143,7 @@ func (m *Server) Start(cfg *config.Config) (err error) {
 		return
 	}
 
-	if m.rocksDBStore, err = raftstore.NewRocksDBStore(m.storeDir, LRUCacheSize, WriteBufferSize); err != nil {
+	if m.rocksDBStore, err = raftstore.NewRocksDBStoreAndRecovery(m.storeDir, LRUCacheSize, WriteBufferSize); err != nil {
 		return
 	}
 

--- a/util/fileutil/exists.go
+++ b/util/fileutil/exists.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fileutil
+
+import "os"
+
+func Exist(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || !os.IsNotExist(err)
+}
+
+func ExistDir(path string) bool {
+	state, err := os.Stat(path)
+	if err == nil || !os.IsNotExist(err) {
+		return state.IsDir()
+	}
+	return false
+}

--- a/util/fileutil/exists_test.go
+++ b/util/fileutil/exists_test.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fileutil_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cubefs/cubefs/util/fileutil"
+)
+
+func TestExits(t *testing.T) {
+	if fileutil.Exist("/not_exist") {
+		t.Fail()
+		return
+	}
+	tempDir := os.TempDir()
+	tempFile := fmt.Sprintf("%v/exist", tempDir)
+	file, err := os.Create(tempFile)
+	if err != nil {
+		t.Errorf("failed to create file %v error: %v\n", tempFile, err.Error())
+		t.Fail()
+		return
+	}
+	file.Close()
+	if !fileutil.Exist(tempFile) {
+		t.Fail()
+		return
+	}
+	if !fileutil.ExistDir(tempDir) {
+		t.Fail()
+		return
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Optimize raft snapshot in master.
* Expose the rocksdb `close` interface.

The Benchmark Code:
```go
const volForSnapshot = "snapshtVol"

const volForSnapshotCount = 300

func BenchmarkSnapshot(b *testing.B) {
	var err error
	// perpare status
	req := &createVolReq{
		name:             "",
		owner:            "cfs",
		size:             1,
		mpCount:          1,
		dpReplicaNum:     3,
		capacity:         300,
		followerRead:     false,
		authenticate:     false,
		crossZone:        false,
		normalZonesFirst: false,
		zoneName:         testZone2,
		description:      "",
		qosLimitArgs:     &qosArgs{},
	}
	for i := 0; i != volForSnapshotCount; i++ {
		req.name = fmt.Sprintf("%v_%v", volForSnapshot, i)
		server.cluster.createVol(req)
	}
	time.Sleep(5 * time.Second)
	mdSnapshot, err := server.cluster.fsm.Snapshot()
	if err != nil {
		b.Error(err)
		return
	}
	b.Logf("snapshot apply index[%v]\n", mdSnapshot.ApplyIndex())
	s := &Server{}

	var dbStore *raftstore.RocksDBStore
	dbStore, err = raftstore.NewRocksDBStore("/tmp/cubefs/raft3", LRUCacheSize, WriteBufferSize)
	if err != nil {
		b.Fatalf("init rocks db store fail cause: %v", err)
	}
	defer dbStore.Close()
	fsm := &MetadataFsm{
		rs:    server.fsm.rs,
		store: dbStore,
	}
	fsm.registerApplySnapshotHandler(func() {
		fsm.restore()
	})
	s.fsm = fsm
	peers := make([]rproto.Peer, 0, len(server.config.peers))
	for _, peer := range server.config.peers {
		peers = append(peers, peer.Peer)
	}
	b.StopTimer()
	b.ResetTimer()
	b.StartTimer()
	if err = fsm.ApplySnapshot(peers, mdSnapshot); err != nil {
		b.Error(err)
		return
	}
	b.StopTimer()
	if fsm.applied != mdSnapshot.ApplyIndex() {
		b.Errorf("applied not equal,applied[%v],snapshot applied[%v]\n", fsm.applied, mdSnapshot.ApplyIndex())
		return
	}
	mdSnapshot.Close()
}
```

**Before**:
```log
1000000000	         0.2425 ns/op	       0 B/op	       0 allocs/op
--- BENCH: BenchmarkSnapshot-12
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
	... [output truncated]
PASS
```

The full log could be found in [here](https://github.com/NaturalSelect/logs/blob/main/bench_after.log).

**After:**
```log
1000000000	         0.1297 ns/op	       0 B/op	       0 allocs/op
--- BENCH: BenchmarkSnapshot-12
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
    master_manager_test.go:97: snapshot apply index[17517]
	... [output truncated]
PASS
```
The full log could be found in [here](https://github.com/NaturalSelect/logs/blob/main/bench_after.log).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

fixes #1916 

**Special notes for your reviewer**:

* Please contract me if this pull request have passed your review, then I will rebase and rearrange commit points.
* This scheme has bad performance when the status is small.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
