### PR TITLE
Log: Dir of log(normal|statistic|audit) be grant as 755 for other use…

### DIFF
--- a/util/auditlog/auditlog.go
+++ b/util/auditlog/auditlog.go
@@ -291,7 +291,7 @@ func InitAudit(dir, logModule string, logMaxSize int64) (*Audit, error) {
 			return nil, errors.New(dir + " is not a directory")
 		}
 	}
-	_ = os.Chmod(dir, 0766)
+	_ = os.Chmod(dir, 0755)
 	logName := path.Join(dir, Audit_Module) + ".log"
 	audit := &Audit{
 		hostName:         host,

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -295,7 +295,7 @@ func InitLog(dir, module string, level Level, rotate *LogRotate) (*Log, error) {
 			return nil, errors.New(dir + " is not a directory")
 		}
 	}
-	_ = os.Chmod(dir, 0766)
+	_ = os.Chmod(dir, 0755)
 	if rotate == nil {
 		rotate = NewLogRotate()
 		fs := syscall.Statfs_t{}

--- a/util/stat/statistic.go
+++ b/util/stat/statistic.go
@@ -102,7 +102,7 @@ func NewStatistic(dir, logModule string, logMaxSize int64, timeOutUs [MaxTimeout
 			return nil, errors.New(dir + " is not a directory")
 		}
 	}
-	_ = os.Chmod(dir, 0766)
+	_ = os.Chmod(dir, 0755)
 	logName := path.Join(dir, Stat_Module)
 	st := &Statistic{
 		logDir:        dir,

--- a/util/ump/ump_async_log.go
+++ b/util/ump/ump_async_log.go
@@ -173,7 +173,7 @@ func initLogName(module, dataDir string) (err error) {
 	} else {
 		return fmt.Errorf("warnLogDir dir not config")
 	}
-	if err = os.MkdirAll(UmpDataDir, 0666); err != nil {
+	if err = os.MkdirAll(UmpDataDir, 0755); err != nil {
 		return
 	}
 


### PR DESCRIPTION
…r access

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For other users in linux, the cubefs logs should be readable, which facilitates the division of operational levels.