### PR TITLE
Some bug fix for blobstore v1.2.2

### DIFF
--- a/blobstore/access/controller/service_test.go
+++ b/blobstore/access/controller/service_test.go
@@ -71,7 +71,7 @@ func TestAccessServiceGetServiceHost(t *testing.T) {
 	require.NoError(t, err)
 
 	keys := make(hostSet)
-	for ii := 0; ii < 100; ii++ {
+	for range [100]struct{}{} {
 		host, err := sc.GetServiceHost(serviceCtx, serviceName)
 		require.NoError(t, err)
 		keys[host] = struct{}{}
@@ -92,7 +92,7 @@ func TestAccessServicePunishService(t *testing.T) {
 
 	{
 		keys := make(hostSet)
-		for ii := 0; ii < 100; ii++ {
+		for range [100]struct{}{} {
 			host, err := sc.GetServiceHost(serviceCtx, serviceName)
 			require.NoError(t, err)
 			keys[host] = struct{}{}
@@ -101,7 +101,7 @@ func TestAccessServicePunishService(t *testing.T) {
 	}
 
 	sc.PunishService(serviceCtx, serviceName, "proxy-2", 2)
-	for ii := 0; ii < 100; ii++ {
+	for range [100]struct{}{} {
 		host, err := sc.GetServiceHost(serviceCtx, serviceName)
 		require.NoError(t, err)
 		require.True(t, host == "proxy-1")
@@ -110,12 +110,24 @@ func TestAccessServicePunishService(t *testing.T) {
 	time.Sleep(time.Millisecond * 1200)
 	{
 		keys := make(hostSet)
-		for ii := 0; ii < 100; ii++ {
+		for range [100]struct{}{} {
 			host, err := sc.GetServiceHost(serviceCtx, serviceName)
 			require.NoError(t, err)
 			keys[host] = struct{}{}
 		}
 		require.ElementsMatch(t, keys.Keys(), []string{"proxy-1", "proxy-2"})
+	}
+
+	{
+		sc.PunishService(serviceCtx, serviceName, "proxy-1", 2)
+		sc.PunishService(serviceCtx, serviceName, "proxy-2", 2)
+		keys := make(hostSet)
+		for range [10000]struct{}{} {
+			host, err := sc.GetServiceHost(serviceCtx, serviceName)
+			require.NoError(t, err)
+			keys[host] = struct{}{}
+		}
+		require.Equal(t, 1, len(keys))
 	}
 }
 
@@ -134,7 +146,7 @@ func TestAccessServicePunishServiceWithThreshold(t *testing.T) {
 
 	{
 		keys := make(hostSet)
-		for ii := 0; ii < 100; ii++ {
+		for range [100]struct{}{} {
 			host, err := sc.GetServiceHost(serviceCtx, serviceName)
 			require.NoError(t, err)
 			keys[host] = struct{}{}
@@ -148,7 +160,7 @@ func TestAccessServicePunishServiceWithThreshold(t *testing.T) {
 	}
 	{
 		keys := make(hostSet)
-		for ii := 0; ii < 100; ii++ {
+		for range [100]struct{}{} {
 			host, err := sc.GetServiceHost(serviceCtx, serviceName)
 			require.NoError(t, err)
 			keys[host] = struct{}{}
@@ -158,7 +170,7 @@ func TestAccessServicePunishServiceWithThreshold(t *testing.T) {
 
 	// punished
 	sc.PunishServiceWithThreshold(serviceCtx, serviceName, "proxy-1", 2)
-	for ii := 0; ii < 100; ii++ {
+	for range [100]struct{}{} {
 		host, err := sc.GetServiceHost(serviceCtx, serviceName)
 		require.NoError(t, err)
 		require.True(t, host == "proxy-2")
@@ -167,7 +179,7 @@ func TestAccessServicePunishServiceWithThreshold(t *testing.T) {
 	time.Sleep(time.Millisecond * 1200)
 	{
 		keys := make(hostSet)
-		for ii := 0; ii < 100; ii++ {
+		for range [100]struct{}{} {
 			host, err := sc.GetServiceHost(serviceCtx, serviceName)
 			require.NoError(t, err)
 			keys[host] = struct{}{}

--- a/blobstore/api/blobnode/iostat.go
+++ b/blobstore/api/blobnode/iostat.go
@@ -59,10 +59,10 @@ func (it IOType) IsValid() bool {
 }
 
 func (it IOType) String() string {
-	return IOtypemap[uint64(it)]
+	return IOtypemap[it]
 }
 
-func Getiotype(ctx context.Context) IOType {
+func GetIoType(ctx context.Context) IOType {
 	v := ctx.Value(_ioFlowStatKey)
 	if v == nil {
 		return NormalIO
@@ -70,7 +70,7 @@ func Getiotype(ctx context.Context) IOType {
 	return v.(IOType)
 }
 
-func Setiotype(ctx context.Context, iot IOType) context.Context {
+func SetIoType(ctx context.Context, iot IOType) context.Context {
 	return context.WithValue(ctx, _ioFlowStatKey, iot)
 }
 

--- a/blobstore/api/blobnode/iostat_test.go
+++ b/blobstore/api/blobnode/iostat_test.go
@@ -21,17 +21,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetIotype(t *testing.T) {
+func TestGetIoType(t *testing.T) {
 	ctx := context.TODO()
 
-	iotype := Getiotype(ctx)
+	iotype := GetIoType(ctx)
 	require.Equal(t, NormalIO, iotype)
 
 	ctx0 := context.WithValue(ctx, _ioFlowStatKey, CompactIO)
-	iotype = Getiotype(ctx0)
+	iotype = GetIoType(ctx0)
 	require.Equal(t, CompactIO, iotype)
 
 	ctx1 := context.WithValue(ctx0, _ioFlowStatKey, DiskRepairIO)
-	iotype = Getiotype(ctx1)
+	iotype = GetIoType(ctx1)
 	require.Equal(t, DiskRepairIO, iotype)
 }

--- a/blobstore/api/proxy/client.go
+++ b/blobstore/api/proxy/client.go
@@ -78,5 +78,6 @@ func (c *client) Erase(ctx context.Context, host string, key string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	return rpc.ParseData(resp, nil)
 }

--- a/blobstore/blobnode/base/flow/iostat.go
+++ b/blobstore/blobnode/base/flow/iostat.go
@@ -67,7 +67,7 @@ func SetupDefaultIOStat(s *IOFlowStat) {
 	defaultIOStat = s
 }
 
-// ${pid}.${key}_${value}.${suffix}
+// GenerateStatName ${pid}.${key}_${value}.${suffix}
 func GenerateStatName(pid int, key string, value string, suffix string) string {
 	return fmt.Sprintf("%d.%s_%s.%s", pid, key, value, suffix)
 }

--- a/blobstore/blobnode/base/limitio/util_test.go
+++ b/blobstore/blobnode/base/limitio/util_test.go
@@ -1,0 +1,29 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package limitio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLimitTrack(t *testing.T) {
+	ctx := context.Background()
+	SetLimitTrack(ctx)
+	flag := IsLimitTrack(ctx)
+	require.False(t, false, flag)
+}

--- a/blobstore/blobnode/core/chunk/compact.go
+++ b/blobstore/blobnode/core/chunk/compact.go
@@ -220,7 +220,6 @@ COMPACT:
 			if err != nil {
 				if err == core.ErrChunkScanEOF {
 					span.Infof("chunk %s scan finished", cs.ID())
-					err = nil
 					break COMPACT
 				} else {
 					span.Errorf("scan chunk meta(%s) failed: %v", cs.ID(), err)

--- a/blobstore/blobnode/core/chunk/compact.go
+++ b/blobstore/blobnode/core/chunk/compact.go
@@ -149,7 +149,7 @@ func (cs *chunk) handleErrCompact(ctx context.Context, ncs core.ChunkAPI) {
 func (cs *chunk) doCompact(ctx context.Context, ncs *chunk) (err error) {
 	span := trace.SpanFromContextSafe(ctx)
 
-	ctx = bnapi.Setiotype(ctx, bnapi.CompactIO)
+	ctx = bnapi.SetIoType(ctx, bnapi.CompactIO)
 
 	startBid := proto.InValidBlobID
 	replStg := cs.getStg()

--- a/blobstore/blobnode/core/disk/chunkinspect.go
+++ b/blobstore/blobnode/core/disk/chunkinspect.go
@@ -132,7 +132,7 @@ func (ds *DiskStorage) maybeCleanRubbishChunk(ctx context.Context, id bnapi.Chun
 	span := trace.SpanFromContextSafe(ctx)
 
 	// set io type
-	ctx = bnapi.Setiotype(ctx, bnapi.InternalIO)
+	ctx = bnapi.SetIoType(ctx, bnapi.InternalIO)
 
 	span.Debugf("chunk:%s maybe rubbish, will confirm", id)
 

--- a/blobstore/blobnode/core/disk/disk.go
+++ b/blobstore/blobnode/core/disk/disk.go
@@ -917,7 +917,7 @@ func (ds *DiskStorage) cleanReleasedChunks() (err error) {
 	span.Debugf("come in CleanChunks.")
 
 	// set io type
-	ctx = bnapi.Setiotype(ctx, bnapi.InternalIO)
+	ctx = bnapi.SetIoType(ctx, bnapi.InternalIO)
 
 	protectionPeriod := time.Duration(ds.Conf.ChunkReleaseProtectionM)
 	now := time.Now().UnixNano()

--- a/blobstore/blobnode/core/storage/datafile.go
+++ b/blobstore/blobnode/core/storage/datafile.go
@@ -505,17 +505,17 @@ func (cd *datafile) spaceInfo() (size int64, phySpace int64, err error) {
 }
 
 func (cd *datafile) qosReaderAt(ctx context.Context, reader io.ReaderAt) io.ReaderAt {
-	ioType := bnapi.Getiotype(ctx)
+	ioType := bnapi.GetIoType(ctx)
 	return cd.ioQos.ReaderAt(ctx, ioType, reader)
 }
 
 func (cd *datafile) qosWriterAt(ctx context.Context, writer io.WriterAt) io.WriterAt {
-	ioType := bnapi.Getiotype(ctx)
+	ioType := bnapi.GetIoType(ctx)
 	w := cd.ioQos.WriterAt(ctx, ioType, writer)
 	return w
 }
 
 func (cd *datafile) qosWriter(ctx context.Context, writer io.Writer) io.Writer {
-	ioType := bnapi.Getiotype(ctx)
+	ioType := bnapi.GetIoType(ctx)
 	return cd.ioQos.Writer(ctx, ioType, writer)
 }

--- a/blobstore/blobnode/datainspect.go
+++ b/blobstore/blobnode/datainspect.go
@@ -95,7 +95,7 @@ func ScanShard(ctx context.Context, cs core.ChunkAPI, startBid proto.BlobID, ins
 func startInspect(ctx context.Context, cs core.ChunkAPI) ([]bnapi.BadShard, error) {
 	span := trace.SpanFromContextSafe(ctx)
 	span.Debugf("start inspect chunk, vuid:%v,chunkid:%s.", cs.Vuid(), cs.ID())
-	ctx = bnapi.Setiotype(ctx, bnapi.InspectIO)
+	ctx = bnapi.SetIoType(ctx, bnapi.InspectIO)
 	startBid := proto.InValidBlobID
 	ds := cs.Disk()
 	badShards := make([]bnapi.BadShard, 0)

--- a/blobstore/blobnode/db/metadb.go
+++ b/blobstore/blobnode/db/metadb.go
@@ -98,7 +98,7 @@ func (md *metadb) SetIOStat(stat *flow.IOFlowStat) {
 }
 
 func (md *metadb) Get(ctx context.Context, key []byte) (value []byte, err error) {
-	mgr, iot := md.getiotype(ctx)
+	mgr, iot := md.getIoType(ctx)
 
 	mgr.ReadBegin(1)
 	defer mgr.ReadEnd(time.Now())
@@ -134,7 +134,7 @@ func (md *metadb) Put(ctx context.Context, kv rdb.KV) (err error) {
 		Data: kv,
 	}
 
-	mgr, iot := md.getiotype(ctx)
+	mgr, iot := md.getIoType(ctx)
 
 	mgr.WriteBegin(1)
 	defer mgr.WriteEnd(time.Now())
@@ -158,7 +158,7 @@ func (md *metadb) Delete(ctx context.Context, key []byte) (err error) {
 		Data: rdb.KV{Key: key},
 	}
 
-	mgr, iot := md.getiotype(ctx)
+	mgr, iot := md.getIoType(ctx)
 
 	mgr.WriteBegin(1)
 	defer mgr.WriteEnd(time.Now())
@@ -182,7 +182,7 @@ func (md *metadb) DeleteRange(ctx context.Context, start, end []byte) (err error
 		Data: rdb.Range{Start: start, Limit: end},
 	}
 
-	mgr, iot := md.getiotype(ctx)
+	mgr, iot := md.getIoType(ctx)
 
 	mgr.WriteBegin(1)
 	defer mgr.WriteEnd(time.Now())
@@ -325,8 +325,8 @@ func (md *metadb) doBatch(ctx context.Context, reqs []Request) (err error) {
 	return err
 }
 
-func (md *metadb) getiotype(ctx context.Context) (iostat.StatMgrAPI, bnapi.IOType) {
-	iot := bnapi.Getiotype(ctx)
+func (md *metadb) getIoType(ctx context.Context) (iostat.StatMgrAPI, bnapi.IOType) {
+	iot := bnapi.GetIoType(ctx)
 	mgr := md.iostat.GetStatMgr(iot)
 	return mgr, iot
 }

--- a/blobstore/blobnode/shard.go
+++ b/blobstore/blobnode/shard.go
@@ -81,7 +81,7 @@ func (s *Service) ShardGet(c *rpc.Context) {
 	}
 
 	// set io type
-	ctx = bnapi.Setiotype(ctx, args.Type)
+	ctx = bnapi.SetIoType(ctx, args.Type)
 	ctx = limitio.SetLimitTrack(ctx)
 
 	s.lock.RLock()
@@ -342,7 +342,7 @@ func (s *Service) ShardMarkdelete(c *rpc.Context) {
 	}
 
 	// set io type
-	ctx = bnapi.Setiotype(ctx, bnapi.DeleteIO)
+	ctx = bnapi.SetIoType(ctx, bnapi.DeleteIO)
 	ctx = limitio.SetLimitTrack(ctx)
 
 	err = cs.MarkDelete(ctx, args.Bid)
@@ -413,7 +413,7 @@ func (s *Service) ShardDelete(c *rpc.Context) {
 	}
 
 	// set io type
-	ctx = bnapi.Setiotype(ctx, bnapi.DeleteIO)
+	ctx = bnapi.SetIoType(ctx, bnapi.DeleteIO)
 	ctx = limitio.SetLimitTrack(ctx)
 
 	err = cs.Delete(ctx, args.Bid)
@@ -465,7 +465,7 @@ func (s *Service) ShardPut(c *rpc.Context) {
 	}
 
 	// set io type
-	ctx = bnapi.Setiotype(ctx, args.Type)
+	ctx = bnapi.SetIoType(ctx, args.Type)
 	ctx = limitio.SetLimitTrack(ctx)
 
 	s.lock.RLock()

--- a/blobstore/cli/common/cfmt/access_test.go
+++ b/blobstore/cli/common/cfmt/access_test.go
@@ -51,13 +51,13 @@ func TestParseLocation(t *testing.T) {
 		},
 	}
 
-	locx, err := cfmt.ParseLocation("")
+	_, err := cfmt.ParseLocation("")
 	require.Error(t, err)
 
 	_, err = cfmt.ParseLocation("xxxx")
 	require.Error(t, err)
 
-	locx, err = cfmt.ParseLocation("{}")
+	locx, err := cfmt.ParseLocation("{}")
 	require.NoError(t, err)
 	require.Equal(t, access.Location{}, locx)
 

--- a/blobstore/clustermgr/diskmgr/alloc.go
+++ b/blobstore/clustermgr/diskmgr/alloc.go
@@ -260,11 +260,7 @@ func (s *idcStorage) allocFromBlobNodeStorages(ctx context.Context, count int, t
 
 	for _, diskInfo := range excludes {
 		diskInfo.lock.RLock()
-		if excludeHosts == nil {
-			excludeHosts = map[string]bool{diskInfo.info.Host: true}
-		} else {
-			excludeHosts[diskInfo.info.Host] = true
-		}
+		excludeHosts[diskInfo.info.Host] = true
 		diskInfo.lock.RUnlock()
 	}
 

--- a/blobstore/clustermgr/diskmgr/alloc_test.go
+++ b/blobstore/clustermgr/diskmgr/alloc_test.go
@@ -16,7 +16,6 @@ package diskmgr
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -123,7 +122,7 @@ func TestAlloc(t *testing.T) {
 		// refresh cluster's disk space allocator
 		testDiskMgr.refresh(ctx)
 
-		t.Log(fmt.Sprintf("all disk length: %d", len(testDiskMgr.allDisks)))
+		t.Logf("all disk length: %d", len(testDiskMgr.allDisks))
 
 		// alloc from not enough space, alloc should return ErrNoEnoughSpace
 		for _, idc := range testIdcs {
@@ -235,7 +234,7 @@ func TestAllocWithSameHost(t *testing.T) {
 		testDiskMgr.RackAware = false
 		testDiskMgr.refresh(ctx)
 
-		t.Log(fmt.Sprintf("all disk length: %d", len(testDiskMgr.allDisks)))
+		t.Logf("all disk length: %d", len(testDiskMgr.allDisks))
 
 		// alloc from not enough space, alloc should return ErrNoEnoughSpace
 		for _, idc := range testIdcs {

--- a/blobstore/common/rpc/auditlog/auditlog.go
+++ b/blobstore/common/rpc/auditlog/auditlog.go
@@ -250,12 +250,10 @@ func (j *jsonAuditlog) Handler(w http.ResponseWriter, req *http.Request, f func(
 	}
 
 	switch j.cfg.LogFormat {
-	case LogFormatText:
-		logBytes = auditLog.ToBytesWithTab(b)
 	case LogFormatJSON:
 		logBytes = auditLog.ToJson()
 	default:
-		logBytes = auditLog.ToBytesWithTab(b)
+		logBytes = b.Bytes() // *bytes.Buffer was filled with metricSender.Send
 	}
 	err = j.logFile.Log(logBytes)
 	if err != nil {

--- a/blobstore/common/rpc/auditlog/proto.go
+++ b/blobstore/common/rpc/auditlog/proto.go
@@ -16,6 +16,11 @@ package auditlog
 
 import "net/http"
 
+const (
+	LogFormatText = "text"
+	LogFormatJSON = "json"
+)
+
 type Config struct {
 	// LogDir audit log whether to enable depend on whether config log dir
 	LogDir string `json:"logdir"`
@@ -33,6 +38,9 @@ type Config struct {
 
 	// KeywordsFilter log filter based on uri and request method
 	KeywordsFilter []string `json:"keywords_filter"`
+
+	// LogFormat valid value is "text" or "json", default is "text"
+	LogFormat string `json:"log_format"`
 }
 
 // LogCloser a implemented audit logger should implements ProgressHandler

--- a/blobstore/common/rpc/auditlog/request_row.go
+++ b/blobstore/common/rpc/auditlog/request_row.go
@@ -72,7 +72,7 @@ var vre = regexp.MustCompile("^v[0-9]+$")
 
 type ReqHeader struct {
 	ContentLength string `json:"Content-Length"`
-	BodySize      int64  `json:"bs"` // body size
+	BodySize      int64  `json:"BodySize"` // body size
 	RawQuery      string `json:"RawQuery"`
 	Host          string `json:"Host"`
 	Token         *Token `json:"Token"`
@@ -353,10 +353,6 @@ func (a *RequestRow) ReqLength() (reqLength int64) {
 	reqHeader := a.getReqHeader()
 	if reqHeader == nil {
 		return
-	}
-	reqLength, _ = strconv.ParseInt(reqHeader.ContentLength, 10, 64)
-	if reqLength > 0 {
-		return reqLength
 	}
 	return reqHeader.BodySize
 }

--- a/blobstore/common/rpc/auditlog/response.go
+++ b/blobstore/common/rpc/auditlog/response.go
@@ -97,11 +97,11 @@ func (w *responseWriter) getBody() []byte {
 	return w.body[:w.n]
 }
 
-func (w *responseWriter) getStatusCode() []byte {
-	return []byte(strconv.Itoa(w.statusCode))
+func (w *responseWriter) getStatusCode() int {
+	return w.statusCode
 }
 
-func (w *responseWriter) getHeader() []byte {
+func (w *responseWriter) getHeader() M {
 	header := w.ResponseWriter.Header()
 	headerM := make(M)
 	for k := range header {
@@ -111,10 +111,7 @@ func (w *responseWriter) getHeader() []byte {
 			headerM[k] = header.Get(k)
 		}
 	}
-	if len(headerM) > 0 {
-		return headerM.Encode()
-	}
-	return nil
+	return headerM
 }
 
 func (w *responseWriter) getBodyWritten() int64 {

--- a/blobstore/common/rpc/lb.go
+++ b/blobstore/common/rpc/lb.go
@@ -112,11 +112,7 @@ var defaultShouldRetry = func(code int, err error) bool {
 }
 
 func (c *lbClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
-	resp, err := c.doCtx(ctx, req)
-	if err != nil {
-		return resp, err
-	}
-	return resp, err
+	return c.doCtx(ctx, req)
 }
 
 func (c *lbClient) Form(ctx context.Context, method, url string, form map[string][]string) (resp *http.Response, err error) {
@@ -162,6 +158,7 @@ func (c *lbClient) DoWith(ctx context.Context, req *http.Request, ret interface{
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	err = serverCrcEncodeCheck(ctx, req, resp)
 	if err != nil {
 		return err
@@ -174,7 +171,7 @@ func (c *lbClient) GetWith(ctx context.Context, url string, ret interface{}) err
 	if err != nil {
 		return err
 	}
-	return ParseData(resp, ret)
+	return parseData(resp, ret)
 }
 
 func (c *lbClient) PutWith(ctx context.Context, url string, ret interface{}, params interface{}, opts ...Option) (err error) {
@@ -194,6 +191,7 @@ func (c *lbClient) PutWith(ctx context.Context, url string, ret interface{}, par
 	if err != nil {
 		return
 	}
+	defer resp.Body.Close()
 	err = serverCrcEncodeCheck(ctx, request, resp)
 	if err != nil {
 		return err
@@ -219,6 +217,7 @@ func (c *lbClient) PostWith(ctx context.Context, url string, ret interface{}, pa
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// set Header and log errors
 	err = serverCrcEncodeCheck(ctx, request, resp)

--- a/blobstore/common/rpc/lb_test.go
+++ b/blobstore/common/rpc/lb_test.go
@@ -184,7 +184,7 @@ func TestLbClient_Delete(t *testing.T) {
 	result := &ret{}
 	resp, err := client.Delete(ctx, "/get/name?id="+strconv.Itoa(122))
 	require.NoError(t, err)
-	err = ParseData(resp, result)
+	err = parseData(resp, result)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	client.Close()
@@ -337,7 +337,7 @@ func TestLbClient_Post(t *testing.T) {
 	check, err := client.Post(ctx, "", ret{Name: "test_lb_PostJSON"})
 	require.NoError(t, err)
 	client.Close()
-	err = ParseData(check, result)
+	err = parseData(check, result)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }

--- a/blobstore/common/rpc/server_test.go
+++ b/blobstore/common/rpc/server_test.go
@@ -462,7 +462,7 @@ func TestServerResponseWith(t *testing.T) {
 		resp := resp(router).ToResponse()
 		require.Equal(t, 204, resp.StatusCode)
 
-		err := ParseData(resp, nil)
+		err := parseData(resp, nil)
 		require.Error(t, err)
 	}
 	{
@@ -474,12 +474,12 @@ func TestServerResponseWith(t *testing.T) {
 		require.Equal(t, 200, resp.StatusCode)
 
 		var r marshalData
-		err := ParseData(resp, &r)
+		err := parseData(resp, &r)
 		require.NoError(t, err)
 		require.Equal(t, "rab oof", r.S)
 
 		resp.Body = io.NopCloser(bytes.NewBuffer(nil))
-		err = ParseData(resp, &r)
+		err = parseData(resp, &r)
 		require.Error(t, err)
 	}
 	{
@@ -491,7 +491,7 @@ func TestServerResponseWith(t *testing.T) {
 		require.Equal(t, 200, resp.StatusCode)
 
 		var r marshalToData
-		err := ParseData(resp, &r)
+		err := parseData(resp, &r)
 		require.NoError(t, err)
 		require.Equal(t, "oof rab", r.S)
 	}
@@ -504,7 +504,7 @@ func TestServerResponseWith(t *testing.T) {
 		require.Equal(t, 200, resp.StatusCode)
 
 		var r marshalToData
-		err := ParseData(resp, &r)
+		err := parseData(resp, &r)
 		require.Error(t, err)
 	}
 }

--- a/blobstore/common/rpc/simple_test.go
+++ b/blobstore/common/rpc/simple_test.go
@@ -230,7 +230,7 @@ func TestClient_Post(t *testing.T) {
 	result := &ret{}
 	resp, err := simpleClient.Post(ctx, testServer.URL+"/json", &ret{Name: "TestClient_Post"})
 	require.NoError(t, err)
-	err = ParseData(resp, result)
+	err = parseData(resp, result)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "TestClient_Post+Test", result.Name)
@@ -268,7 +268,7 @@ func TestClient_Put(t *testing.T) {
 	result := &ret{}
 	resp, err := simpleClient.Put(ctx, testServer.URL+"/json", &ret{Name: "TestClient_Put"})
 	require.NoError(t, err)
-	err = ParseData(resp, result)
+	err = parseData(resp, result)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "TestClient_Put+Test", result.Name)
@@ -325,7 +325,7 @@ func TestClient_ParseDataWithContentLengthZero(t *testing.T) {
 	require.NoError(t, err)
 	resp.StatusCode = 400
 	resp.ContentLength = 0
-	err = ParseData(resp, result)
+	err = parseData(resp, result)
 	require.Error(t, err)
 }
 
@@ -338,7 +338,7 @@ func TestClient_ParseData(t *testing.T) {
 	require.NoError(t, err)
 	resp.StatusCode = 400
 	resp.ContentLength = 12
-	err = ParseData(resp, result)
+	err = parseData(resp, result)
 	require.Error(t, err)
 }
 
@@ -360,7 +360,7 @@ func TestClient_ResponseClose(t *testing.T) {
 		&ret{Name: "TestClient_ResponseClose"})
 	require.NoError(t, err)
 	resp.Body.Close()
-	err = ParseData(resp, result)
+	err = parseData(resp, result)
 	require.Error(t, err)
 }
 

--- a/blobstore/proxy/allocator.go
+++ b/blobstore/proxy/allocator.go
@@ -39,6 +39,7 @@ func (s *Service) Alloc(c *rpc.Context) {
 	span.Infof("accept Alloc request, args: %v", args)
 	resp, err := s.volumeMgr.Alloc(ctx, args)
 	if err != nil {
+		span.Errorf("alloc volume failed, err: %v", err)
 		c.RespondError(err)
 		return
 	}

--- a/blobstore/proxy/allocator/retain_volume_task.go
+++ b/blobstore/proxy/allocator/retain_volume_task.go
@@ -99,7 +99,6 @@ func (v *volumeMgr) handleFullVols(ctx context.Context, isBackup bool) {
 			if vol.Free < uint64(v.VolumeReserveSize) {
 				vol.deleted = true
 				fullVols = append(fullVols, vid)
-				info.UpdateTotalFree(isBackup, -vol.Free)
 			}
 			vol.mu.Unlock()
 		}
@@ -159,7 +158,6 @@ func (v *volumeMgr) discardVolume(ctx context.Context, token string, isBackup bo
 	for _, info := range v.modeInfos {
 		if vol, ok := info.Get(vid, isBackup); ok {
 			vol.mu.Lock()
-			info.UpdateTotalFree(isBackup, -vol.Free)
 			vol.deleted = true
 			vol.mu.Unlock()
 			info.Delete(vid)

--- a/blobstore/proxy/allocator/volume.go
+++ b/blobstore/proxy/allocator/volume.go
@@ -30,14 +30,14 @@ type volume struct {
 }
 
 const (
-	ALLOCATING = true
-	ALLOCATED  = false
+	ALLOCATED  = int32(0)
+	ALLOCATING = int32(1)
 )
 
 type volumes struct {
 	vols       []*volume
 	totalFree  uint64
-	allocating bool
+	allocating int32
 
 	sync.RWMutex
 }
@@ -95,16 +95,12 @@ func (s *volumes) List() (vols []*volume) {
 	return vols
 }
 
-func (s *volumes) SetAllocateState(state bool) {
-	s.Lock()
-	s.allocating = state
-	s.Unlock()
+func (s *volumes) SetAllocateState(state int32) {
+	atomic.StoreInt32(&s.allocating, state)
 }
 
 func (s *volumes) IsAllocating() bool {
-	s.RLock()
-	defer s.RUnlock()
-	return s.allocating
+	return ALLOCATING == atomic.LoadInt32(&s.allocating)
 }
 
 func (s *volumes) Len() int {

--- a/blobstore/proxy/allocator/volume.go
+++ b/blobstore/proxy/allocator/volume.go
@@ -29,9 +29,15 @@ type volume struct {
 	mu      sync.RWMutex
 }
 
+const (
+	ALLOCATING = true
+	ALLOCATED  = false
+)
+
 type volumes struct {
-	vols      []*volume
-	totalFree uint64
+	vols       []*volume
+	totalFree  uint64
+	allocating bool
 
 	sync.RWMutex
 }
@@ -87,6 +93,18 @@ func (s *volumes) List() (vols []*volume) {
 	defer s.RUnlock()
 	vols = s.vols[:]
 	return vols
+}
+
+func (s *volumes) SetAllocateState(state bool) {
+	s.Lock()
+	s.allocating = state
+	s.Unlock()
+}
+
+func (s *volumes) IsAllocating() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.allocating
 }
 
 func (s *volumes) Len() int {

--- a/blobstore/proxy/allocator/volumemgr_test.go
+++ b/blobstore/proxy/allocator/volumemgr_test.go
@@ -408,34 +408,7 @@ func TestAllocVolumeFailed(t *testing.T) {
 	info.Put(&volume{
 		AllocVolumeInfo: volInfo,
 	}, false)
-	info.SetAllocateState(ALLOCATING, false)
 
-	args = &proxy.AllocVolsArgs{
-		Fsize:    1 << 30,
-		CodeMode: codemode.EC6P6,
-		BidCount: 1,
-		Excludes: nil,
-		Discards: nil,
-	}
-	_, err = vm.allocVid(ctx, args)
-	require.Error(t, err)
-	require.ErrorIs(t, err, errcode.ErrNoAvaliableVolume)
-
-	info.SetAllocateState(ALLOCATED, false)
-	info.Put(&volume{
-		AllocVolumeInfo: cm.AllocVolumeInfo{
-			VolumeInfo: cm.VolumeInfo{
-				VolumeInfoBase: cm.VolumeInfoBase{
-					Vid:  proto.Vid(20),
-					Free: 1024,
-				},
-			},
-			ExpireTime: 100,
-		},
-	}, true)
-	vm.modeInfos[codemode.EC6P6] = info
-	vm.allocChs = make(map[codemode.CodeMode]chan *allocArgs, 1)
-	vm.allocChs[codemode.EC6P6] = make(chan *allocArgs)
 	args = &proxy.AllocVolsArgs{
 		Fsize:    1 << 30,
 		CodeMode: codemode.EC6P6,
@@ -558,7 +531,7 @@ func TestGetAvaliableVols(t *testing.T) {
 		Discards: []proto.Vid{1, 3, 5},
 	}
 	_, err = v.getAvailableVols(ctx, args3)
-	require.Error(t, err, errcode.ErrNoAvaliableVolume)
+	require.NoError(t, err)
 
 	// test alloc background
 	v.modeInfos[codemode.EC6P6].current.vols = []*volume{}
@@ -590,7 +563,7 @@ func TestAllocParallel(b *testing.T) {
 				VolumeInfoBase: cm.VolumeInfoBase{
 					Vid:      proto.Vid(i),
 					CodeMode: codemode.EC6P6,
-					Free:     16 * 1024 * 1024,
+					Free:     20 * 1024 * 1024,
 				},
 			},
 			ExpireTime: 100,

--- a/blobstore/proxy/allocator/volumemgr_test.go
+++ b/blobstore/proxy/allocator/volumemgr_test.go
@@ -442,7 +442,7 @@ func TestGetAvaliableVols(t *testing.T) {
 	v.modeInfos[codemode.EC6P6] = info
 
 	args := &proxy.AllocVolsArgs{
-		Fsize:    5 << 30,
+		Fsize:    1 << 30,
 		CodeMode: codemode.EC6P6,
 		BidCount: 1,
 		Excludes: nil,
@@ -458,7 +458,7 @@ func TestGetAvaliableVols(t *testing.T) {
 	require.Equal(t, []proto.Vid{1, 2, 3, 4, 5}, vids)
 
 	args2 := &proxy.AllocVolsArgs{
-		Fsize:    5 << 30,
+		Fsize:    1 << 30,
 		CodeMode: codemode.EC6P6,
 		BidCount: 1,
 		Excludes: nil,
@@ -473,7 +473,6 @@ func TestGetAvaliableVols(t *testing.T) {
 	require.Equal(t, []proto.Vid{1, 3, 5}, vids2)
 
 	args3 := &proxy.AllocVolsArgs{
-		Fsize:    5 << 30,
 		CodeMode: codemode.EC6P6,
 		BidCount: 1,
 		Excludes: nil,
@@ -543,7 +542,7 @@ func TestAllocParallel(b *testing.T) {
 		go func() {
 			vid, err := vm.allocVid(context.Background(),
 				&proxy.AllocVolsArgs{
-					Fsize:    1024,
+					Fsize:    1024 * 1024,
 					CodeMode: codemode.EC6P6,
 					BidCount: 1,
 				})

--- a/blobstore/scheduler/client/clustermgr.go
+++ b/blobstore/scheduler/client/clustermgr.go
@@ -123,6 +123,7 @@ type ClusterMgrAPI interface {
 //	for example:
 //		blob_delete-consume_offset-blob_delete-1
 //		shard_repair-consume_offset-shard_repair-2
+
 const (
 	_delimiter           = "-"
 	_migratingDiskPrefix = "migrating"
@@ -847,11 +848,12 @@ func (c *clustermgrClient) listAllMigrateTasks(ctx context.Context, prefix strin
 			Count:  defaultListTaskNum,
 			Marker: marker,
 		}
-		ret, marker, err := c.listMigrateTasks(ctx, taskType, args)
+		ret, newMarker, err := c.listMigrateTasks(ctx, taskType, args)
 		if err != nil {
 			return nil, err
 		}
 		tasks = append(tasks, ret...)
+		marker = newMarker
 		if marker == defaultListTaskMarker {
 			break
 		}


### PR DESCRIPTION
Bug Fix:

- Proxy: dead lock in allocation stage.
- Access: try last service host even if all were punished.
- Auditlog: use structured data directly to reduce the parsing process. #1913
- Auditlog:  no metric if there is no context-length in the request header. #2120
- RPC: correctly close response body. #2253
- Scheduler: fixup stuck when migrating task over 1000. #2267
