### PR TITLE
fix: dentry fsm create between inodeTree clone and deteyTree clone le…

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -243,7 +243,6 @@ run_test() {
     pushd $SrcPath >/dev/null
     echo -n "${TPATH}"
 #    go test $MODFLAGS -ldflags "${LDFlags}" -cover ./master
-
     go test -cover -v -coverprofile=cover.output $(go list ./... | grep -v depends | grep -v master) | tee cubefs_unittest.output
     ret=$?
     popd >/dev/null

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -456,6 +456,7 @@ type metaPartition struct {
 	uidManager             *UidManager
 	xattrLock              sync.Mutex
 	mqMgr                  *MetaQuotaManager
+	nonIdempotent          sync.RWMutex
 }
 
 func (mp *metaPartition) acucumRebuildStart() {

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -94,6 +94,9 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 			return
 		}
 	}
+
+	mp.nonIdempotent.RLock()
+	defer mp.nonIdempotent.RUnlock()
 	if item, ok := mp.dentryTree.ReplaceOrInsert(dentry, false); !ok {
 		//do not allow directories and files to overwrite each
 		// other when renaming

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -188,6 +188,7 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 	si.txId = mp.txProcessor.txManager.txIdAlloc.getTransactionID()
 	si.cursor = mp.GetCursor()
 
+	mp.nonIdempotent.Lock()
 	si.inodeTree = mp.inodeTree.GetTree()
 	si.dentryTree = mp.dentryTree.GetTree()
 	si.extendTree = mp.extendTree.GetTree()
@@ -195,6 +196,7 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 	si.txTree = mp.txProcessor.txManager.txTree.GetTree()
 	si.txRbInodeTree = mp.txProcessor.txResource.txRbInodeTree.GetTree()
 	si.txRbDentryTree = mp.txProcessor.txResource.txRbDentryTree.GetTree()
+	mp.nonIdempotent.Unlock()
 
 	si.dataCh = make(chan interface{})
 	si.errorCh = make(chan error, 1)


### PR DESCRIPTION
…ad to inconstent of link of parentInode

close:#1580. use lock to protect dentry create and snapshot clone parrellel

issue happend while create a file, and do fsm operation and clone as the sequece : 1)inode create 2)inodeTree clone  3)fsmCreateDetnry 4)dentryTree lone, while restart, the 3)step will not work because the detry already the detreeTree, which make the parent miss the link addition,so we need make the detry create not happend between the tree clone

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
