### PR TITLE
feature(metanode): add a flag to getInode of metanode for supporting noatime feature

### DIFF
--- a/sdk/master/client.go
+++ b/sdk/master/client.go
@@ -181,12 +181,12 @@ func (c *MasterClient) serveRequest(r *request) (repsData []byte, err error) {
 			}
 			return []byte(body.Data), nil
 		default:
+			err = errors.New(fmt.Sprintf("err(%v)", strings.Replace(string(repsData), "\n", "", -1)))
 			log.LogErrorf("serveRequest: unknown status: host(%v) uri(%v) status(%v) body(%s).",
 				resp.Request.URL.String(), host, stateCode, strings.Replace(string(repsData), "\n", "", -1))
 			continue
 		}
 	}
-	err = ErrNoValidMaster
 	return
 }
 


### PR DESCRIPTION
close: #2164

**What this PR does / why we need it**:
 add a flag to getInode of metanode for supporting client noatime feature



