### PR TITLE
feature(scheduler): batch consume kafka msg, kafka server manages offset

### DIFF
--- a/blobstore/scheduler/base_mock_test.go
+++ b/blobstore/scheduler/base_mock_test.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	sarama "github.com/Shopify/sarama"
-	proto "github.com/cubefs/cubefs/blobstore/common/proto"
 	base "github.com/cubefs/cubefs/blobstore/scheduler/base"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -37,18 +36,18 @@ func (m *MockKafkaConsumer) EXPECT() *MockKafkaConsumerMockRecorder {
 }
 
 // StartKafkaConsumer mocks base method.
-func (m *MockKafkaConsumer) StartKafkaConsumer(arg0 proto.TaskType, arg1 string, arg2 func(*sarama.ConsumerMessage, base.ConsumerPause) bool) (base.GroupConsumer, error) {
+func (m *MockKafkaConsumer) StartKafkaConsumer(arg0 base.KafkaConsumerCfg, arg1 func([]*sarama.ConsumerMessage, base.ConsumerPause) bool) (base.GroupConsumer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartKafkaConsumer", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "StartKafkaConsumer", arg0, arg1)
 	ret0, _ := ret[0].(base.GroupConsumer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StartKafkaConsumer indicates an expected call of StartKafkaConsumer.
-func (mr *MockKafkaConsumerMockRecorder) StartKafkaConsumer(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockKafkaConsumerMockRecorder) StartKafkaConsumer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartKafkaConsumer", reflect.TypeOf((*MockKafkaConsumer)(nil).StartKafkaConsumer), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartKafkaConsumer", reflect.TypeOf((*MockKafkaConsumer)(nil).StartKafkaConsumer), arg0, arg1)
 }
 
 // MockGroupConsumer is a mock of GroupConsumer interface.

--- a/blobstore/scheduler/blob_deleter_test.go
+++ b/blobstore/scheduler/blob_deleter_test.go
@@ -86,7 +86,11 @@ func newBlobDeleteMgr(t *testing.T) *BlobDeleteMgr {
 		delFailCounterByMin:    &counter.Counter{},
 
 		Closer: closer.New(),
-		cfg:    &BlobDeleteConfig{MessagePunishThreshold: defaultMessagePunishThreshold},
+		cfg: &BlobDeleteConfig{
+			MessagePunishThreshold: defaultMessagePunishThreshold,
+			MaxBatchSize:           defaultMaxBatchSize,
+			BatchIntervalS:         1,
+		},
 	}
 }
 
