### PR TITLE
bugfix(client):serverRequest always return no vailed master if http s…

### DIFF
--- a/sdk/master/client.go
+++ b/sdk/master/client.go
@@ -181,12 +181,12 @@ func (c *MasterClient) serveRequest(r *request) (repsData []byte, err error) {
 			}
 			return []byte(body.Data), nil
 		default:
+			err = errors.New(fmt.Sprintf("err(%v)", strings.Replace(string(repsData), "\n", "", -1)))
 			log.LogErrorf("serveRequest: unknown status: host(%v) uri(%v) status(%v) body(%s).",
 				resp.Request.URL.String(), host, stateCode, strings.Replace(string(repsData), "\n", "", -1))
 			continue
 		}
 	}
-	err = ErrNoValidMaster
 	return
 }
 


### PR DESCRIPTION
…tatus code is not 403 or 200
**What this PR does / why we need it**:
function serverRequest of master client sdk always return no vailed master if http status code is not 403 or 200