### PR TITLE
feat(auditlog): use structured data directly to reduce the parsing pr…

### DIFF
--- a/blobstore/common/rpc/auditlog/auditlog.go
+++ b/blobstore/common/rpc/auditlog/auditlog.go
@@ -16,9 +16,9 @@ package auditlog
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +45,22 @@ type jsonAuditlog struct {
 	bodyPool sync.Pool
 
 	cfg *Config
+}
+
+// AuditLog Define a struct to represent the structured log data
+type AuditLog struct {
+	ReqType     string `json:"req_type"`
+	Module      string `json:"module"`
+	StartTime   int64  `json:"start_time"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	ReqHeader   M      `json:"req_header"`
+	ReqParams   M      `json:"req_params"`
+	StatusCode  int    `json:"status_code"`
+	RespHeader  M      `json:"resp_header"`
+	RespBody    string `json:"resp_body"`
+	BodyWritten int64  `json:"body_written"`
+	Duration    int64  `json:"duration"`
 }
 
 func Open(module string, cfg *Config) (ph rpc.ProgressHandler, logFile LogCloser, err error) {
@@ -127,68 +143,48 @@ func (j *jsonAuditlog) Handler(w http.ResponseWriter, req *http.Request, f func(
 	f(_w, req)
 
 	endTime := time.Now().UnixNano() / 1000
-	b := j.logPool.Get().(*bytes.Buffer)
-	defer j.logPool.Put(b)
-	b.Reset()
 
-	b.WriteString("REQ\t")
-	b.WriteString(j.module)
-	b.WriteByte('\t')
-
-	// record request info
-	b.WriteString(strconv.FormatInt(startTime/100, 10))
-	b.WriteByte('\t')
-	b.WriteString(req.Method)
-	b.WriteByte('\t')
-	b.WriteString(decodeReq.Path)
-	b.WriteByte('\t')
-	b.Write(decodeReq.Header.Encode())
-	b.WriteByte('\t')
-	if len(decodeReq.Params) <= maxSeekableBodyLength && len(decodeReq.Params) > 0 {
-		b.Write(decodeReq.Params)
+	// Create a new AuditLog instance
+	auditLog := &AuditLog{
+		ReqType:   "REQ",
+		Module:    j.module,
+		StartTime: startTime / 100,
+		Method:    req.Method,
+		Path:      decodeReq.Path,
+		ReqHeader: decodeReq.Header,
+		ReqParams: decodeReq.Params,
 	}
-	b.WriteByte('\t')
 
-	// record response info
-	respContentType := _w.Header().Get("Content-Type")
-	b.Write(_w.getStatusCode())
-	b.WriteByte('\t')
-
-	// Check if track-log and tags changed or not,
-	// if changed, we should set into response header again.
-	// But the additional headers DO NOT write to client if
-	// they set after response WriteHeader, just logging.
-	wHeader := _w.Header()
-	traceLogs := span.TrackLog()
-	if len(wHeader[rpc.HeaderTraceLog]) < len(traceLogs) {
-		wHeader[rpc.HeaderTraceLog] = traceLogs
-	}
-	tags := span.Tags().ToSlice()
-	if len(wHeader[rpc.HeaderTraceTags]) < len(tags) {
-		wHeader[rpc.HeaderTraceTags] = tags
-	}
-	b.Write(_w.getHeader())
-	b.WriteByte('\t')
+	// Update response fields in the AuditLog instance
+	auditLog.StatusCode = _w.getStatusCode()
+	auditLog.RespHeader = _w.getHeader()
 
 	// record body in json or xml content type
+	respContentType := _w.Header().Get("Content-Type")
 	if (respContentType == rpc.MIMEJSON || respContentType == rpc.MIMEXML) &&
 		_w.Header().Get("Content-Encoding") != rpc.GzipEncodingType {
-		b.Write(_w.getBody())
+		auditLog.RespBody = string(_w.getBody())
 	}
-	b.WriteByte('\t')
-	b.WriteString(strconv.FormatInt(_w.getBodyWritten(), 10))
-	b.WriteByte('\t')
-	b.WriteString(strconv.FormatInt(endTime-startTime/1000, 10))
-	b.WriteByte('\n')
+
+	auditLog.BodyWritten = _w.getBodyWritten()
+	auditLog.Duration = endTime - startTime/1000
+
+	// Serialize the AuditLog instance as JSON
+	auditLogJSON, err := json.Marshal(auditLog)
+	if err != nil {
+		span.Errorf("jsonlog.Handler JSON serialization failed, err: %s", err.Error())
+		return
+	}
 
 	// report request metric
-	j.metricSender.Send(b.Bytes())
+	j.metricSender.Send(auditLogJSON)
 
 	// log filter
 	if j.logFile == nil || (len(j.cfg.KeywordsFilter) > 0 && defaultLogFilter(req, j.cfg.KeywordsFilter)) {
 		return
 	}
-	err := j.logFile.Log(b.Bytes())
+	// Write the JSON data to the log file
+	err = j.logFile.Log(auditLogJSON)
 	if err != nil {
 		span.Errorf("jsonlog.Handler Log failed, err: %s", err.Error())
 		return

--- a/blobstore/common/rpc/auditlog/auditlog_test.go
+++ b/blobstore/common/rpc/auditlog/auditlog_test.go
@@ -15,21 +15,25 @@
 package auditlog
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/cubefs/cubefs/blobstore/common/rpc"
 	"github.com/cubefs/cubefs/blobstore/common/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testRespData struct {
@@ -150,4 +154,111 @@ func TestBodylimit(t *testing.T) {
 		require.NoError(t, lc.Close())
 		require.Equal(t, limit.expected, cfg.BodyLimit)
 	}
+}
+
+type mockMetricSender struct {
+	data []byte
+}
+
+func (m *mockMetricSender) Send(raw []byte) error {
+	m.data = append(m.data, raw...)
+	return nil
+}
+
+type mockLogFile struct {
+	logs bytes.Buffer
+}
+
+func (m *mockLogFile) Log(data []byte) error {
+	m.logs.Write(data)
+	return nil
+}
+
+func (m *mockLogFile) Close() error {
+	return nil
+}
+
+func TestHandler(t *testing.T) {
+	// Create a mock metric sender and log file
+	var (
+		metricSender     = &mockMetricSender{}
+		logFile          = &mockLogFile{}
+		mockHttpRespJson = "{\"msg\": \"OK\"}"
+		mockContentType  = "application/json"
+		testModule       = "testModule"
+	)
+
+	cfg := &Config{
+		BodyLimit: 13,
+	}
+	decoder := &defaultDecoder{}
+	j := &jsonAuditlog{
+		module:       testModule,
+		metricSender: metricSender,
+		logFile:      logFile,
+		cfg:          cfg,
+		decoder:      decoder,
+		logPool: sync.Pool{
+			New: func() interface{} {
+				return new(bytes.Buffer)
+			},
+		},
+		bodyPool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, cfg.BodyLimit)
+			},
+		},
+	}
+
+	// Define a test handler
+	testHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(mockHttpRespJson))
+		w.Header().Set("Content-Type", mockContentType)
+		w.Header().Set("Content-Length", strconv.Itoa(len(mockHttpRespJson)))
+		assert.NoError(t, err)
+	}
+
+	// Create a test request with a body
+	req := httptest.NewRequest("GET", "https://example.com/test", strings.NewReader("{\"text\": \"hello\"}"))
+	req.Header.Set("Content-Type", mockContentType)
+
+	// Record the response
+	respRec := httptest.NewRecorder()
+
+	// Call the Handler function
+	j.Handler(respRec, req, testHandler)
+
+	// Check the response
+	resp := respRec.Result()
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, mockHttpRespJson, string(body))
+
+	// Check the log file
+	assert.Equal(t, logFile.logs.Bytes(), metricSender.data)
+
+	var logEntry AuditLog
+	err = json.Unmarshal(logFile.logs.Bytes(), &logEntry)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "REQ", logEntry.ReqType)
+	assert.Equal(t, testModule, logEntry.Module)
+	assert.True(t, logEntry.StartTime > 0)
+	assert.Equal(t, "GET", logEntry.Method)
+	assert.Equal(t, "/test", logEntry.Path)
+	assert.NotNil(t, logEntry.ReqHeader)
+	assert.NotNil(t, logEntry.RespHeader)
+	assert.Equal(t, "example.com", logEntry.ReqHeader["Host"])
+	assert.True(t, logEntry.ReqHeader["IP"] != "")
+	assert.Equal(t, logEntry.ReqParams["text"], "hello")
+	assert.Equal(t, http.StatusOK, logEntry.StatusCode)
+	assert.Contains(t, logEntry.RespHeader, "Blobstore-Tracer-Traceid")
+	assert.True(t, fmt.Sprintf("%v", logEntry.RespHeader["Trace-Log"]) != "")
+	assert.Equal(t, []interface{}{"span.kind:server"}, logEntry.RespHeader["Trace-Tags"])
+	assert.Equal(t, mockHttpRespJson, logEntry.RespBody)
+	assert.Equal(t, int64(len(mockHttpRespJson)), logEntry.BodyWritten)
+	assert.True(t, logEntry.Duration > 0)
 }

--- a/blobstore/common/rpc/auditlog/decoder.go
+++ b/blobstore/common/rpc/auditlog/decoder.go
@@ -60,7 +60,7 @@ var DefaultRequestHeaderKeys = []string{
 type DecodedReq struct {
 	Path   string
 	Header M
-	Params []byte
+	Params M
 }
 
 type ReadCloser struct {
@@ -69,14 +69,6 @@ type ReadCloser struct {
 }
 
 type M map[string]interface{}
-
-func (m M) Encode() []byte {
-	if len(m) > 0 {
-		ret, _ := json.Marshal(m)
-		return ret
-	}
-	return nil
-}
 
 type defaultDecoder struct{}
 
@@ -132,7 +124,7 @@ func (d *defaultDecoder) DecodeReq(req *http.Request) *DecodedReq {
 						params[k] = v
 					}
 				}
-				decodedReq.Params = params.Encode()
+				decodedReq.Params = params
 			}
 		case rpc.MIMEJSON:
 			buff, err := d.readFull(req)
@@ -140,7 +132,7 @@ func (d *defaultDecoder) DecodeReq(req *http.Request) *DecodedReq {
 				req.Body = ReadCloser{bytes.NewReader(buff), req.Body}
 				// check if request body is valid or not, and do not print invalid request body in audit log
 				if json.Valid(buff) {
-					decodedReq.Params = compactNewline(buff)
+					json.Unmarshal(buff, &decodedReq.Params)
 				}
 			}
 		}

--- a/blobstore/common/rpc/auditlog/response.go
+++ b/blobstore/common/rpc/auditlog/response.go
@@ -97,11 +97,11 @@ func (w *responseWriter) getBody() []byte {
 	return w.body[:w.n]
 }
 
-func (w *responseWriter) getStatusCode() []byte {
-	return []byte(strconv.Itoa(w.statusCode))
+func (w *responseWriter) getStatusCode() int {
+	return w.statusCode
 }
 
-func (w *responseWriter) getHeader() []byte {
+func (w *responseWriter) getHeader() M {
 	header := w.ResponseWriter.Header()
 	headerM := make(M)
 	for k := range header {
@@ -111,10 +111,7 @@ func (w *responseWriter) getHeader() []byte {
 			headerM[k] = header.Get(k)
 		}
 	}
-	if len(headerM) > 0 {
-		return headerM.Encode()
-	}
-	return nil
+	return headerM
 }
 
 func (w *responseWriter) getBodyWritten() int64 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use structured data directly to reduce the parsing process. After this implementation, the format of the log will look like this:
```json
{"req_type":"REQ","module":"testModule","start_time":16864141324060244,"method":"GET","path":"/test","req_header":{"Content-Type":"application/json","Host":"example.com","IP":"192.0.2.1"},"req_params":{"text":"hello"},"status_code":200,"resp_header":{"Blobstore-Tracer-Traceid":"4e1e1626be6fbd80","Content-Length":"13","Content-Type":"application/json","Trace-Log":["testModule:2"],"Trace-Tags":["span.kind:server"]},"resp_body":"{\"msg\": \"OK\"}","body_written":13,"duration":2301}
```

**Which issue this PR fixes**
close: #1913