### PR TITLE
feat(auditlog): use structured data directly to reduce the parsing process

### DIFF
--- a/blobstore/common/rpc/auditlog/decoder.go
+++ b/blobstore/common/rpc/auditlog/decoder.go
@@ -60,7 +60,7 @@ var DefaultRequestHeaderKeys = []string{
 type DecodedReq struct {
 	Path   string
 	Header M
-	Params []byte
+	Params M
 }
 
 type ReadCloser struct {
@@ -69,14 +69,6 @@ type ReadCloser struct {
 }
 
 type M map[string]interface{}
-
-func (m M) Encode() []byte {
-	if len(m) > 0 {
-		ret, _ := json.Marshal(m)
-		return ret
-	}
-	return nil
-}
 
 type defaultDecoder struct{}
 
@@ -132,7 +124,7 @@ func (d *defaultDecoder) DecodeReq(req *http.Request) *DecodedReq {
 						params[k] = v
 					}
 				}
-				decodedReq.Params = params.Encode()
+				decodedReq.Params = params
 			}
 		case rpc.MIMEJSON:
 			buff, err := d.readFull(req)
@@ -140,7 +132,7 @@ func (d *defaultDecoder) DecodeReq(req *http.Request) *DecodedReq {
 				req.Body = ReadCloser{bytes.NewReader(buff), req.Body}
 				// check if request body is valid or not, and do not print invalid request body in audit log
 				if json.Valid(buff) {
-					decodedReq.Params = compactNewline(buff)
+					err = json.Unmarshal(buff, &decodedReq.Params)
 				}
 			}
 		}

--- a/blobstore/common/rpc/auditlog/response.go
+++ b/blobstore/common/rpc/auditlog/response.go
@@ -97,11 +97,11 @@ func (w *responseWriter) getBody() []byte {
 	return w.body[:w.n]
 }
 
-func (w *responseWriter) getStatusCode() []byte {
-	return []byte(strconv.Itoa(w.statusCode))
+func (w *responseWriter) getStatusCode() int {
+	return w.statusCode
 }
 
-func (w *responseWriter) getHeader() []byte {
+func (w *responseWriter) getHeader() M {
 	header := w.ResponseWriter.Header()
 	headerM := make(M)
 	for k := range header {
@@ -111,10 +111,7 @@ func (w *responseWriter) getHeader() []byte {
 			headerM[k] = header.Get(k)
 		}
 	}
-	if len(headerM) > 0 {
-		return headerM.Encode()
-	}
-	return nil
+	return headerM
 }
 
 func (w *responseWriter) getBodyWritten() int64 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use structured data directly to reduce the parsing process. After this implementation, the format of the log will look like this:
```json
{"req_type":"REQ","module":"testModule","start_time":16864141324060244,"method":"GET","path":"/test","req_header":{"Content-Type":"application/json","Host":"example.com","IP":"192.0.2.1"},"req_params":{"text":"hello"},"status_code":200,"resp_header":{"Blobstore-Tracer-Traceid":"4e1e1626be6fbd80","Content-Length":"13","Content-Type":"application/json","Trace-Log":["testModule:2"],"Trace-Tags":["span.kind:server"]},"resp_body":"{\"msg\": \"OK\"}","body_written":13,"duration":2301}
```

**Which issue this PR fixes**
close: #1913