### PR TITLE
fix(proxy): if proxy have no available volumes, should send a request to clustermgr

### DIFF
--- a/blobstore/cli/blobnode/shard.go
+++ b/blobstore/cli/blobnode/shard.go
@@ -83,4 +83,34 @@ func addCmdShard(cmd *grumble.Command) {
 			return nil
 		},
 	})
+
+	chunkCommand.AddCommand(&grumble.Command{
+		Name: "mark",
+		Help: "mark delete is dangerous operation, execute with caution",
+		Flags: func(f *grumble.Flags) {
+			blobnodeFlags(f)
+		},
+		Args: func(c *grumble.Args) {
+			c.Uint64("diskid", "disk id")
+			c.Uint64("vuid", "vuid")
+			c.Uint64("bid", "bid")
+		},
+		Run: func(c *grumble.Context) error {
+			cli := blobnode.New(&blobnode.Config{})
+			host := c.Flags.String("host")
+			args := blobnode.DeleteShardArgs{
+				DiskID: proto.DiskID(c.Args.Uint64("diskid")),
+				Vuid:   proto.Vuid(c.Args.Uint64("vuid")),
+				Bid:    proto.BlobID(c.Args.Uint64("bid")),
+			}
+			if !common.Confirm("to mark delete?") {
+				return nil
+			}
+			if err := cli.MarkDeleteShard(common.CmdContext(), host, &args); err != nil {
+				return err
+			}
+			fmt.Println("mark delete success")
+			return nil
+		},
+	})
 }

--- a/blobstore/proxy/allocator/volumemgr.go
+++ b/blobstore/proxy/allocator/volumemgr.go
@@ -467,6 +467,7 @@ func (v *volumeMgr) getAvailableVols(ctx context.Context, args *proxy.AllocVolsA
 
 	needSwitch, err := info.needSwitchToBackup(int64(args.Fsize))
 	if err != nil {
+		v.allocNotify(ctx, args.CodeMode, v.DefaultAllocVolsNum, true)
 		span.Errorf("no available volumes to alloc and current allocating from clustermgr")
 		return nil, err
 	}

--- a/blobstore/proxy/allocator/volumemgr_test.go
+++ b/blobstore/proxy/allocator/volumemgr_test.go
@@ -416,6 +416,8 @@ func TestAllocVolumeFailed(t *testing.T) {
 		Excludes: nil,
 		Discards: nil,
 	}
+	vm.allocChs = make(map[codemode.CodeMode]chan *allocArgs)
+	vm.allocChs[codemode.EC6P6] = make(chan *allocArgs)
 	_, err = vm.allocVid(ctx, args)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errcode.ErrNoAvaliableVolume)


### PR DESCRIPTION
1. if proxy have no available volumes, should send a request to clustermgr
2. add mark delete function in cli for blobnode, to solve delete failed in result of unexpected occasion