### PR TITLE
When data processing cannot be accessed, read requests may be suspended for an extended period of time.

### DIFF
--- a/datanode/wrap_post.go
+++ b/datanode/wrap_post.go
@@ -25,7 +25,7 @@ func (s *DataNode) Post(p *repl.Packet) error {
 	if p.IsMasterCommand() {
 		p.NeedReply = true
 	}
-	if p.IsReadOperation() {
+	if p.IsReadOperation() && p.AfterPre {
 		p.NeedReply = false
 	}
 	s.cleanupPkt(p)

--- a/datanode/wrap_prepare.go
+++ b/datanode/wrap_prepare.go
@@ -30,6 +30,8 @@ func (s *DataNode) Prepare(p *repl.Packet) (err error) {
 		p.SetPacketHasPrepare()
 		if err != nil {
 			p.PackErrorBody(repl.ActionPreparePkt, err.Error())
+		} else {
+			p.AfterPre = true
 		}
 	}()
 	if p.IsMasterCommand() {

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -47,6 +47,7 @@ type Packet struct {
 
 	// used locally
 	shallDegrade bool
+	AfterPre     bool
 }
 
 type FollowerPacket struct {


### PR DESCRIPTION
When data processing cannot be accessed, read requests may be suspended for an extended period of time.

close:#2237

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
