### PR TITLE
fix(raft): when raft replicas or raft partitions are deleted, delete them from raft monitor accordingly

### DIFF
--- a/depends/tiglabs/raft/monitor.go
+++ b/depends/tiglabs/raft/monitor.go
@@ -11,4 +11,7 @@ type Monitor interface {
 	MonitorZombie(id uint64, peer proto.Peer, replicasMsg string, du time.Duration)
 	//If raft election failed continuously. MonitorElection will be called
 	MonitorElection(id uint64, replicaMsg string, du time.Duration)
+
+	RemovePeer(id uint64, peer proto.Peer)
+	RemovePartition(id uint64, peers []proto.Peer)
 }

--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -228,6 +228,10 @@ func (s *raft) runApply() {
 			switch cmd := apply.command.(type) {
 			case *proto.ConfChange:
 				resp, err = s.raftConfig.StateMachine.ApplyMemberChange(cmd, apply.index)
+				if cmd.Type == proto.ConfRemoveNode && err == nil {
+					s.raftFsm.mo.RemovePeer(s.raftFsm.id, cmd.Peer)
+				}
+
 			case []byte:
 				resp, err = s.raftConfig.StateMachine.Apply(cmd, apply.index)
 			}

--- a/depends/tiglabs/raft/raft_fsm.go
+++ b/depends/tiglabs/raft/raft_fsm.go
@@ -173,6 +173,12 @@ func (r *raftFsm) doRandomSeed() {
 }
 
 func (r *raftFsm) StopFsm() {
+	peers := make([]proto.Peer, len(r.replicas))
+	for _, r := range r.replicas {
+		peers = append(peers, r.peer)
+	}
+
+	r.mo.RemovePartition(r.id, peers)
 	close(r.stopCh)
 }
 


### PR DESCRIPTION
…them from raft monitor accordingly

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the bug: 
when raft replicas or raft partitions are deleted, them are still in raft monitor and the error log is still printing.

fix:
when raft replicas or raft partitions are deleted, delete them from raft monitor accordingly