### PR TITLE
feat(metanode): optimize mp leader send snapshot to follower

### DIFF
--- a/metanode/const.go
+++ b/metanode/const.go
@@ -182,23 +182,25 @@ const (
 
 // Configuration keys
 const (
-	cfgLocalIP           = "localIP"
-	cfgListen            = "listen"
-	cfgMetadataDir       = "metadataDir"
-	cfgRaftDir           = "raftDir"
-	cfgMasterAddrs       = "masterAddrs" // will be deprecated
-	cfgRaftHeartbeatPort = "raftHeartbeatPort"
-	cfgRaftReplicaPort   = "raftReplicaPort"
-	cfgDeleteBatchCount  = "deleteBatchCount"
-	cfgTotalMem          = "totalMem"
-	cfgMemRatio          = "memRatio"
-	cfgZoneName          = "zoneName"
-	cfgTickInterval      = "tickInterval"
-	cfgRaftRecvBufSize   = "raftRecvBufSize"
-	cfgSmuxPortShift     = "smuxPortShift"     //int
-	cfgSmuxMaxConn       = "smuxMaxConn"       //int
-	cfgSmuxStreamPerConn = "smuxStreamPerConn" //int
-	cfgSmuxMaxBuffer     = "smuxMaxBuffer"     //int
+	cfgLocalIP                   = "localIP"
+	cfgListen                    = "listen"
+	cfgMetadataDir               = "metadataDir"
+	cfgRaftDir                   = "raftDir"
+	cfgMasterAddrs               = "masterAddrs" // will be deprecated
+	cfgRaftHeartbeatPort         = "raftHeartbeatPort"
+	cfgRaftReplicaPort           = "raftReplicaPort"
+	cfgDeleteBatchCount          = "deleteBatchCount"
+	cfgTotalMem                  = "totalMem"
+	cfgMemRatio                  = "memRatio"
+	cfgZoneName                  = "zoneName"
+	cfgTickInterval              = "tickInterval"
+	cfgRaftRecvBufSize           = "raftRecvBufSize"
+	cfgSmuxPortShift             = "smuxPortShift"             //int
+	cfgSmuxMaxConn               = "smuxMaxConn"               //int
+	cfgSmuxStreamPerConn         = "smuxStreamPerConn"         //int
+	cfgSmuxMaxBuffer             = "smuxMaxBuffer"             //int
+	cfgRetainLogs                = "retainLogs"                //string, raft RetainLogs
+	cfgRaftSyncSnapFormatVersion = "raftSyncSnapFormatVersion" //int, format version of snapshot that raft leader sent to follower
 
 	metaNodeDeleteBatchCountKey = "batchCount"
 	configNameResolveInterval   = "nameResolveInterval" // int
@@ -209,10 +211,11 @@ const (
 	intervalToPersistData = time.Minute * 5
 	intervalToSyncCursor  = time.Minute * 1
 
-	defaultDelExtentsCnt       = 100000
-	defaultMaxQuotaGoroutine   = 5
-	defaultQuotaSwitch         = true
-	DefaultNameResolveInterval = 1 // minutes
+	defaultDelExtentsCnt         = 100000
+	defaultMaxQuotaGoroutine     = 5
+	defaultQuotaSwitch           = true
+	DefaultNameResolveInterval   = 1 // minutes
+	DefaultRaftNumOfLogsToRetain = 20000 * 2
 )
 
 const (

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -52,24 +52,26 @@ var (
 // The MetaNode manages the dentry and inode information of the meta partitions on a meta node.
 // The data consistency is ensured by Raft.
 type MetaNode struct {
-	nodeId            uint64
-	listen            string
-	bindIp            bool
-	metadataDir       string // root dir of the metaNode
-	raftDir           string // root dir of the raftStore log
-	metadataManager   MetadataManager
-	localAddr         string
-	clusterId         string
-	raftStore         raftstore.RaftStore
-	raftHeartbeatPort string
-	raftReplicatePort string
-	zoneName          string
-	httpStopC         chan uint8
-	smuxStopC         chan uint8
-	metrics           *MetaNodeMetrics
-	tickInterval      int
-	raftRecvBufSize   int
-	connectionCnt     int64
+	nodeId                    uint64
+	listen                    string
+	bindIp                    bool
+	metadataDir               string // root dir of the metaNode
+	raftDir                   string // root dir of the raftStore log
+	metadataManager           MetadataManager
+	localAddr                 string
+	clusterId                 string
+	raftStore                 raftstore.RaftStore
+	raftHeartbeatPort         string
+	raftReplicatePort         string
+	raftRetainLogs            uint64
+	raftSyncSnapFormatVersion uint32 //format version of snapshot that raft leader sent to follower
+	zoneName                  string
+	httpStopC                 chan uint8
+	smuxStopC                 chan uint8
+	metrics                   *MetaNodeMetrics
+	tickInterval              int
+	raftRecvBufSize           int
+	connectionCnt             int64
 
 	control common.Control
 }
@@ -247,6 +249,34 @@ func (m *MetaNode) parseConfig(cfg *config.Config) (err error) {
 	if m.raftReplicatePort == "" {
 		return fmt.Errorf("bad cfgRaftReplicaPort config")
 	}
+
+	raftRetainLogs := cfg.GetString(cfgRetainLogs)
+	if raftRetainLogs != "" {
+		if m.raftRetainLogs, err = strconv.ParseUint(raftRetainLogs, 10, 64); err != nil {
+			return fmt.Errorf("%v, err:%v", proto.ErrInvalidCfg, err.Error())
+		}
+	}
+	if m.raftRetainLogs <= 0 {
+		m.raftRetainLogs = DefaultRaftNumOfLogsToRetain
+	}
+	syslog.Println("conf raftRetainLogs=", m.raftRetainLogs)
+	log.LogInfof("[parseConfig] raftRetainLogs[%v]", m.raftRetainLogs)
+
+	if cfg.HasKey(cfgRaftSyncSnapFormatVersion) {
+		raftSyncSnapFormatVersion := uint32(cfg.GetInt64(cfgRaftSyncSnapFormatVersion))
+		if raftSyncSnapFormatVersion < 0 || raftSyncSnapFormatVersion > SnapFormatVersion_1 {
+			m.raftSyncSnapFormatVersion = SnapFormatVersion_1
+			log.LogInfof("invalid config raftSyncSnapFormatVersion, using default[%v]", m.raftSyncSnapFormatVersion)
+		} else {
+			m.raftSyncSnapFormatVersion = raftSyncSnapFormatVersion
+			log.LogInfof("by config raftSyncSnapFormatVersion:[%v]", m.raftSyncSnapFormatVersion)
+		}
+	} else {
+		m.raftSyncSnapFormatVersion = SnapFormatVersion_1
+		log.LogInfof("using default raftSyncSnapFormatVersion[%v]", m.raftSyncSnapFormatVersion)
+	}
+	syslog.Println("conf raftSyncSnapFormatVersion=", m.raftSyncSnapFormatVersion)
+	log.LogInfof("[parseConfig] raftSyncSnapFormatVersion[%v]", m.raftSyncSnapFormatVersion)
 
 	constCfg := config.ConstConfig{
 		Listen:           m.listen,

--- a/metanode/raft_server.go
+++ b/metanode/raft_server.go
@@ -47,7 +47,7 @@ func (m *MetaNode) startRaftServer(cfg *config.Config) (err error) {
 		ReplicaPort:       replicaPort,
 		TickInterval:      m.tickInterval,
 		RecvBufSize:       m.raftRecvBufSize,
-		NumOfLogsToRetain: raftstore.DefaultNumOfLogsToRetain * 2,
+		NumOfLogsToRetain: m.raftRetainLogs,
 	}
 	m.raftStore, err = raftstore.NewRaftStore(raftConf, cfg)
 	if err != nil {

--- a/metanode/transaction.go
+++ b/metanode/transaction.go
@@ -47,6 +47,14 @@ const (
 	RbFromClient uint32 = 2
 )
 
+func (i *TxRollbackInode) ToString() string {
+	content := fmt.Sprintf("{inode:[ino:%v, type:%v, nlink:%v], quotaIds:%v, rbType:%v, rbInitiator:%v, rbPlaceholder:%v, rbPlaceholderTimestamp:%v, "+
+		"txInodeInfo:[Ino:%v, MpID:%v, CreateTime:%v, Timeout:%v, TxID:%v, MpMembers:%v]}",
+		i.inode.Inode, i.inode.Type, i.inode.NLink, i.quotaIds, i.rbType, i.rbInitiator, i.rbPlaceholder, i.rbPlaceholderTimestamp,
+		i.txInodeInfo.Ino, i.txInodeInfo.MpID, i.txInodeInfo.CreateTime, i.txInodeInfo.Timeout, i.txInodeInfo.TxID, i.txInodeInfo.MpMembers)
+	return content
+}
+
 type TxRollbackInode struct {
 	inode                  *Inode
 	txInodeInfo            *proto.TxInodeInfo
@@ -55,14 +63,6 @@ type TxRollbackInode struct {
 	rbPlaceholder          bool   //default false
 	rbPlaceholderTimestamp int64
 	quotaIds               []uint32
-}
-
-func (i *TxRollbackInode) ToString() string {
-	content := fmt.Sprintf("{inode:[ino:%v, type:%v, nlink:%v], quotaIds:%v, rbType:%v, rbInitiator:%v, rbPlaceholder:%v, rbPlaceholderTimestamp:%v, "+
-		"txInodeInfo:[Ino:%v, MpID:%v, CreateTime:%v, Timeout:%v, TxID:%v, MpMembers:%v]}",
-		i.inode.Inode, i.inode.Type, i.inode.NLink, i.quotaIds, i.rbType, i.rbInitiator, i.rbPlaceholder, i.rbPlaceholderTimestamp,
-		i.txInodeInfo.Ino, i.txInodeInfo.MpID, i.txInodeInfo.CreateTime, i.txInodeInfo.Timeout, i.txInodeInfo.TxID, i.txInodeInfo.MpMembers)
-	return content
 }
 
 // Less tests whether the current TxRollbackInode item is less than the given one.

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -124,7 +124,7 @@ func (c *Config) GetBool(key string) bool {
 	return false
 }
 
-// GetBool returns a int value for the config key.
+// GetInt returns a int value for the config key.
 func (c *Config) GetInt(key string) int {
 	x, present := c.data[key]
 	if !present {
@@ -136,7 +136,7 @@ func (c *Config) GetInt(key string) int {
 	return 0
 }
 
-// GetBool returns a int64 value for the config key.
+// GetInt64 returns a int64 value for the config key.
 func (c *Config) GetInt64(key string) int64 {
 	x, present := c.data[key]
 	if !present {
@@ -157,7 +157,12 @@ func (c *Config) GetInt64(key string) int64 {
 	return 0
 }
 
-// GetBool returns a int64 value for the config key.
+func (c *Config) HasKey(key string) bool {
+	_, present := c.data[key]
+	return present
+}
+
+// GetInt64WithDefault returns a int64 value for the config key.
 func (c *Config) GetInt64WithDefault(key string, defaultVal int64) int64 {
 	if val := c.GetInt64(key); val == 0 {
 		return defaultVal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
(1) add a configuration item for raft retainLogs, for metaNode; 
(2) add a configuration item to set which format version to use when mp raft leader send snapshot to follower; 
(3) when follower apply snapshot, won't fail if format snapshot version not match, just handle the part of fields it can recognize;

(2 )and (3) are the  focus of this revision，to handle the compatibility of snapshot format of meta partitifion when upgrading. 


**Special notes for your reviewer**:
