### PR TITLE
feat: support listing nodesets and displaying space capacity

### DIFF
--- a/cli/cmd/datanode.go
+++ b/cli/cmd/datanode.go
@@ -71,7 +71,7 @@ func newDataNodeListCmd(client *master.MasterClient) *cobra.Command {
 				return view.DataNodes[i].ID < view.DataNodes[j].ID
 			})
 			stdout("[Data nodes]\n")
-			stdout("%v\n", formatNodeViewTableHeader())
+			stdout("%v\n", formatNodeViewTableHeaderForZone())
 			for _, node := range view.DataNodes {
 				if optFilterStatus != "" &&
 					!strings.Contains(formatNodeStatus(node.Status), optFilterStatus) {
@@ -81,7 +81,7 @@ func newDataNodeListCmd(client *master.MasterClient) *cobra.Command {
 					!strings.Contains(formatYesNo(node.IsWritable), optFilterWritable) {
 					continue
 				}
-				stdout("%v\n", formatNodeView(&node, true))
+				stdout("%v\n", formatNodeViewForZone(&node, true))
 			}
 		},
 	}

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -432,6 +432,11 @@ func formatDataPartitionInfo(partition *proto.DataPartitionInfo) string {
 		sb.WriteString(fmt.Sprintf("  [%v]", zone))
 	}
 	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("NodeSets :\n"))
+	for _, nodeSet := range partition.NodeSets {
+		sb.WriteString(fmt.Sprintf("  [%v]", nodeSet))
+	}
+	sb.WriteString("\n")
 	sb.WriteString("\n")
 	sb.WriteString(fmt.Sprintf("MissingNodes :\n"))
 	for partitionHost, id := range partition.MissingNodes {
@@ -474,6 +479,11 @@ func formatMetaPartitionInfo(partition *proto.MetaPartitionInfo) string {
 	sb.WriteString(fmt.Sprintf("Zones :\n"))
 	for _, zone := range partition.Zones {
 		sb.WriteString(fmt.Sprintf("  [%v]", zone))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("NodeSets :\n"))
+	for _, nodeSet := range partition.NodeSets {
+		sb.WriteString(fmt.Sprintf("  [%v]", nodeSet))
 	}
 	sb.WriteString("\n")
 	sb.WriteString("\n")

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -101,14 +101,15 @@ func formatNodeViewForZone(view *proto.NodeView, tableRow bool) string {
 	return sb.String()
 }
 
+var nodeViewTableRowPatternForNodeSet = "%-6v    %-65v    %-8v    %-8v    %-10v    %-10v    %-10v"
+
 func formatNodeViewTableHeaderForNodeSet() string {
-	return fmt.Sprintf("%-6v    %-65v    %-8v    %-8v    %-10v    %-10v    %-10v",
-		"ID", "ADDRESS", "WRITABLE", "STATUS", "TOTAL", "USED", "AVAIL")
+	return fmt.Sprintf(nodeViewTableRowPatternForNodeSet, "ID", "ADDRESS", "WRITABLE", "STATUS", "TOTAL", "USED", "AVAIL")
 }
 
 func formatNodeViewForNodeSet(view *proto.NodeStatView) string {
-	return fmt.Sprintf("%-6v    %-65v    %-8v    %-8v    %-10v    %-10v    %-10v",
-		view.ID, formatAddr(view.Addr, view.DomainAddr), formatYesNo(view.IsWritable), formatNodeStatus(view.Status),
+	return fmt.Sprintf(nodeViewTableRowPatternForNodeSet, view.ID, formatAddr(view.Addr, view.DomainAddr),
+		formatYesNo(view.IsWritable), formatNodeStatus(view.Status),
 		formatSize(view.Total),
 		formatSize(view.Used),
 		formatSize(view.Avail))
@@ -773,9 +774,9 @@ func formatMetaNodeDetail(mn *proto.MetaNodeInfo, rowTable bool) string {
 
 func formatNodeSetView(ns *proto.NodeSetStatInfo) string {
 	var sb = strings.Builder{}
-	sb.WriteString(fmt.Sprintf("NodeSet ID:   %v\n", ns.ID))
+	sb.WriteString(fmt.Sprintf("NodeSet ID:    %v\n", ns.ID))
 	sb.WriteString(fmt.Sprintf("Capacity:      %v\n", ns.Capacity))
-	sb.WriteString(fmt.Sprintf("Zone:     %v\n", ns.Zone))
+	sb.WriteString(fmt.Sprintf("Zone:          %v\n", ns.Zone))
 	var dataTotal, dataUsed, dataAvail, metaTotal, metaUsed, metaAvail uint64
 	for _, dn := range ns.DataNodes {
 		dataTotal += dn.Total

--- a/cli/cmd/metanode.go
+++ b/cli/cmd/metanode.go
@@ -72,7 +72,7 @@ func newMetaNodeListCmd(client *master.MasterClient) *cobra.Command {
 				return view.MetaNodes[i].ID < view.MetaNodes[j].ID
 			})
 			stdout("[Meta nodes]\n")
-			stdout("%v\n", formatNodeViewTableHeader())
+			stdout("%v\n", formatNodeViewTableHeaderForZone())
 			for _, node := range view.MetaNodes {
 				if optFilterStatus != "" &&
 					!strings.Contains(formatNodeStatus(node.Status), optFilterStatus) {
@@ -82,7 +82,7 @@ func newMetaNodeListCmd(client *master.MasterClient) *cobra.Command {
 					!strings.Contains(formatYesNo(node.IsWritable), optFilterWritable) {
 					continue
 				}
-				stdout("%v\n", formatNodeView(&node, true))
+				stdout("%v\n", formatNodeViewForZone(&node, true))
 			}
 		},
 	}

--- a/cli/cmd/nodeset.go
+++ b/cli/cmd/nodeset.go
@@ -76,7 +76,7 @@ func newNodeSetListCmd(client *sdk.MasterClient) *cobra.Command {
 
 func newNodeSetInfoCmd(client *sdk.MasterClient) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   CliOpGet,
+		Use:   CliOpInfo,
 		Short: cmdGetNodeSetShort,
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cli/cmd/nodeset.go
+++ b/cli/cmd/nodeset.go
@@ -1,0 +1,82 @@
+// Copyright 2018 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"github.com/cubefs/cubefs/proto"
+	sdk "github.com/cubefs/cubefs/sdk/master"
+	"github.com/cubefs/cubefs/util"
+	"github.com/spf13/cobra"
+)
+
+const (
+	cmdNodeSetUse   = "nodeset [COMMAND]"
+	cmdNodeSetShort = "Manage nodeset"
+)
+
+func newNodeSetCmd(client *sdk.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   cmdNodeSetUse,
+		Short: cmdNodeSetShort,
+		Args:  cobra.MinimumNArgs(0),
+	}
+	cmd.AddCommand(
+		newNodeSetListCmd(client),
+	)
+	return cmd
+}
+
+const (
+	cmdNodeSetListShort = "List cluster nodeSets"
+)
+
+func newNodeSetListCmd(client *sdk.MasterClient) *cobra.Command {
+	var zoneName string
+	var cmd = &cobra.Command{
+		Use:     CliOpList,
+		Short:   cmdNodeSetListShort,
+		Aliases: []string{"ls"},
+		Run: func(cmd *cobra.Command, args []string) {
+			var nodeSetStats []*proto.NodeSetStat
+			var err error
+			defer func() {
+				if err != nil {
+					errout("Error: %v\n", err)
+				}
+			}()
+			if nodeSetStats, err = client.AdminAPI().ListNodeSets(zoneName); err != nil {
+				return
+			}
+			zoneTablePattern := "%-4v %-4v %-10v %-8v %-8v %12v %12v %12v %12v %12v %12v\n"
+			stdout(zoneTablePattern, "ID", "Cap", "Zone", "MetaNum", "DataNum", "MetaTotal", "MetaUsed", "MetaAvail", "DataTotal", "DataUsed", "DataAvail")
+			zoneDataPattern := "%-4v %-4v %-10v %-8v %-8v %10.2fGB %10.2fGB %10.2fGB %10.2fGB %10.2fGB %10.2fGB\n"
+			for _, nodeSet := range nodeSetStats {
+				stdout(zoneDataPattern, nodeSet.ID, nodeSet.Capacity, nodeSet.Zone, nodeSet.MetaNodeNum, nodeSet.DataNodeNum,
+					float64(nodeSet.MetaTotal)/float64(util.GB),
+					float64(nodeSet.MetaUsed)/float64(util.GB),
+					float64(nodeSet.MetaAvail)/float64(util.GB),
+					float64(nodeSet.DataTotal)/float64(util.GB),
+					float64(nodeSet.DataUsed)/float64(util.GB),
+					float64(nodeSet.DataAvail)/float64(util.GB),
+				)
+			}
+			return
+		},
+	}
+
+	cmd.Flags().StringVar(&zoneName, CliFlagZoneName, "", "List nodeSets in the specified zone")
+
+	return cmd
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -73,6 +73,7 @@ func NewRootCmd(client *master.MasterClient) *CubeFSCmd {
 		newMetaPartitionCmd(client),
 		newConfigCmd(),
 		newZoneCmd(client),
+		newNodeSetCmd(client),
 		newAclCmd(client),
 		newUidCmd(client),
 		newQuotaCmd(client),

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -4331,10 +4331,12 @@ func (m *Server) getMetaPartition(w http.ResponseWriter, r *http.Request) {
 		defer mp.RUnlock()
 		var replicas = make([]*proto.MetaReplicaInfo, len(mp.Replicas))
 		zones := make([]string, len(mp.Hosts))
+		nodeSets := make([]uint64, len(mp.Hosts))
 		for idx, host := range mp.Hosts {
 			metaNode, err := m.cluster.metaNode(host)
 			if err == nil {
 				zones[idx] = metaNode.ZoneName
+				nodeSets[idx] = metaNode.NodeSetID
 			}
 		}
 		for i := 0; i < len(replicas); i++ {
@@ -4365,6 +4367,7 @@ func (m *Server) getMetaPartition(w http.ResponseWriter, r *http.Request) {
 			Hosts:         mp.Hosts,
 			Peers:         mp.Peers,
 			Zones:         zones,
+			NodeSets:      nodeSets,
 			MissNodes:     mp.MissNodes,
 			OfflinePeerID: mp.OfflinePeerID,
 			LoadResponse:  mp.LoadResponse,

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -1002,4 +1002,8 @@ func TestListNodeSets(t *testing.T) {
 	reqURL := fmt.Sprintf("%v%v", hostAddr, proto.GetAllNodeSets)
 	fmt.Println(reqURL)
 	process(reqURL, t)
+
+	reqURL = fmt.Sprintf("%v%v?zoneName=%v", hostAddr, proto.GetAllNodeSets, testZone2)
+	fmt.Println(reqURL)
+	process(reqURL, t)
 }

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -1007,3 +1007,9 @@ func TestListNodeSets(t *testing.T) {
 	fmt.Println(reqURL)
 	process(reqURL, t)
 }
+
+func TestGetNodeSets(t *testing.T) {
+	reqURL := fmt.Sprintf("%v%v?nodesetId=1", hostAddr, proto.GetNodeSet)
+	fmt.Println(reqURL)
+	process(reqURL, t)
+}

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -632,7 +632,7 @@ func TestDataPartitionDecommission(t *testing.T) {
 //	reqURL := fmt.Sprintf("%v%v", hostAddr, proto.GetALLVols)
 //	process(reqURL, t)
 //}
-//
+
 func TestGetMetaPartitions(t *testing.T) {
 	reqURL := fmt.Sprintf("%v%v?name=%v", hostAddr, proto.ClientMetaPartitions, commonVolName)
 	process(reqURL, t)
@@ -994,6 +994,12 @@ func TestDeleteUser(t *testing.T) {
 
 func TestListUsersOfVol(t *testing.T) {
 	reqURL := fmt.Sprintf("%v%v?name=%v", hostAddr, proto.UsersOfVol, "test_create_vol")
+	fmt.Println(reqURL)
+	process(reqURL, t)
+}
+
+func TestListNodeSets(t *testing.T) {
+	reqURL := fmt.Sprintf("%v%v", hostAddr, proto.GetAllNodeSets)
 	fmt.Println(reqURL)
 	process(reqURL, t)
 }

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -921,10 +921,12 @@ func (partition *DataPartition) buildDpInfo(c *Cluster) *proto.DataPartitionInfo
 	}
 
 	zones := make([]string, len(partition.Hosts))
+	nodeSets := make([]uint64, len(partition.Hosts))
 	for idx, host := range partition.Hosts {
 		dataNode, err := c.dataNode(host)
 		if err == nil {
 			zones[idx] = dataNode.ZoneName
+			nodeSets[idx] = dataNode.NodeSetID
 		}
 	}
 
@@ -939,6 +941,7 @@ func (partition *DataPartition) buildDpInfo(c *Cluster) *proto.DataPartitionInfo
 		Hosts:                    partition.Hosts,
 		Peers:                    partition.Peers,
 		Zones:                    zones,
+		NodeSets:                 nodeSets,
 		MissingNodes:             partition.MissingNodes,
 		VolName:                  partition.VolName,
 		VolID:                    partition.VolID,

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -536,6 +536,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.GetAllNodeSets).
 		HandlerFunc(m.listNodeSets)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.GetNodeSet).
+		HandlerFunc(m.getNodeSet)
 
 	// Quota
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -533,6 +533,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.GetAllZones).
 		HandlerFunc(m.listZone)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.GetAllNodeSets).
+		HandlerFunc(m.listNodeSets)
 
 	// Quota
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -214,6 +214,10 @@ func zoneNotFound(name string) (err error) {
 	return notFoundMsg(fmt.Sprintf("zone[%v]", name))
 }
 
+func nodeSetNotFound(id uint64) (err error) {
+	return notFoundMsg(fmt.Sprintf("nodeSet[%v]", id))
+}
+
 func dataNodeNotFound(addr string) (err error) {
 	return notFoundMsg(fmt.Sprintf("data node[%v]", addr))
 }

--- a/master/topology.go
+++ b/master/topology.go
@@ -1212,15 +1212,6 @@ func (t *topology) allocZonesForDataNode(zoneNum, replicaNum int, excludeZone []
 	return
 }
 
-func (ns *nodeSet) dataNodeCount() int {
-	var count int
-	ns.dataNodes.Range(func(key, value interface{}) bool {
-		count++
-		return true
-	})
-	return count
-}
-
 func (ns *nodeSet) getAvailDataNodeHosts(excludeHosts []string, replicaNum int) (hosts []string, peers []proto.Peer, err error) {
 	return getAvailHosts(ns.dataNodes, excludeHosts, replicaNum, selectDataNode)
 }

--- a/master/topology.go
+++ b/master/topology.go
@@ -1093,10 +1093,30 @@ func (t *topology) getAllZones() (zones []*Zone) {
 	return
 }
 
+func (t *topology) getZoneByZoneName(zoneName string) (zone *Zone) {
+	t.zoneLock.RLock()
+	defer t.zoneLock.RUnlock()
+	if value, ok := t.zoneMap.Load(zoneName); ok {
+		zone = value.(*Zone)
+	}
+	return
+}
+
 func (t *topology) getZoneByIndex(index int) (zone *Zone) {
 	t.zoneLock.RLock()
 	defer t.zoneLock.RUnlock()
 	return t.zones[index]
+}
+
+func (t *topology) getNodeSetByNodeSetId(nodeSetId uint64) (nodeSet *nodeSet, err error) {
+	zones := t.getAllZones()
+	for _, zone := range zones {
+		nodeSet, err = zone.getNodeSet(nodeSetId)
+		if err == nil {
+			return nodeSet, nil
+		}
+	}
+	return nil, errors.NewErrorf("set %v not found", nodeSetId)
 }
 
 func calculateDemandWriteNodes(zoneNum int, replicaNum int) (demandWriteNodes int) {

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -158,6 +158,7 @@ const (
 	GetTopologyView = "/topo/get"
 	UpdateZone      = "/zone/update"
 	GetAllZones     = "/zone/list"
+	GetAllNodeSets  = "/nodeSet/list"
 
 	// Header keys
 	SkipOwnerValidation = "Skip-Owner-Validation"

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -159,6 +159,7 @@ const (
 	UpdateZone      = "/zone/update"
 	GetAllZones     = "/zone/list"
 	GetAllNodeSets  = "/nodeSet/list"
+	GetNodeSet      = "/nodeSet/get"
 
 	// Header keys
 	SkipOwnerValidation = "Skip-Owner-Validation"

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -16,7 +16,7 @@ package proto
 
 import "github.com/cubefs/cubefs/util/errors"
 
-//err
+// err
 var (
 	ErrSuc                    = errors.New("success")
 	ErrInternalError          = errors.New("internal error")
@@ -89,6 +89,7 @@ var (
 	ErrVolNoCacheAndRule                       = errors.New("vol has no cache and rule")
 	ErrNoAclPermission                         = errors.New("acl no permission")
 	ErrQuotaNotExists                          = errors.New("quota not exists")
+	ErrNodeSetNotExists                        = errors.New("node set not exists")
 )
 
 // http response error code and error message definitions
@@ -153,6 +154,7 @@ const (
 	ErrCodeInvalidSecretKey
 	ErrCodeIsOwner
 	ErrCodeZoneNumError
+	ErrCodeNodeSetNotExists
 )
 
 // Err2CodeMap error map to code
@@ -215,6 +217,7 @@ var Err2CodeMap = map[error]int32{
 	ErrInvalidSecretKey:                ErrCodeInvalidSecretKey,
 	ErrIsOwner:                         ErrCodeIsOwner,
 	ErrZoneNum:                         ErrCodeZoneNumError,
+	ErrNodeSetNotExists:                ErrCodeNodeSetNotExists,
 }
 
 func ParseErrorCode(code int32) error {
@@ -284,6 +287,7 @@ var code2ErrMap = map[int32]error{
 	ErrCodeInvalidSecretKey:                ErrInvalidSecretKey,
 	ErrCodeIsOwner:                         ErrIsOwner,
 	ErrCodeZoneNumError:                    ErrZoneNum,
+	ErrCodeNodeSetNotExists:                ErrNodeSetNotExists,
 }
 
 type GeneralResp struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -84,6 +84,7 @@ type MetaPartitionInfo struct {
 	Hosts         []string
 	Peers         []Peer
 	Zones         []string
+	NodeSets      []uint64
 	OfflinePeerID uint64
 	MissNodes     map[string]int64
 	LoadResponse  []*MetaPartitionLoadResponse
@@ -223,6 +224,7 @@ type DataPartitionInfo struct {
 	Hosts                    []string // host addresses
 	Peers                    []Peer
 	Zones                    []string
+	NodeSets                 []uint64
 	MissingNodes             map[string]int64 // key: address of the missing node, value: when the node is missing
 	VolName                  string
 	VolID                    uint64

--- a/proto/model.go
+++ b/proto/model.go
@@ -183,12 +183,25 @@ type NodeSetStat struct {
 	Zone        string
 	MetaNodeNum int
 	DataNodeNum int
-	DataTotal   uint64
-	DataUsed    uint64
-	DataAvail   uint64
-	MetaTotal   uint64
-	MetaUsed    uint64
-	MetaAvail   uint64
+}
+
+type NodeSetStatInfo struct {
+	ID        uint64
+	Capacity  int
+	Zone      string
+	MetaNodes []*NodeStatView
+	DataNodes []*NodeStatView
+}
+
+type NodeStatView struct {
+	Addr       string
+	Status     bool
+	DomainAddr string
+	ID         uint64
+	IsWritable bool
+	Total      uint64
+	Used       uint64
+	Avail      uint64
 }
 
 type NodeStatInfo struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -176,6 +176,20 @@ type ZoneNodesStat struct {
 	WritableNodes int
 }
 
+type NodeSetStat struct {
+	ID          uint64
+	Capacity    int
+	Zone        string
+	MetaNodeNum int
+	DataNodeNum int
+	DataTotal   uint64
+	DataUsed    uint64
+	DataAvail   uint64
+	MetaTotal   uint64
+	MetaUsed    uint64
+	MetaAvail   uint64
+}
+
 type NodeStatInfo struct {
 	TotalGB     uint64
 	UsedGB      uint64

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -117,6 +117,19 @@ func (api *AdminAPI) ListNodeSets(zoneName string) (nodeSetStats []*proto.NodeSe
 	}
 	return
 }
+func (api *AdminAPI) GetNodeSet(nodeSetId string) (nodeSetStatInfo *proto.NodeSetStatInfo, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.GetNodeSet)
+	request.addParam("nodesetId", nodeSetId)
+	var buf []byte
+	if buf, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	nodeSetStatInfo = &proto.NodeSetStatInfo{}
+	if err = json.Unmarshal(buf, &nodeSetStatInfo); err != nil {
+		return
+	}
+	return
+}
 func (api *AdminAPI) Topo() (topo *proto.TopologyView, err error) {
 	var buf []byte
 	var request = newAPIRequest(http.MethodGet, proto.GetTopologyView)

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -102,6 +102,21 @@ func (api *AdminAPI) ListZones() (zoneViews []*proto.ZoneView, err error) {
 	}
 	return
 }
+func (api *AdminAPI) ListNodeSets(zoneName string) (nodeSetStats []*proto.NodeSetStat, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.GetAllNodeSets)
+	if zoneName != "" {
+		request.addParam("zoneName", zoneName)
+	}
+	var buf []byte
+	if buf, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	nodeSetStats = make([]*proto.NodeSetStat, 0)
+	if err = json.Unmarshal(buf, &nodeSetStats); err != nil {
+		return
+	}
+	return
+}
 func (api *AdminAPI) Topo() (topo *proto.TopologyView, err error) {
 	var buf []byte
 	var request = newAPIRequest(http.MethodGet, proto.GetTopologyView)

--- a/sdk/master/client.go
+++ b/sdk/master/client.go
@@ -45,6 +45,9 @@ type MasterCLientWithResolver struct {
 	stopC          chan struct{}
 }
 
+type IMasterClient interface {
+}
+
 type MasterClient struct {
 	sync.RWMutex
 	masters    []string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- add `nodeset` subcommand
- support listing nodesets and displaying space capacity

## support listing nodesets and displaying space capacity
```shell
$ cfs-cli nodeset list -h
List cluster nodeSets

Usage:
  cfs-cli nodeset list [flags]

Aliases:
  list, ls

Flags:
  -h, --help               help for list
      --zone-name string   List nodeSets in the specified zone
```
```
$ cfs-cli nodeset list
ID     Cap    Zone         MetaNum    DataNum   
1      18     default      4          4         
11     18     test         0          0         
14     6      test2        0          0         
19     6      test2        0          0         
$ cfs-cli nodeset list --zone-name=test2
ID     Cap    Zone         MetaNum    DataNum   
14     6      test2        0          0         
19     6      test2        0          0         
```
```
$ cfs-cli nodeset info 1
NodeSet ID:    1
Capacity:      18
Zone:          default
DataTotal:     215.53 GB
DataUsed:      175.13 GB
DataAvail:     40.40 GB
MetaTotal:     9.77 GB
MetaUsed:      457.20 MB
MetaAvail:     9.32 GB

DataNodes[4]:
  ID        ADDRESS                                                              WRITABLE    STATUS      TOTAL         USED          AVAIL     
  9         172.16.1.104:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  
  8         172.16.1.103:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  
  6         172.16.1.101:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  
  7         172.16.1.102:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  

MetaNodes[4]:
  ID        ADDRESS                                                              WRITABLE    STATUS      TOTAL         USED          AVAIL     
  3         172.16.1.102:17210                                                   Yes         Active      2.44 GB       156.75 MB     2.29 GB   
  5         172.16.1.104:17210                                                   Yes         Active      2.44 GB       121.94 MB     2.32 GB   
  4         172.16.1.103:17210                                                   Yes         Active      2.44 GB       85.04 MB      2.36 GB   
  2         172.16.1.101:17210                                                   Yes         Active      2.44 GB       93.47 MB      2.35 GB  
```

## partitions support displaying in which nodeSet
```shell
$ cfs-cli nodeset datapartition info 1

...

NodeSets :
  [1]  [1]  [1]

...

```
```shell
$ cfs-cli nodeset metapartition info 1

...

NodeSets :
  [1]  [1]  [1]

...

```

**Which issue this PR fixes**
part of issue #1894

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
