### PR TITLE
[Feature]: DataNode receiving processing supports speed limit

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -282,19 +282,7 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 		return fmt.Errorf("Err:port must string")
 	}
 	s.port = port
-
-	/*for _, ip := range cfg.GetSlice(proto.MasterAddr) {
-		MasterClient.AddNode(ip.(string))
-	}*/
-
-	updateInterval := cfg.GetInt(configNameResolveInterval)
-	if updateInterval <= 0 || updateInterval > 60 {
-		log.LogWarnf("name resolving interval[1-60] is set to default: %v", DefaultNameResolveInterval)
-		updateInterval = DefaultNameResolveInterval
-	}
-
-	addrs := cfg.GetSlice(proto.MasterAddr)
-	if len(addrs) == 0 {
+	if len(cfg.GetSlice(proto.MasterAddr)) == 0 {
 		return fmt.Errorf("Err:masterAddr unavalid")
 	}
 	for _, ip := range cfg.GetSlice(proto.MasterAddr) {

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -77,7 +77,7 @@ func isColdVolExtentDelErr(p *repl.Packet) bool {
 	return false
 }
 
-func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn, limiter *repl.RecvLimiter) (err error) {
+func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn) (err error) {
 	var (
 		tpLabels map[string]string
 		tpObject *exporter.TimePointCount

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -77,7 +77,7 @@ func isColdVolExtentDelErr(p *repl.Packet) bool {
 	return false
 }
 
-func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn) (err error) {
+func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn, limiter *repl.RecvLimiter) (err error) {
 	var (
 		tpLabels map[string]string
 		tpObject *exporter.TimePointCount

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -1,0 +1,157 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl
+
+import (
+	"sync"
+	"time"
+)
+
+type OperatorStats struct {
+	lock               sync.RWMutex
+	flowEnqueCounter   uint64
+	flowDequeCounter   uint64
+	packetEnqueCounter uint64
+	packetDequeCounter uint64
+	waitTime           time.Duration
+	firstEnqueTime     time.Time
+	lastDequeTime      time.Time
+}
+
+type OperatorStatsSnapshot struct {
+	FlowEnqueCounter   uint64
+	FlowDequeCounter   uint64
+	PacketEnqueCounter uint64
+	PacketDequeCounter uint64
+	WaitTime           time.Duration
+	SnapshotTime       time.Time
+}
+
+type OperatorStatsSample struct {
+	first         OperatorStatsSnapshot
+	second        OperatorStatsSnapshot
+	queueLength   int
+	queueCapacity int
+}
+
+func (s *OperatorStats) OnEnque(flow uint64) {
+	now := time.Now()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.flowEnqueCounter += flow
+	s.packetEnqueCounter += 1
+	var zeroTime time.Time
+	if s.firstEnqueTime == zeroTime {
+		s.firstEnqueTime = now
+	}
+}
+
+func (s *OperatorStats) OnDeque(flow uint64, last bool) {
+	now := time.Now()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.flowDequeCounter += flow
+	s.packetDequeCounter += 1
+	if last {
+		var zeroTime time.Time
+		// if s.firstEnqueTime equal with zero or before s.lastDequeTime
+		// it means that OnDeque acquire the lock before OnEnque
+		// we doesn't need to record the wait time, because the duration is too short
+		if s.firstEnqueTime != zeroTime && s.firstEnqueTime.After(s.lastDequeTime) {
+			duration := now.Sub(s.firstEnqueTime)
+			s.waitTime += duration
+		}
+		s.lastDequeTime = now
+	}
+}
+
+func (s *OperatorStats) GetSnapshot() *OperatorStatsSnapshot {
+	now := time.Now()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	waitTime := s.waitTime
+	var zeroTime time.Time
+	if s.firstEnqueTime != zeroTime && (s.lastDequeTime == zeroTime || s.firstEnqueTime.After(s.lastDequeTime)) {
+		duration := now.Sub(s.firstEnqueTime)
+		waitTime += duration
+	}
+	snapshot := &OperatorStatsSnapshot{
+		FlowEnqueCounter:   s.flowDequeCounter,
+		FlowDequeCounter:   s.flowDequeCounter,
+		PacketEnqueCounter: s.packetEnqueCounter,
+		PacketDequeCounter: s.packetDequeCounter,
+		WaitTime:           waitTime,
+		SnapshotTime:       now,
+	}
+	return snapshot
+}
+
+func (s *OperatorStats) Sample(sampleDuration time.Duration, queue chan *Packet) *OperatorStatsSample {
+	first := s.GetSnapshot()
+	time.Sleep(sampleDuration)
+	second := s.GetSnapshot()
+	return &OperatorStatsSample{
+		first:         *first,
+		second:        *second,
+		queueLength:   len(queue),
+		queueCapacity: cap(queue),
+	}
+}
+
+func (s *OperatorStatsSample) GetEnqueFlow() uint64 {
+	return s.second.FlowEnqueCounter - s.first.FlowEnqueCounter
+}
+
+func (s *OperatorStatsSample) GetDequeFlow() uint64 {
+	return s.second.FlowDequeCounter - s.first.FlowDequeCounter
+}
+
+func (s *OperatorStatsSample) GetWaitFlow() uint64 {
+	return s.second.FlowEnqueCounter - s.second.FlowDequeCounter
+}
+
+func (s *OperatorStatsSample) GetEnquePacket() uint64 {
+	return s.second.PacketEnqueCounter - s.first.PacketEnqueCounter
+}
+
+func (s *OperatorStatsSample) GetDequePacket() uint64 {
+	return s.second.PacketDequeCounter - s.first.PacketDequeCounter
+}
+
+func (s *OperatorStatsSample) GetWaitPacket() uint64 {
+	return s.second.FlowEnqueCounter - s.second.FlowDequeCounter
+}
+
+func (s *OperatorStatsSample) GetSampleDuration() time.Duration {
+	return s.second.SnapshotTime.Sub(s.first.SnapshotTime)
+}
+
+func (s *OperatorStatsSample) GetWaitTime() time.Duration {
+	return s.second.WaitTime - s.first.WaitTime
+}
+
+func (s *OperatorStatsSample) GetUtil() float64 {
+	sampleDuration := s.GetSampleDuration()
+	waitTime := s.GetWaitTime()
+	return float64(waitTime.Milliseconds()) / float64(sampleDuration.Milliseconds())
+}
+
+func (s *OperatorStatsSample) GetQueueLength() int {
+	return s.queueLength
+}
+
+func (s *OperatorStatsSample) GetQueueCapacity() int {
+	return s.queueCapacity
+}

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -178,10 +178,10 @@ func (s *OperatorStatsSample) GetDropFlow() uint64 {
 }
 
 func (s *OperatorStatsSample) GetDropPacketRate() float64 {
-	if s.GetDequePacket() == 0 {
+	if s.GetDropPacket() == 0 {
 		return 0
 	}
-	return float64(s.GetDequePacket()) / float64(s.GetDequePacket()+s.GetEnquePacket())
+	return float64(s.GetDropPacket()) / float64(s.GetDropPacket()+s.GetEnquePacket())
 }
 
 func (s *OperatorStatsSample) GetDropFlowRate() float64 {

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -178,9 +178,15 @@ func (s *OperatorStatsSample) GetDropFlow() uint64 {
 }
 
 func (s *OperatorStatsSample) GetDropPacketPercent() float64 {
+	if s.GetDequePacket() == 0 {
+		return 0
+	}
 	return float64(s.GetDequePacket()) / float64(s.GetDequePacket()+s.GetEnquePacket())
 }
 
 func (s *OperatorStatsSample) GetDropFlowPercent() float64 {
+	if s.GetDequeFlow() == 0 {
+		return 0
+	}
 	return float64(s.GetDropFlow()) / float64(s.GetDropFlow()+s.GetEnqueFlow())
 }

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -57,7 +57,7 @@ func (s *OperatorStats) OnEnque(flow uint64) {
 	s.flowEnqueCounter += flow
 	s.packetEnqueCounter += 1
 	var zeroTime time.Time
-	if s.firstEnqueTime == zeroTime {
+	if s.firstEnqueTime == zeroTime || (s.lastDequeTime != zeroTime && s.lastDequeTime.After(zeroTime)) {
 		s.firstEnqueTime = now
 	}
 }
@@ -99,7 +99,7 @@ func (s *OperatorStats) GetSnapshot() *OperatorStatsSnapshot {
 		waitTime += duration
 	}
 	snapshot := &OperatorStatsSnapshot{
-		FlowEnqueCounter:   s.flowDequeCounter,
+		FlowEnqueCounter:   s.flowEnqueCounter,
 		FlowDequeCounter:   s.flowDequeCounter,
 		FlowDropCounter:    s.flowDropCounter,
 		PacketEnqueCounter: s.packetEnqueCounter,
@@ -177,14 +177,14 @@ func (s *OperatorStatsSample) GetDropFlow() uint64 {
 	return s.second.FlowDropCounter - s.first.FlowDropCounter
 }
 
-func (s *OperatorStatsSample) GetDropPacketPercent() float64 {
+func (s *OperatorStatsSample) GetDropPacketRate() float64 {
 	if s.GetDequePacket() == 0 {
 		return 0
 	}
 	return float64(s.GetDequePacket()) / float64(s.GetDequePacket()+s.GetEnquePacket())
 }
 
-func (s *OperatorStatsSample) GetDropFlowPercent() float64 {
+func (s *OperatorStatsSample) GetDropFlowRate() float64 {
 	if s.GetDequeFlow() == 0 {
 		return 0
 	}

--- a/repl/operator_stats_test.go
+++ b/repl/operator_stats_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cubefs/cubefs/repl"
+)
+
+func TestOperatorSampleTest(t *testing.T) {
+	var stats repl.OperatorStats
+	processCh := make(chan *repl.Packet, 2048)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Wait()
+		stats.OnEnque(100)
+		time.Sleep(1 * time.Second)
+		stats.OnDeque(100, true)
+	}()
+	wg.Done()
+	sample := stats.Sample(2*time.Second, processCh)
+	t.Logf("Enque Flow:\t%v", sample.GetEnqueFlow())
+	t.Logf("Deque Flow:\t%v", sample.GetDequeFlow())
+	t.Logf("Enque Packet:\t%v", sample.GetEnquePacket())
+	t.Logf("Deque Packet:\t%v", sample.GetDequePacket())
+	t.Logf("Wait Flow:\t%v", sample.GetWaitFlow())
+	t.Logf("Wait Packet:\t%v", sample.GetWaitPacket())
+	t.Logf("Wait Time:\t%v", sample.GetWaitTime())
+	t.Logf("Sample Duration:\t%v", sample.GetSampleDuration())
+	t.Logf("Util:\t%.1f", sample.GetUtil()*100)
+	if sample.GetQueueCapacity() != 2048 {
+		t.Errorf("queue capacity should equal with 0, but get %v", sample.GetQueueCapacity())
+	}
+	if sample.GetQueueLength() != 0 {
+		t.Errorf("queue length should equal with 0, but get %v", sample.GetQueueLength())
+	}
+	if sample.GetEnqueFlow() != 100 {
+		t.Errorf("enque flow should equal with 100, but get %v", sample.GetEnqueFlow())
+	}
+	if sample.GetDequeFlow() != 100 {
+		t.Errorf("deque flow should equal with 100, but get %v", sample.GetDequeFlow())
+	}
+	if sample.GetEnquePacket() != 1 {
+		t.Errorf("enque packet should equal with 1, but get %v", sample.GetEnquePacket())
+	}
+	if sample.GetDequePacket() != 1 {
+		t.Errorf("deque packet should equal with 1, but get %v", sample.GetDequePacket())
+	}
+	if sample.GetUtil() > 0.5 {
+		t.Errorf("util should less than or equal with 0.5, but get %v", sample.GetUtil())
+	}
+}

--- a/repl/operator_stats_test.go
+++ b/repl/operator_stats_test.go
@@ -48,8 +48,8 @@ func TestOperatorSampleTest(t *testing.T) {
 	t.Logf("Util:\t%.1f", sample.GetUtil()*100)
 	t.Logf("Drop Packet:\t%v", sample.GetDequePacket())
 	t.Logf("Drop Flow:\t%v", sample.GetDropFlow())
-	t.Logf("Drop Packet Percent:\t%.1f", sample.GetDropPacketPercent()*100)
-	t.Logf("Drop Flow Percent:\t%.1f", sample.GetDropFlowPercent()*100)
+	t.Logf("Drop Packet Percent:\t%.1f", sample.GetDropPacketRate()*100)
+	t.Logf("Drop Flow Percent:\t%.1f", sample.GetDropFlowRate()*100)
 	if sample.GetQueueCapacity() != 2048 {
 		t.Errorf("queue capacity should equal with 0, but get %v", sample.GetQueueCapacity())
 	}

--- a/repl/operator_stats_test.go
+++ b/repl/operator_stats_test.go
@@ -15,6 +15,7 @@
 package repl_test
 
 import (
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ func TestOperatorSampleTest(t *testing.T) {
 	go func() {
 		wg.Wait()
 		stats.OnEnque(100)
+		stats.OnDrop(50)
 		time.Sleep(1 * time.Second)
 		stats.OnDeque(100, true)
 	}()
@@ -44,6 +46,10 @@ func TestOperatorSampleTest(t *testing.T) {
 	t.Logf("Wait Time:\t%v", sample.GetWaitTime())
 	t.Logf("Sample Duration:\t%v", sample.GetSampleDuration())
 	t.Logf("Util:\t%.1f", sample.GetUtil()*100)
+	t.Logf("Drop Packet:\t%v", sample.GetDequePacket())
+	t.Logf("Drop Flow:\t%v", sample.GetDropFlow())
+	t.Logf("Drop Packet Percent:\t%.1f", sample.GetDropPacketPercent()*100)
+	t.Logf("Drop Flow Percent:\t%.1f", sample.GetDropFlowPercent()*100)
 	if sample.GetQueueCapacity() != 2048 {
 		t.Errorf("queue capacity should equal with 0, but get %v", sample.GetQueueCapacity())
 	}
@@ -62,7 +68,13 @@ func TestOperatorSampleTest(t *testing.T) {
 	if sample.GetDequePacket() != 1 {
 		t.Errorf("deque packet should equal with 1, but get %v", sample.GetDequePacket())
 	}
-	if sample.GetUtil() > 0.5 {
-		t.Errorf("util should less than or equal with 0.5, but get %v", sample.GetUtil())
+	if math.Abs(sample.GetUtil()-0.5) > 0.01 {
+		t.Errorf("util should equal with 0.5, but get %v", sample.GetUtil())
+	}
+	if sample.GetDropPacket() != 1 {
+		t.Errorf("drop packet should equal with 1, but get %v", sample.GetDropPacket())
+	}
+	if sample.GetDropFlow() != 50 {
+		t.Errorf("drop flow should equal with 50, but get %v", sample.GetDropFlow())
 	}
 }

--- a/repl/recv_limiter.go
+++ b/repl/recv_limiter.go
@@ -21,9 +21,9 @@ type RecvLimiter struct {
 	packet *rate.Limiter
 }
 
-func NewRecvLimiter(recvLimiter *rate.Limiter, packetLimiter *rate.Limiter) *RecvLimiter {
+func NewRecvLimiter(flowLimiter *rate.Limiter, packetLimiter *rate.Limiter) *RecvLimiter {
 	return &RecvLimiter{
-		flow:   recvLimiter,
+		flow:   flowLimiter,
 		packet: packetLimiter,
 	}
 }

--- a/repl/recv_limiter.go
+++ b/repl/recv_limiter.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl
+
+import "golang.org/x/time/rate"
+
+type RecvLimiter struct {
+	flow   *rate.Limiter
+	packet *rate.Limiter
+}
+
+func NewRecvLimiter(recvLimiter *rate.Limiter, packetLimiter *rate.Limiter) *RecvLimiter {
+	return &RecvLimiter{
+		flow:   recvLimiter,
+		packet: packetLimiter,
+	}
+}
+
+func (l *RecvLimiter) Packet() *rate.Limiter {
+	return l.packet
+}
+
+func (l *RecvLimiter) Flow() *rate.Limiter {
+	return l.flow
+}

--- a/repl/recv_limiter_test.go
+++ b/repl/recv_limiter_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl_test
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/repl"
+	"golang.org/x/time/rate"
+)
+
+const (
+	flow   = 0
+	packet = iota
+)
+
+func LimiterTest(t *testing.T, recv *repl.RecvLimiter, internal *rate.Limiter, mode int) {
+	limiter := recv.Flow()
+	if mode != flow {
+		limiter = recv.Packet()
+	}
+	internal.SetLimit(1)
+	if limiter.Limit() != 1 {
+		t.Errorf("limiter should equal with 1")
+	}
+	internal.SetBurst(1)
+	if limiter.Burst() != 1 {
+		t.Errorf("burst should equal with 1")
+	}
+	if !limiter.Allow() {
+		t.Errorf("limiter should allow 1")
+	}
+	if limiter.Allow() {
+		t.Errorf("limiter should not allow")
+	}
+}
+
+func TestRecvLimiter(t *testing.T) {
+	flowLimiter := rate.NewLimiter(10, 10)
+	packetLimiter := rate.NewLimiter(10, 10)
+	recvLimiter := repl.NewRecvLimiter(flowLimiter, packetLimiter)
+	if recvLimiter.Flow() != flowLimiter {
+		t.Errorf("flow limiter should equal with %v", flowLimiter)
+	}
+	if recvLimiter.Packet() != packetLimiter {
+		t.Errorf("packer limiter should equal witg %v", packetLimiter)
+	}
+	LimiterTest(t, recvLimiter, flowLimiter, flow)
+	LimiterTest(t, recvLimiter, packetLimiter, packet)
+}

--- a/repl/repl_protocol.go
+++ b/repl/repl_protocol.go
@@ -584,6 +584,9 @@ func (rp *ReplProtocol) cleanResource() {
 	rp.packetList = nil
 	rp.followerConnects = nil
 	rp.packetListLock.Unlock()
+	if rp.sampleDone != nil {
+		close(rp.sampleDone)
+	}
 }
 
 func (rp *ReplProtocol) deletePacket(reply *Packet, e *list.Element) (success bool) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Add speed limit to receiving processing.
* Support to adjust speed limit.
* Add operation phase statistics to help adjust limit.
* Add peer connection operation phase statistics sampler(`sampleDuration` is `1*time.Second` by default).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

fixes #1906

**Special notes for your reviewer**:

These  operation phase statistics include:
* `EnqueFlow`: The number of bytes enqueued.
* `DequeFlow`: The number of bytes dequeued.
* `DropFlow`: The number of bytes discarded because the queue was full.
* `EnquePacket`: The number of packets enqueued.
* `DequePacket`: The number of packets dequeued.
* `DropPacket`: The number of packets discarded because the queue was full.
* `WaitTime`: How long the queue was not empty during the sampling duration.
* `Util`: Operator utilization rate(`WaitTime/SampleDuration`).
* `DropPacketRate`: The proportion of dropped packets to all packets.
* `DropFlowRate`: The proportion of dropped bytes to all bytes.

Due to my inexperience, I didn't finish setting up the limit adjust strategy, current policy as follows(it only works as a log):
```go
func (s *DataNode) recvLimiterAdjust(limiter *repl.RecvLimiter, sample *repl.OperatorStatsSample) {
	builder := strings.Builder{}
	builder.WriteString(fmt.Sprintf("Operator Util:\t%.2f\n", sample.GetUtil()*100))
	builder.WriteString(fmt.Sprintf("Operator Drop Packet Percent:\t%.2f\n", sample.GetDropPacketRate()*100))
	builder.WriteString(fmt.Sprintf("Operator Queue Length:\t%v\n", sample.GetQueueLength()))
	builder.WriteString(fmt.Sprintf("Operator Queue Capacity:\t%v\n", sample.GetQueueCapacity()))
	builder.WriteString(fmt.Sprintf("Operator Sample Duration:\t%v\n", sample.GetSampleDuration()))
	builder.WriteString(fmt.Sprintf("Operator Wait Time:\t%v\n", sample.GetWaitTime()))
	builder.WriteString(fmt.Sprintf("Operator Enque Packet:\t%v\n", sample.GetEnquePacket()))
	builder.WriteString(fmt.Sprintf("Operator Deque Packet:\t%v\n", sample.GetDequePacket()))
	builder.WriteString(fmt.Sprintf("Operator Enque Flow:\t%v\n", sample.GetEnqueFlow()))
	builder.WriteString(fmt.Sprintf("Operator Deque Flow:\t%v\n", sample.GetDequeFlow()))
	log.LogInfof(builder.String())
	// adjust receive limiter in here
}
```

On my computer it produces these worthwhile logs.

Datanode 1:
```log
...
2023/06/29 08:09:00.230690 [INFO ] server.go:626: Operator Util:	19.20
Operator Drop Packet Percent:	0.00
Operator Queue Length:	0
Operator Queue Capacity:	2048
Operator Sample Duration:	1.000120115s
Operator Wait Time:	192.321455ms
Operator Enque Packet:	857
Operator Deque Packet:	857
Operator Enque Flow:	112361270
Operator Deque Flow:	0
```

The logs of datanode 2, datanode 3 and datanode 4 are omitted.

Full logs can be found in [here](https://github.com/NaturalSelect/logs/tree/main/dataNode-recv)

Please contract me if the pull request passed review, and I will rebase and rearrange commint points .

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
