### PR TITLE
fix datanode panic and remove update size goroutine.

### DIFF
--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -475,30 +475,6 @@ func (mp *metaPartition) acucumUidSizeByLoad(ino *Inode) {
 	mp.uidManager.accumInoUidSize(ino, mp.uidManager.accumBase)
 }
 
-func (mp *metaPartition) updateSize() {
-	timer := time.NewTicker(time.Minute * 2)
-	go func() {
-		for {
-			select {
-			case <-timer.C:
-				size := uint64(0)
-
-				mp.inodeTree.GetTree().Ascend(func(item BtreeItem) bool {
-					inode := item.(*Inode)
-					size += inode.Size
-					return true
-				})
-
-				mp.size = size
-				log.LogDebugf("[updateSize] update mp(%d) size(%d) success", mp.config.PartitionId, size)
-			case <-mp.stopC:
-				log.LogDebugf("[updateSize] stop update mp(%d) size", mp.config.PartitionId)
-				return
-			}
-		}
-	}()
-}
-
 func (mp *metaPartition) ForceSetMetaPartitionToLoadding() {
 	mp.isLoadingMetaPartition = true
 }
@@ -618,8 +594,11 @@ func (mp *metaPartition) onStart(isCreate bool) (err error) {
 		}
 		mp.ebsClient = ebsClient
 	}
-	mp.updateSize()
 
+	if proto.IsHot(mp.volType) {
+		log.LogInfof("hot vol not need cacheTTL")
+		return
+	}
 	// do cache TTL die out process
 	if err = mp.cacheTTLWork(); err != nil {
 		err = errors.NewErrorf("[onStart] start CacheTTLWork id=%d: %s",

--- a/storage/extent_cache.go
+++ b/storage/extent_cache.go
@@ -107,10 +107,12 @@ func (cache *ExtentCache) Del(extentID uint64) {
 
 // Clear closes all the extents stored in the cache.
 func (cache *ExtentCache) Clear() {
+	cache.tinyLock.RLock()
 	for _, extent := range cache.tinyExtents {
-
 		extent.Close()
 	}
+	cache.tinyLock.RUnlock()
+
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	for e := cache.extentList.Front(); e != nil; {
@@ -153,9 +155,13 @@ func (cache *ExtentCache) evict() {
 
 // Flush synchronizes the extent stored in the cache to the disk.
 func (cache *ExtentCache) Flush() {
+
+	cache.tinyLock.RLock()
 	for _, extent := range cache.tinyExtents {
 		extent.Flush()
 	}
+	cache.tinyLock.RUnlock()
+
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
 	for _, item := range cache.extentMap {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. use rlock to avoid map panic when stop dp.
2. remove updateSize() goroutine.

**Which issue this PR fixes**: 
fixes #2150,  fixes #2153

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
