### PR TITLE
set dp status readwrite when load from disk.

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -50,6 +50,7 @@ type Cluster struct {
 	badPartitionMutex            sync.RWMutex // BadDataPartitionIds and BadMetaPartitionIds operate mutex
 	leaderInfo                   *LeaderInfo
 	cfg                          *clusterConfig
+	metaReady                    bool
 	retainLogs                   uint64
 	idAlloc                      *IDAllocator
 	t                            *topology
@@ -507,7 +508,9 @@ func (c *Cluster) checkDataPartitions() {
 	for _, vol := range vols {
 		readWrites := vol.checkDataPartitions(c)
 		vol.dataPartitions.setReadWriteDataPartitions(readWrites, c.Name)
-		vol.dataPartitions.updateResponseCache(true, 0, vol.VolType)
+		if c.metaReady {
+			vol.dataPartitions.updateResponseCache(true, 0, vol.VolType)
+		}
 		msg := fmt.Sprintf("action[checkDataPartitions],vol[%v] can readWrite partitions:%v  ",
 			vol.Name, vol.dataPartitions.readableAndWritableCnt)
 		log.LogInfo(msg)

--- a/master/master_manager.go
+++ b/master/master_manager.go
@@ -47,6 +47,7 @@ func (m *Server) handleLeaderChange(leader uint64) {
 			m.cluster.checkPersistClusterValue()
 
 			m.loadMetadata()
+			m.cluster.metaReady = true
 			m.metaReady = true
 		}
 		m.cluster.checkDataNodeHeartbeat()
@@ -58,6 +59,7 @@ func (m *Server) handleLeaderChange(leader uint64) {
 			m.clusterName, m.leaderInfo.addr))
 		m.clearMetadata()
 		m.metaReady = false
+		m.cluster.metaReady = false
 		m.cluster.masterClient.AddNode(m.leaderInfo.addr)
 		m.cluster.masterClient.SetLeader(m.leaderInfo.addr)
 		WarnMetrics.reset()

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -1346,6 +1346,8 @@ func (c *Cluster) loadDataPartitions() (err error) {
 		}
 
 		dp := dpv.Restore(c)
+		// TODO need to refactor
+		dp.setReadWrite()
 		vol.dataPartitions.put(dp)
 		c.addBadDataParitionIdMap(dp)
 		//add to nodeset decommission list

--- a/master/vol.go
+++ b/master/vol.go
@@ -361,9 +361,10 @@ func (vol *Vol) checkDataPartitions(c *Cluster) (cnt int) {
 		dp.checkMissingReplicas(c.Name, c.leaderInfo.addr, c.cfg.MissingDataPartitionInterval, c.cfg.IntervalToAlarmMissingDataPartition)
 		dp.checkReplicaNum(c, vol)
 
-		if time.Since(time.Unix(vol.createTime, 0).Add(time.Second*defaultIntervalToCheckHeartbeat*3)) < 0 {
+		if time.Now().Unix()-vol.createTime < defaultIntervalToCheckHeartbeat*3 {
 			dp.setReadWrite()
 		}
+
 		if dp.Status == proto.ReadWrite {
 			cnt++
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

1. set dp status readwrite
2. not update datapartition cache before load meta from disk ready.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