@@ -98,18 +102,17 @@ func TestBlobDeleteConsume(t *testing.T) {
 	defer commonCloser.Close()
 	{
 		// return invalid message
+		kafkaMsgs := make([]*sarama.ConsumerMessage, 2)
 		msg := proto.DeleteMsg{}
 		msgByte, _ := json.Marshal(msg)
 		kafkaMsg := &sarama.ConsumerMessage{
 			Value: msgByte,
 		}
-		success := mgr.Consume(kafkaMsg, commonCloser)
-		require.True(t, success)
-
-		kafkaMsg = &sarama.ConsumerMessage{
+		kafkaMsgs[0] = kafkaMsg
+		kafkaMsgs[1] = &sarama.ConsumerMessage{
 			Value: []byte("123"),
 		}
-		success = mgr.Consume(kafkaMsg, commonCloser)
+		success := mgr.Consume(kafkaMsgs, commonCloser)
 		require.True(t, success)
 	}
 	{
@@ -131,7 +134,8 @@ func TestBlobDeleteConsume(t *testing.T) {
 		kafkaMsg := &sarama.ConsumerMessage{
 			Value: msgByte,
 		}
-		success := mgr.Consume(kafkaMsg, commonCloser)
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		success := mgr.Consume(kafkaMsgs, commonCloser)
 		require.True(t, success)
 		mgr.clusterTopology = oldClusterTopology
 	}
@@ -157,7 +161,8 @@ func TestBlobDeleteConsume(t *testing.T) {
 		kafkaMsg := &sarama.ConsumerMessage{
 			Value: msgByte,
 		}
-		success := mgr.Consume(kafkaMsg, commonCloser)
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		success := mgr.Consume(kafkaMsgs, commonCloser)
 		require.True(t, success)
 		mgr.clusterTopology = oldClusterTopology
 		mgr.blobnodeCli = oldBlobNode
@@ -193,7 +198,8 @@ func TestBlobDeleteConsume(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 			closer.Close()
 		}()
-		success := mgr.Consume(kafkaMsg, closer)
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		success := mgr.Consume(kafkaMsgs, closer)
 		require.False(t, success)
 		mgr.clusterTopology = oldClusterTopology
 	}
@@ -544,7 +550,7 @@ func TestNewDeleteMgr(t *testing.T) {
 	kafkaClient := NewMockKafkaConsumer(ctr)
 	consumer := NewMockGroupConsumer(ctr)
 	consumer.EXPECT().Stop().AnyTimes().Return()
-	kafkaClient.EXPECT().StartKafkaConsumer(any, any, any).AnyTimes().Return(consumer, nil)
+	kafkaClient.EXPECT().StartKafkaConsumer(any, any).AnyTimes().Return(consumer, nil)
 
 	mgr, err := NewBlobDeleteMgr(blobCfg, clusterTopology, switchMgr, blobnodeCli, kafkaClient)
 	require.NoError(t, err)

--- a/blobstore/scheduler/config.go
+++ b/blobstore/scheduler/config.go
@@ -26,12 +26,11 @@ import (
 )
 
 const (
-	defaultTopologyUpdateIntervalMin   = 1
-	defaultVolumeCacheUpdateIntervalS  = 10
-	defaultRetryHostsCnt               = 1
-	defaultClientTimeoutMs             = int64(1000)
-	defaultHostSyncIntervalMs          = int64(1000)
-	defaultKafkaOffsetCommitIntervalMs = 1000
+	defaultTopologyUpdateIntervalMin  = 1
+	defaultVolumeCacheUpdateIntervalS = 10
+	defaultRetryHostsCnt              = 1
+	defaultClientTimeoutMs            = int64(1000)
+	defaultHostSyncIntervalMs         = int64(1000)
 
 	defaultMaxDiskFreeChunkCnt = int64(1024)
 	defaultMinDiskFreeChunkCnt = int64(20)
@@ -49,6 +48,8 @@ const (
 	defaultDeleteLogChunkSize     = uint(29)
 	defaultDeleteDelayH           = int64(72)
 	defaultDeleteNoDelay          = int64(0)
+	defaultMaxBatchSize           = 10
+	defaultBatchIntervalSec       = 2
 
 	defaultTickInterval   = uint32(1)
 	defaultHeartbeatTicks = uint32(30)
@@ -128,7 +129,6 @@ type Topics struct {
 type KafkaConfig struct {
 	BrokerList             []string `json:"broker_list"`
 	Topics                 Topics   `json:"topics"`
-	CommitIntervalMs       int      `json:"commit_interval_ms"`
 	FailMsgSenderTimeoutMs int64    `json:"fail_msg_sender_timeout_ms"`
 }
 
@@ -207,7 +207,6 @@ func (c *Config) fixKafkaConfig() {
 	defaulter.Empty(&c.Kafka.Topics.BlobDelete, defaultBlobDeleteNormalTopic)
 	defaulter.Empty(&c.Kafka.Topics.BlobDeleteFailed, defaultBlobDeleteFailedTopic)
 	defaulter.Empty(&c.Kafka.Topics.ShardRepairFailed, defaultShardRepairFailedTopic)
-	defaulter.LessOrEqual(&c.Kafka.CommitIntervalMs, defaultKafkaOffsetCommitIntervalMs)
 	defaulter.LessOrEqual(&c.Kafka.FailMsgSenderTimeoutMs, defaultClientTimeoutMs)
 	if len(c.Kafka.Topics.ShardRepair) == 0 {
 		c.Kafka.Topics.ShardRepair = []string{defaultShardRepairNormalTopic, defaultShardRepairPriorityTopic}
@@ -273,6 +272,8 @@ func (c *Config) fixBlobDeleteConfig() error {
 	defaulter.LessOrEqual(&c.BlobDelete.MessagePunishTimeM, defaultMessagePunishTimeM)
 	defaulter.Equal(&c.BlobDelete.SafeDelayTimeH, defaultDeleteDelayH)
 	defaulter.Less(&c.BlobDelete.SafeDelayTimeH, defaultDeleteNoDelay)
+	defaulter.Equal(&c.BlobDelete.MaxBatchSize, defaultMaxBatchSize)
+	defaulter.Equal(&c.BlobDelete.BatchIntervalS, defaultBatchIntervalSec)
 	c.BlobDelete.Kafka.BrokerList = c.Kafka.BrokerList
 	c.BlobDelete.Kafka.FailMsgSenderTimeoutMs = c.Kafka.FailMsgSenderTimeoutMs
 	c.BlobDelete.Kafka.TopicNormal = c.Kafka.Topics.BlobDelete

--- a/blobstore/scheduler/shard_repairer_test.go
+++ b/blobstore/scheduler/shard_repairer_test.go
@@ -57,7 +57,7 @@ func newShardRepairMgr(t *testing.T) *ShardRepairMgr {
 	kafkaClient := NewMockKafkaConsumer(ctr)
 	consumer := NewMockGroupConsumer(ctr)
 	consumer.EXPECT().Stop().AnyTimes().Return()
-	kafkaClient.EXPECT().StartKafkaConsumer(any, any, any).AnyTimes().Return(consumer, nil)
+	kafkaClient.EXPECT().StartKafkaConsumer(any, any).AnyTimes().Return(consumer, nil)
 
 	orphanShardLog := mocks.NewMockRecordLogEncoder(ctr)
 	orphanShardLog.EXPECT().Encode(any).AnyTimes().Return(nil)
@@ -82,7 +82,9 @@ func newShardRepairMgr(t *testing.T) *ShardRepairMgr {
 		errStatsDistribution:    base.NewErrorStats(),
 		repairSuccessCounterMin: &counter.Counter{},
 		repairFailedCounterMin:  &counter.Counter{},
-		cfg:                     &ShardRepairConfig{MessagePunishThreshold: defaultMessagePunishThreshold},
+		cfg: &ShardRepairConfig{
+			MessagePunishThreshold: defaultMessagePunishThreshold,
+		},
 	}
 }
 
@@ -102,18 +104,21 @@ func TestConsumerShardRepairMsg(t *testing.T) {
 		kafkaMsg := &sarama.ConsumerMessage{
 			Value: []byte("123"),
 		}
-		require.True(t, mgr.Consume(kafkaMsg, commonCloser))
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		require.True(t, mgr.Consume(kafkaMsgs, commonCloser))
 
 		msg := proto.ShardRepairMsg{}
 		msgByte, _ := json.Marshal(msg)
 		kafkaMsg = &sarama.ConsumerMessage{
 			Value: msgByte,
 		}
-		require.True(t, mgr.Consume(kafkaMsg, commonCloser))
+		kafkaMsgs = []*sarama.ConsumerMessage{kafkaMsg}
+		require.True(t, mgr.Consume(kafkaMsgs, commonCloser))
 	}
 	{
 		// repair success
-		require.True(t, mgr.Consume(kafkaMsg, commonCloser))
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		require.True(t, mgr.Consume(kafkaMsgs, commonCloser))
 	}
 	{
 		// repair failed
@@ -121,14 +126,16 @@ func TestConsumerShardRepairMsg(t *testing.T) {
 		blobnode := NewMockBlobnodeAPI(ctr)
 		blobnode.EXPECT().RepairShard(any, any, any).AnyTimes().Return(errMock)
 		mgr.blobnodeCli = blobnode
-		require.True(t, mgr.Consume(kafkaMsg, commonCloser))
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		require.True(t, mgr.Consume(kafkaMsgs, commonCloser))
 		mgr.blobnodeCli = oldBlobnode
 	}
 	{
 		// consume undo
 		consuming := closer.New()
 		consuming.Close()
-		require.False(t, mgr.Consume(kafkaMsg, consuming))
+		kafkaMsgs := []*sarama.ConsumerMessage{kafkaMsg}
+		require.False(t, mgr.Consume(kafkaMsgs, consuming))
 	}
 	{
 		// repair success
@@ -240,7 +247,7 @@ func TestNewShardRepairMgr(t *testing.T) {
 	kafkaClient := NewMockKafkaConsumer(ctr)
 	consumer := NewMockGroupConsumer(ctr)
 	consumer.EXPECT().Stop().AnyTimes().Return()
-	kafkaClient.EXPECT().StartKafkaConsumer(any, any, any).AnyTimes().Return(consumer, nil)
+	kafkaClient.EXPECT().StartKafkaConsumer(any, any).AnyTimes().Return(consumer, nil)
 
 	mgr, err := NewShardRepairMgr(cfg, clusterTopology, switchMgr, blobnode, clusterCli, kafkaClient)
 	require.NoError(t, err)

--- a/blobstore/scheduler/startup.go
+++ b/blobstore/scheduler/startup.go
@@ -118,7 +118,8 @@ func NewService(conf *Config) (svr *Service, err error) {
 	}
 	topologyMgr := NewClusterTopologyMgr(clusterMgrCli, topoConf)
 
-	kafkaClient := base.NewKafkaConsumer(conf.Kafka.BrokerList, time.Duration(conf.Kafka.CommitIntervalMs)*time.Millisecond, clusterMgrCli)
+	offsetMgr := base.NewKafkaOffsetMgr()
+	kafkaClient := base.NewKafkaConsumer(conf.Kafka.BrokerList, offsetMgr)
 	shardRepairMgr, err := NewShardRepairMgr(&conf.ShardRepair, topologyMgr, switchMgr, blobnodeCli, clusterMgrCli, kafkaClient)
 	if err != nil {
 		log.Errorf("new shard repair mgr: cfg[%+v], err[%w]", conf.ShardRepair, err)
@@ -149,7 +150,7 @@ func NewService(conf *Config) (svr *Service, err error) {
 		return
 	}
 
-	err = svr.NewKafkaMonitor(conf.ClusterID, clusterMgrCli)
+	err = svr.NewKafkaMonitor(conf.ClusterID, offsetMgr)
 	if err != nil {
 		log.Errorf("run kafka monitor failed: err[%w]", err)
 		return nil, err

--- a/docs-zh/source/maintenance/configs/blobstore/scheduler.md
+++ b/docs-zh/source/maintenance/configs/blobstore/scheduler.md
@@ -220,6 +220,8 @@ v3.3.0版本开始支持配置数据删除时间段。
 * message_punish_time_m，惩罚时间，默认10分钟
 * delete_log，删除日志保留目录，需要配置，chunkbits默认为29
 * delete_hour_range，支持配置删除时间段，24小时制，比如以下配置表示凌晨1点到3点中间时间段才会发起删除请求，如果不配置默认全天删除
+* max_batch_size, 批量消费kafka消息的大小，默认10; 如果batch大小已满或已经达到时间间隔，则消费在此期间累积的Kafka消息
+* batch_interval_s, 消费kafka消息的最大间隔，默认2秒
 ```json
 {
   "task_pool_size": 400,
@@ -230,6 +232,8 @@ v3.3.0版本开始支持配置数据删除时间段。
     "from": 1,
     "to": 3
   },
+  "max_batch_size": 10,
+  "batch_interval_s": 2,
   "delete_log": {
     "dir": "/home/service/scheduler/_package/delete_log",
     "chunkbits": 29

--- a/docs-zh/source/user-guide/blobstore.md
+++ b/docs-zh/source/user-guide/blobstore.md
@@ -185,6 +185,8 @@ nohup ./scheduler -f scheduler.conf &
      "broker_list": ["127.0.0.1:9092"]
    },
    "blob_delete": {
+     "max_batch_size": 10,
+     "batch_interval_s": 2,
      "delete_log": {
        "dir": "./run/delete_log"
      }

--- a/docs/source/maintenance/configs/blobstore/scheduler.md
+++ b/docs/source/maintenance/configs/blobstore/scheduler.md
@@ -222,6 +222,8 @@ Starting from version v3.3.0, it is supported to configure the data deletion tim
 * message_punish_time_m, punishment time, default 10 minutes
 * delete_log, directory for storing deletion logs, needs to be configured, chunkbits default is 29
 * delete_hour_range, supports configuring the deletion time period in 24-hour format. For example, the following configuration indicates that deletion requests will only be initiated during the time period between 1:00 a.m. and 3:00 a.m. If not configured, deletion will be performed all day.
+* max_batch_size, batch consumption size of kafka messages, default is 10. If the batch is full or the time interval is reached, consume the Kafka messages accumulated during this period
+* batch_interval_s, time interval for consuming kafka messages, default is 2s
 ```json
 {
   "task_pool_size": 400,
@@ -232,6 +234,8 @@ Starting from version v3.3.0, it is supported to configure the data deletion tim
     "from": 1,
     "to": 3
   },
+  "max_batch_size": 10,
+  "batch_interval_s": 2,
   "delete_log": {
     "dir": "/home/service/scheduler/_package/delete_log",
     "chunkbits": 29

--- a/docs/source/user-guide/blobstore.md
+++ b/docs/source/user-guide/blobstore.md
@@ -186,6 +186,8 @@ nohup ./scheduler -f scheduler.conf &
      "broker_list": ["127.0.0.1:9092"]
    },
    "blob_delete": {
+     "max_batch_size": 10,
+     "batch_interval_s": 2,
      "delete_log": {
        "dir": "./run/delete_log"
      }


### PR DESCRIPTION
1. add batch consume kafka msg for scheduler, to solve handle blob delete msg too slow.
2. remove kafka client manage offset local, let kafka server manage offset.