### PR TITLE
refactor(meta): add concurrency cnt limit when process transaction

### DIFF
--- a/proto/transaction.go
+++ b/proto/transaction.go
@@ -494,7 +494,7 @@ type TransactionInfo struct {
 	CreateTime int64 //time.Now().UnixNano()
 	Timeout    int64 //minutes
 	State      int32
-	DoneTime   int64 //time.Now().UnixNano()
+	DoneTime   int64 //time.Now()
 	//ItemMap    map[string]TxItemInfo
 	TxInodeInfos  map[uint64]*TxInodeInfo
 	TxDentryInfos map[string]*TxDentryInfo


### PR DESCRIPTION
Signed-off-by: Victor1319 <834863182@qq.com>

add concurrency cnt limit when process transaction
Closes #2205

<!-- Thanks for sending a pull request! -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
