### PR TITLE
Develop 3.3.0

### DIFF
--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -844,7 +844,17 @@ func (mp *metaPartition) LoadSnapshot(snapshotPath string) (err error) {
 		loadFunc := f
 		i := idx
 		go func() {
-			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.LogWarnf("action[LoadSnapshot] recovered when load partition partition: %v, failed: %v",
+						mp.config.PartitionId, r)
+
+					errs[i] = errors.NewErrorf("%v", r)
+				}
+
+				wg.Done()
+			}()
+
 			if i == 2 { //loadExtend must be executed after loadInode
 				return
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
while meta node loading all the meta partitions, the program will abort if panic cccurs when loading any one all the partitions.
but we hope that meta node not to abort in such failure, it can just skip  partitions which failed to load and continue to load and serve other partitions.

