### PR TITLE
feat(master, client): optimize data partition status management:

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -232,7 +232,8 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		OnCacheBcache:     s.bc.Put,
 		OnEvictBcache:     s.bc.Evict,
 
-		DisableMetaCache: DisableMetaCache,
+		DisableMetaCache:             DisableMetaCache,
+		MinWriteAbleDataPartitionCnt: opt.MinWriteAbleDataPartitionCnt,
 	}
 
 	s.ec, err = stream.NewExtentClient(extentConfig)

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -759,6 +759,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.MetaSendTimeout = GlobalMountOptions[proto.MetaSendTimeout].GetInt64()
 	opt.MaxStreamerLimit = GlobalMountOptions[proto.MaxStreamerLimit].GetInt64()
 	opt.EnableAudit = GlobalMountOptions[proto.EnableAudit].GetBool()
+	opt.MinWriteAbleDataPartitionCnt = int(GlobalMountOptions[proto.MinWriteAbleDataPartitionCnt].GetInt64())
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -1350,8 +1350,6 @@ func (c *Cluster) loadDataPartitions() (err error) {
 		}
 
 		dp := dpv.Restore(c)
-		// TODO need to refactor
-		dp.setReadWrite()
 		vol.dataPartitions.put(dp)
 		c.addBadDataParitionIdMap(dp)
 		//add to nodeset decommission list

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -68,6 +68,7 @@ const (
 
 	EnableAudit
 	LocallyProf
+	MinWriteAbleDataPartitionCnt
 	MaxMountOption
 )
 
