### PR TITLE
enhance(client): support read ahead in ec

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -84,6 +84,7 @@ type Super struct {
 	bcacheFilterFiles   string
 	bcacheCheckInterval int64
 	bcacheBatchCnt      int64
+	enableReadAhead     bool
 
 	readThreads  int
 	writeThreads int
@@ -208,6 +209,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	s.enableBcache = opt.EnableBcache
 	s.readThreads = int(opt.ReadThreads)
 	s.writeThreads = int(opt.WriteThreads)
+	s.enableReadAhead = opt.EnableReadAhead
 
 	if s.enableBcache {
 		s.bc = bcache.NewBcacheClient()

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -761,6 +761,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.MaxStreamerLimit = GlobalMountOptions[proto.MaxStreamerLimit].GetInt64()
 	opt.EnableAudit = GlobalMountOptions[proto.EnableAudit].GetBool()
 	opt.MinWriteAbleDataPartitionCnt = int(GlobalMountOptions[proto.MinWriteAbleDataPartitionCnt].GetInt64())
+	opt.EnableReadAhead = GlobalMountOptions[proto.EnableReadAhead].GetBool()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -69,6 +69,7 @@ const (
 	EnableAudit
 	LocallyProf
 	MinWriteAbleDataPartitionCnt
+	EnableReadAhead
 	MaxMountOption
 )
 
@@ -156,6 +157,8 @@ func InitMountOptions(opts []MountOption) {
 	opts[MinWriteAbleDataPartitionCnt] = MountOption{"minWriteAbleDataPartitionCnt",
 		"Min writeable data partition count retained int dpSelector when update DataPartitionsView from master",
 		"", int64(10)}
+	opts[EnableReadAhead] = MountOption{"enableReadAhead", "enable read ahead", "", false}
+
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
 	}
@@ -311,4 +314,5 @@ type MountOptions struct {
 	MaxStreamerLimit             int64
 	EnableAudit                  bool
 	MinWriteAbleDataPartitionCnt int
+	EnableReadAhead              bool
 }


### PR DESCRIPTION
Limited by fuse in kernel, the read size of read request from fuse is not greater than 128KB so that fuse client only reads a little part of objExtent in each read request. So read shows low performance.

In this pr, read ahead can be choosen to applied by add config ' "enableReadAhead": true ' and make read show high performance in sequential read.

