### PR TITLE
bugfix(client):check bcache cache file path

### DIFF
--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -109,7 +109,7 @@ func NewFile(s *Super, i *proto.InodeInfo, flag uint32, pino uint64, filename st
 	return &File{super: s, info: i, parentIno: pino, name: filename}
 }
 
-//get file parentPath
+// get file parentPath
 func (f *File) getParentPath() string {
 	filepath := ""
 	if f.parentIno == f.super.rootIno {


### PR DESCRIPTION
close:#2242

**What this PR does / why we need it**:
Client would check cache path received from bcache service, in case   cache path belongs to other file



