### PR TITLE
fix(blobstore): fix build error when run directory not exits

### DIFF
--- a/blobstore/run.sh
+++ b/blobstore/run.sh
@@ -6,8 +6,8 @@ source ./init.sh
 # build blobstore and get consul kafka
 INIT
 
-if [ ! -d ./run/logs ];then
-  mkdir -p ./run/logs
+if [ ! -d ./blobstore/run/logs ];then
+  mkdir -p ./blobstore/run/logs
 fi
 cd build
 # start consul


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
After executing INIT, the current directory is located at the root directory of the project. So the target log directory is `./blobstore/run/logs` instead of `./run/logs`

If we use `./run/logs`, errors will occur during the installation of the Erasure Code Subsystem.
(script from https://cubefs.io/docs/master/deploy/node.html#install-erasure-code-subsystem)
```shell
$ cd cubefs/blobstore
$ ./run.sh --consul
build blobstore    success
./run.sh: line 15: ../blobstore/run/logs/consul.log: No such file or directory
```