### PR TITLE
refactor(metanode): refactor quota check and uid check

### DIFF
--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -306,11 +306,10 @@ func (mp *metaPartition) fsmAppendExtents(ino *Inode) (status uint8) {
 	}
 	oldSize := int64(ino2.Size)
 	eks := ino.Extents.CopyExtents()
-	delExtents := ino2.AppendExtents(eks, ino.ModifyTime, mp.volType)
 	if status = mp.uidManager.addUidSpace(ino2.Uid, ino2.Inode, eks); status != proto.OpOk {
-		mp.extDelCh <- eks
 		return
 	}
+	delExtents := ino2.AppendExtents(eks, ino.ModifyTime, mp.volType)
 	mp.updateUsedInfo(int64(ino2.Size)-oldSize, 0, ino2.Inode)
 	log.LogInfof("fsmAppendExtents inode(%v) deleteExtents(%v)", ino2.Inode, delExtents)
 	mp.uidManager.minusUidSpace(ino2.Uid, ino2.Inode, delExtents)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1.move fsm uid quota to api handler for performance
2.refactor code of uid quota and dir quota to reduce duplicated code
3.uid add space in extentappend should not drop extent 