@@ -152,6 +153,9 @@ func InitMountOptions(opts []MountOption) {
 	opts[BcacheBatchCnt] = MountOption{"bcacheBatchCnt", "The block cache get meta count", "", int64(100000)}
 	opts[BcacheCheckIntervalS] = MountOption{"bcacheCheckIntervalS", "The block cache check interval", "", int64(300)}
 	opts[EnableAudit] = MountOption{"enableAudit", "enable client audit logging", "", false}
+	opts[MinWriteAbleDataPartitionCnt] = MountOption{"minWriteAbleDataPartitionCnt",
+		"Min writeable data partition count retained int dpSelector when update DataPartitionsView from master",
+		"", int64(10)}
 
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
@@ -177,8 +181,8 @@ func ParseMountOptions(opts []MountOption, cfg *config.Config) {
 			if opts[i].cmdlineValue != "" {
 				opts[i].value = parseInt64(opts[i].cmdlineValue)
 			} else {
-				if value, present := cfg.CheckAndGetString(opts[i].keyword); present {
-					opts[i].value = parseInt64(value)
+				if present := cfg.HasKey(opts[i].keyword); present {
+					opts[i].value = cfg.GetInt64(opts[i].keyword)
 				} else {
 					opts[i].value = v
 				}
@@ -249,61 +253,62 @@ func (opt *MountOption) GetInt64() int64 {
 }
 
 type MountOptions struct {
-	Config                  *config.Config
-	MountPoint              string
-	Volname                 string
-	Owner                   string
-	Master                  string
-	Logpath                 string
-	Loglvl                  string
-	Profport                string
-	LocallyProf             bool
-	IcacheTimeout           int64
-	LookupValid             int64
-	AttrValid               int64
-	ReadRate                int64
-	WriteRate               int64
-	EnSyncWrite             int64
-	AutoInvalData           int64
-	UmpDatadir              string
-	Rdonly                  bool
-	WriteCache              bool
-	KeepCache               bool
-	FollowerRead            bool
-	Authenticate            bool
-	TicketMess              auth.TicketMess
-	TokenKey                string
-	AccessKey               string
-	SecretKey               string
-	DisableDcache           bool
-	SubDir                  string
-	FsyncOnClose            bool
-	MaxCPUs                 int64
-	EnableXattr             bool
-	NearRead                bool
-	EnablePosixACL          bool
-	EnableTransaction       string
-	TxTimeout               int64
-	TxConflictRetryNum      int64
-	TxConflictRetryInterval int64
-	VolType                 int
-	EbsEndpoint             string
-	EbsServicePath          string
-	CacheAction             int
-	CacheThreshold          int
-	EbsBlockSize            int
-	EnableBcache            bool
-	BcacheDir               string
-	BcacheFilterFiles       string
-	BcacheCheckIntervalS    int64
-	BcacheBatchCnt          int64
-	ReadThreads             int64
-	WriteThreads            int64
-	EnableSummary           bool
-	EnableUnixPermission    bool
-	NeedRestoreFuse         bool
-	MetaSendTimeout         int64
-	BuffersTotalLimit       int64
-	MaxStreamerLimit        int64
-	EnableAudit             bool
+	Config                       *config.Config
+	MountPoint                   string
+	Volname                      string
+	Owner                        string
+	Master                       string
+	Logpath                      string
+	Loglvl                       string
+	Profport                     string
+	LocallyProf                  bool
+	IcacheTimeout                int64
+	LookupValid                  int64
+	AttrValid                    int64
+	ReadRate                     int64
+	WriteRate                    int64
+	EnSyncWrite                  int64
+	AutoInvalData                int64
+	UmpDatadir                   string
+	Rdonly                       bool
+	WriteCache                   bool
+	KeepCache                    bool
+	FollowerRead                 bool
+	Authenticate                 bool
+	TicketMess                   auth.TicketMess
+	TokenKey                     string
+	AccessKey                    string
+	SecretKey                    string
+	DisableDcache                bool
+	SubDir                       string
+	FsyncOnClose                 bool
+	MaxCPUs                      int64
+	EnableXattr                  bool
+	NearRead                     bool
+	EnablePosixACL               bool
+	EnableTransaction            string
+	TxTimeout                    int64
+	TxConflictRetryNum           int64
+	TxConflictRetryInterval      int64
+	VolType                      int
+	EbsEndpoint                  string
+	EbsServicePath               string
+	CacheAction                  int
+	CacheThreshold               int
+	EbsBlockSize                 int
+	EnableBcache                 bool
+	BcacheDir                    string
+	BcacheFilterFiles            string
+	BcacheCheckIntervalS         int64
+	BcacheBatchCnt               int64
+	ReadThreads                  int64
+	WriteThreads                 int64
+	EnableSummary                bool
+	EnableUnixPermission         bool
+	NeedRestoreFuse              bool
+	MetaSendTimeout              int64
+	BuffersTotalLimit            int64
+	MaxStreamerLimit             int64
+	EnableAudit                  bool
+	MinWriteAbleDataPartitionCnt int
 }

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -113,7 +113,8 @@ type ExtentConfig struct {
 	OnCacheBcache     CacheBcacheFunc
 	OnEvictBcache     EvictBacheFunc
 
-	DisableMetaCache bool
+	DisableMetaCache             bool
+	MinWriteAbleDataPartitionCnt int
 }
 
 // ExtentClient defines the struct of the extent client.
@@ -224,7 +225,9 @@ func NewExtentClient(config *ExtentConfig) (client *ExtentClient, err error) {
 	client.LimitManager.WrapperUpdate = client.UploadFlowInfo
 	limit := 0
 retry:
-	client.dataWrapper, err = wrapper.NewDataPartitionWrapper(client, config.Volume, config.Masters, config.Preload)
+
+	client.dataWrapper, err = wrapper.NewDataPartitionWrapper(client, config.Volume, config.Masters, config.Preload,
+		config.MinWriteAbleDataPartitionCnt)
 	if err != nil {
 		log.LogErrorf("NewExtentClient: new data partition wrapper failed: volume(%v) mayRetry(%v) err(%v)",
 			config.Volume, limit, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
(1) on master: NOT set all data partitions's status to ReadWrite when becaming a leader;
(2) on client: when periodically update data partition view in the background, revert the condition of whether to refresh dpSelector as "writable dp count should >= minWriteAbleDataPartitionCnt"; and the param minWriteAbleDataPartitionCnt is changed to configurable now, and the config should be updated accordingly.


