### PR TITLE
fix(rpc): a custom readCloser is used as request.body to count the size of…

### DIFF
--- a/blobstore/common/rpc/auditlog/request_row.go
+++ b/blobstore/common/rpc/auditlog/request_row.go
@@ -72,7 +72,7 @@ var vre = regexp.MustCompile("^v[0-9]+$")
 
 type ReqHeader struct {
 	ContentLength string `json:"Content-Length"`
-	BodySize      int64  `json:"bs"` // body size
+	BodySize      int64  `json:"BodySize"` // body size
 	RawQuery      string `json:"RawQuery"`
 	Host          string `json:"Host"`
 	Token         *Token `json:"Token"`
@@ -353,10 +353,6 @@ func (a *RequestRow) ReqLength() (reqLength int64) {
 	reqHeader := a.getReqHeader()
 	if reqHeader == nil {
 		return
-	}
-	reqLength, _ = strconv.ParseInt(reqHeader.ContentLength, 10, 64)
-	if reqLength > 0 {
-		return reqLength
 	}
 	return reqHeader.BodySize
 }


### PR DESCRIPTION
fix(rpc): a custom readCloser is used as request.body to count the size of the request body

in previous version,blobstore access upload no metric if there is no context-length in the request header,now the size is counted when read request body

Fixes #2120

Signed-off-by: shuqiang-zheng <zhengshuqiang@oppo.com>
