### PR TITLE
feat(metanode):  meta partition raft leader send snapshot includes txInfo, txRbInode, txRbDentry only when snapshot format version is v1

### DIFF
--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -302,27 +302,27 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 			return
 		}
 
-		iter.txTree.Ascend(func(i BtreeItem) bool {
-			return produceItem(i)
-		})
+		if si.SnapFormatVersion == SnapFormatVersion_1 {
+			iter.txTree.Ascend(func(i BtreeItem) bool {
+				return produceItem(i)
+			})
+			if checkClose() {
+				return
+			}
 
-		if checkClose() {
-			return
-		}
+			iter.txRbInodeTree.Ascend(func(i BtreeItem) bool {
+				return produceItem(i)
+			})
+			if checkClose() {
+				return
+			}
 
-		iter.txRbInodeTree.Ascend(func(i BtreeItem) bool {
-			return produceItem(i)
-		})
-
-		if checkClose() {
-			return
-		}
-
-		iter.txRbDentryTree.Ascend(func(i BtreeItem) bool {
-			return produceItem(i)
-		})
-		if checkClose() {
-			return
+			iter.txRbDentryTree.Ascend(func(i BtreeItem) bool {
+				return produceItem(i)
+			})
+			if checkClose() {
+				return
+			}
 		}
 
 		// process extent del files


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 optimization: meta partition raft leader send snapshot includes txInfo, txRbInode, txRbDentry only when snapshot format version is v1.


 




