### PR TITLE
fix(metanode):  newMetaItemIterator nonidempotent with lock

### DIFF
--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -471,7 +471,7 @@ type metaPartition struct {
 	uidManager             *UidManager
 	xattrLock              sync.Mutex
 	mqMgr                  *MetaQuotaManager
-	nonIdempotent          sync.RWMutex
+	nonIdempotent          sync.Mutex
 	uniqChecker            *uniqChecker
 }
 
@@ -1110,7 +1110,7 @@ func (mp *metaPartition) ResponseLoadMetaPartition(p *Packet) (err error) {
 	resp.MaxInode = mp.GetCursor()
 	resp.InodeCount = uint64(mp.GetInodeTreeLen())
 	resp.DentryCount = uint64(mp.GetDentryTreeLen())
-	resp.ApplyID = mp.applyID
+	resp.ApplyID = mp.getApplyID()
 	if err != nil {
 		err = errors.Trace(err,
 			"[ResponseLoadMetaPartition] check snapshot")

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -46,6 +46,9 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		return
 	}
 
+	mp.nonIdempotent.Lock()
+	defer mp.nonIdempotent.Unlock()
+
 	switch msg.Op {
 	case opFSMCreateInode:
 		ino := NewInode(0, 0)
@@ -752,4 +755,8 @@ func (mp *metaPartition) submit(op uint32, data []byte) (resp interface{}, err e
 
 func (mp *metaPartition) uploadApplyID(applyId uint64) {
 	atomic.StoreUint64(&mp.applyID, applyId)
+}
+
+func (mp *metaPartition) getApplyID() (applyId uint64) {
+	return atomic.LoadUint64(&mp.applyID)
 }

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -95,8 +95,6 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 		}
 	}
 
-	mp.nonIdempotent.RLock()
-	defer mp.nonIdempotent.RUnlock()
 	if item, ok := mp.dentryTree.ReplaceOrInsert(dentry, false); !ok {
 		//do not allow directories and files to overwrite each
 		// other when renaming

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -112,6 +112,7 @@ func (mp *metaPartition) fsmCreateLinkInode(ino *Inode, uniqID uint64) (resp *In
 		resp.Status = proto.OpNotExistErr
 		return
 	}
+
 	resp.Msg = i
 	if !mp.uniqChecker.legalIn(uniqID) {
 		log.LogWarnf("fsmCreateLinkInode repeated, ino %v uniqID %v nlink %v", ino.Inode, uniqID, ino.GetNLink())

--- a/metanode/partition_item.go
+++ b/metanode/partition_item.go
@@ -188,12 +188,11 @@ func newMetaItemIterator(mp *metaPartition) (si *MetaItemIterator, err error) {
 	si = new(MetaItemIterator)
 	si.fileRootDir = mp.config.RootDir
 	si.SnapFormatVersion = mp.manager.metaNode.raftSyncSnapFormatVersion
-	si.applyID = mp.applyID
+	mp.nonIdempotent.Lock()
+	si.applyID = mp.getApplyID()
 	si.txId = mp.txProcessor.txManager.txIdAlloc.getTransactionID()
 	si.cursor = mp.GetCursor()
 	si.uniqID = mp.GetUniqId()
-
-	mp.nonIdempotent.Lock()
 	si.inodeTree = mp.inodeTree.GetTree()
 	si.dentryTree = mp.dentryTree.GetTree()
 	si.extendTree = mp.extendTree.GetTree()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. fix newMetaItemIterator nonidempotent bug when it is running concurrently with fsm apply
2. use sync.Mutex much better than RWMutex, there is no concurrency reads

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2222 #1580 
