### PR TITLE
enhance: support truncate and concurrent write in ec

### DIFF
--- a/sdk/data/blobstore/reader_test.go
+++ b/sdk/data/blobstore/reader_test.go
@@ -461,12 +461,12 @@ func MockGetObjExtentsTrue(m *meta.MetaWrapper, inode uint64) (gen uint64, size 
 		objEks = append(objEks, proto.ObjExtentKey{Size: uint64(100), FileOffset: uint64(expectedFileSize)})
 		expectedFileSize += size
 	}
-	return 1, 1, nil, objEks, nil
+	return 1, 500, nil, objEks, nil
 }
 
 func MockGetObjExtentsFalse(m *meta.MetaWrapper, inode uint64) (gen uint64, size uint64,
 	extents []proto.ExtentKey, objExtents []proto.ObjExtentKey, err error) {
-	return 1, 1, nil, nil, errors.New("Get objEks failed")
+	return 1, 0, nil, nil, errors.New("Get objEks failed")
 }
 
 func MockEbscReadTrue(ebsc *BlobStoreClient, ctx context.Context, volName string,

--- a/sdk/data/blobstore/writer_test.go
+++ b/sdk/data/blobstore/writer_test.go
@@ -115,6 +115,12 @@ func TestWriter_doBufferWrite_(t *testing.T) {
 		{111111, make([]byte, 1000000), 1000000},
 		{1111111, make([]byte, 5000000), 5000000},
 	}
+	mw := &meta.MetaWrapper{}
+	err := gohook.HookMethod(mw, "GetObjExtents", MockGetObjExtentsNull, nil)
+	if err != nil {
+		panic(fmt.Sprintf("Hook advance instance method failed:%s", err.Error()))
+	}
+	writer.mw = mw
 	var flag int
 	flag |= proto.FlagsAppend
 	var fileSize int
@@ -128,6 +134,10 @@ func TestWriter_doBufferWrite_(t *testing.T) {
 	if writer.CacheFileSize() != fileSize {
 		t.Fatalf("write fail. fileSize is correct. fileSize:(%v),expect:(%v)", writer.CacheFileSize(), fileSize)
 	}
+}
+
+func MockGetObjExtentsNull(mw *meta.MetaWrapper, inode uint64) (gen uint64, size uint64, extents []proto.ExtentKey, objExtents []proto.ObjExtentKey, err error) {
+	return 0, 0, nil, nil, nil
 }
 
 func TestWriter_prepareWriteSlice(t *testing.T) {


### PR DESCRIPTION
1、only support truncate from small size to big size.
2、support to write concurrently at different position in same file, and it's not allowed that two concurrent writes overlap each other. So overwrite is still not allowed in this pr.