### PR TITLE
fix(scheduler): kafka offset metric is not accurate,update kafka offset getter

### DIFF
--- a/blobstore/common/kafka/monitor.go
+++ b/blobstore/common/kafka/monitor.go
@@ -99,6 +99,7 @@ type Monitor struct {
 	closer.Closer
 	clusterID                   proto.ClusterID
 	kafkaClient                 sarama.Client
+	kafkaAdmCli                 sarama.ClusterAdmin
 	topic                       string
 	pids                        []int32
 	newestOffsetMap             *offsetMap
@@ -144,6 +145,12 @@ func NewKafkaMonitor(
 			return nil, err
 		}
 		monitor.kafkaClient = client
+
+		adminCli, err := sarama.NewClusterAdmin(brokerHosts, nil)
+		if err != nil {
+			return nil, err
+		}
+		monitor.kafkaAdmCli = adminCli
 	}
 
 	monitor.offsetGauge = newKafkaOffsetGauge()
@@ -157,16 +164,26 @@ func NewKafkaMonitor(
 func (monitor *Monitor) loopAcquireKafkaOffset() {
 	ticker := time.NewTicker(time.Duration(monitor.kafkaOffAcquireIntervalSecs) * time.Second)
 	defer ticker.Stop()
+	groupID := fmt.Sprintf("%s-%s", proto.ServiceNameScheduler, monitor.topic)
 
 	for {
 		select {
 		case <-ticker.C:
-			for _, pid := range monitor.pids {
-				if err := monitor.update(pid); err != nil {
-					continue
+			offsets, err := monitor.kafkaAdmCli.ListConsumerGroupOffsets(groupID, map[string][]int32{monitor.topic: monitor.pids})
+			if err != nil {
+				log.Errorf("get consume offset failed: topic[%s], pids[%+v]", monitor.topic, monitor.pids)
+				continue
+			}
+
+			for _, partitionOffsets := range offsets.Blocks {
+				for partition, consumeOffset := range partitionOffsets {
+					if err := monitor.update(partition, consumeOffset.Offset); err != nil {
+						continue
+					}
 				}
 			}
 			monitor.report()
+
 		case <-monitor.Closer.Done():
 			monitor.report()
 			return
@@ -174,7 +191,7 @@ func (monitor *Monitor) loopAcquireKafkaOffset() {
 	}
 }
 
-func (monitor *Monitor) update(pid int32) error {
+func (monitor *Monitor) update(pid int32, consumerOffet int64) error {
 	newestOffset, err := monitor.kafkaClient.GetOffset(monitor.topic, pid, sarama.OffsetNewest)
 	if err != nil {
 		log.Errorf("get newest offset failed: topic[%s], pid[%d]", monitor.topic, pid)
@@ -188,6 +205,8 @@ func (monitor *Monitor) update(pid int32) error {
 		return err
 	}
 	monitor.oldestOffsetMap.setOffset(oldestOffset, pid)
+
+	monitor.consumeOffsetMap.setOffset(consumerOffet, pid)
 	return nil
 }
 
@@ -197,7 +216,7 @@ func (monitor *Monitor) report() {
 		newestOffset := monitor.newestOffsetMap.getOffset(pid)
 		consumeOffset := monitor.consumeOffsetMap.getOffset(pid)
 		latency := int64(0)
-		if consumeOffset < oldestOffset && consumeOffset < 0 { // means not consumed yet
+		if consumeOffset < oldestOffset && consumeOffset <= 0 { // means not consumed yet
 			latency = newestOffset - oldestOffset - 1 //-1，because the newestOffset is the next message offset
 		} else {
 			latency = newestOffset - consumeOffset - 1
@@ -232,8 +251,4 @@ func (monitor *Monitor) reportLatencyMetric(pid int32, val float64) {
 		"partition":   fmt.Sprintf("%d", pid),
 	}
 	monitor.latencyGauge.With(labels).Set(val)
-}
-
-func (monitor *Monitor) SetConsumeOffset(consumerOff int64, pid int32) {
-	monitor.consumeOffsetMap.setOffset(consumerOff, pid)
 }

--- a/blobstore/common/kafka/monitor_test.go
+++ b/blobstore/common/kafka/monitor_test.go
@@ -15,13 +15,7 @@
 package kafka
 
 import (
-	"testing"
-	"time"
-
 	"github.com/Shopify/sarama"
-	"github.com/stretchr/testify/require"
-
-	"github.com/cubefs/cubefs/blobstore/common/proto"
 )
 
 type MockKafkaClient struct{}
@@ -107,20 +101,4 @@ func (c *MockKafkaClient) Close() error {
 
 func (c *MockKafkaClient) Closed() bool {
 	return true
-}
-
-func TestSetConsumeOffset(t *testing.T) {
-	brokens := []string{"127.0.01:9092"}
-	mockTestKafkaClient = &MockKafkaClient{}
-	monitor, _ := NewKafkaMonitor(proto.ClusterID(1), "", brokens, "Test_monitor", []int32{0, 1, 2}, 1)
-	monitor.SetConsumeOffset(1, 1)
-	err := monitor.update(0)
-	require.NoError(t, err)
-	err = monitor.update(1)
-	require.NoError(t, err)
-	err = monitor.update(2)
-	require.NoError(t, err)
-	monitor.report()
-	time.Sleep(time.Second + 10*time.Microsecond)
-	monitor.Close()
 }

--- a/blobstore/scheduler/base/base_test.go
+++ b/blobstore/scheduler/base/base_test.go
@@ -15,12 +15,10 @@
 package base
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/Shopify/sarama"
 
-	"github.com/cubefs/cubefs/blobstore/common/proto"
 	_ "github.com/cubefs/cubefs/blobstore/testing/nolog"
 )
 
@@ -47,27 +45,4 @@ func newBroker(t *testing.T) *sarama.MockBroker {
 	})
 
 	return broker
-}
-
-type mockAccess struct {
-	offsets map[string]int64
-	err     error
-}
-
-func newMockAccess(err error) *mockAccess {
-	return &mockAccess{
-		offsets: make(map[string]int64),
-		err:     err,
-	}
-}
-
-func (m *mockAccess) SetConsumeOffset(taskType proto.TaskType, topic string, partition int32, offset int64) error {
-	key := fmt.Sprintf("%s_%d", topic, partition)
-	m.offsets[key] = offset
-	return m.err
-}
-
-func (m *mockAccess) GetConsumeOffset(taskType proto.TaskType, topic string, partition int32) (int64, error) {
-	key := fmt.Sprintf("%s_%d", topic, partition)
-	return m.offsets[key], m.err
 }

--- a/blobstore/scheduler/base/kafka_consumer_group_test.go
+++ b/blobstore/scheduler/base/kafka_consumer_group_test.go
@@ -79,7 +79,7 @@ func TestConsumer(t *testing.T) {
 		wg.Add(batchNum)
 		offset := int64(0)
 
-		cli := NewKafkaConsumer([]string{broker.Addr()}, newMockAccess(nil))
+		cli := NewKafkaConsumer([]string{broker.Addr()})
 		consumer, err := cli.StartKafkaConsumer(KafkaConsumerCfg{
 			TaskType:     proto.TaskTypeShardRepair,
 			Topic:        testTopic,
@@ -104,7 +104,7 @@ func TestConsumer(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Add(batchNum)
 
-		cli := NewKafkaConsumer([]string{broker.Addr()}, newMockAccess(nil))
+		cli := NewKafkaConsumer([]string{broker.Addr()})
 		consumer, err := cli.StartKafkaConsumer(KafkaConsumerCfg{
 			TaskType:     proto.TaskTypeBlobDelete,
 			Topic:        testTopic,

--- a/blobstore/scheduler/base/kafka_monitor_test.go
+++ b/blobstore/scheduler/base/kafka_monitor_test.go
@@ -30,14 +30,11 @@ func TestNewKafkaTopicMonitor(t *testing.T) {
 		BrokerList: []string{broker.Addr()},
 	}
 
-	access := newMockAccess(nil)
-	monitor, err := NewKafkaTopicMonitor(proto.TaskTypeBlobDelete, 1, cfg, access, 0)
+	monitor, err := NewKafkaTopicMonitor(proto.TaskTypeBlobDelete, 1, cfg)
 	require.NoError(t, err)
-	go func() {
-		monitor.Run()
-	}()
+	require.NotNil(t, monitor.monitor)
 
 	cfg.BrokerList = []string{}
-	_, err = NewKafkaTopicMonitor(proto.TaskTypeBlobDelete, 1, cfg, access, 0)
+	_, err = NewKafkaTopicMonitor(proto.TaskTypeBlobDelete, 1, cfg)
 	require.Error(t, err)
 }

--- a/blobstore/scheduler/config.go
+++ b/blobstore/scheduler/config.go
@@ -44,7 +44,8 @@ const (
 	defaultTaskPoolSize           = 10
 	defaultDeleteHourRangeTo      = 24
 	defaultMessagePunishThreshold = 3
-	defaultMessagePunishTimeM     = 10
+	defaultMessagePunishTimeM     = 4
+	defaultSlowDownTimeS          = 3
 	defaultDeleteLogChunkSize     = uint(29)
 	defaultDeleteDelayH           = int64(72)
 	defaultDeleteNoDelay          = int64(0)
@@ -270,6 +271,7 @@ func (c *Config) fixBlobDeleteConfig() error {
 	defaulter.LessOrEqual(&c.BlobDelete.DeleteLog.ChunkBits, defaultDeleteLogChunkSize)
 	defaulter.LessOrEqual(&c.BlobDelete.MessagePunishThreshold, defaultMessagePunishThreshold)
 	defaulter.LessOrEqual(&c.BlobDelete.MessagePunishTimeM, defaultMessagePunishTimeM)
+	defaulter.LessOrEqual(&c.BlobDelete.MessageSlowDownTimeS, defaultSlowDownTimeS)
 	defaulter.Equal(&c.BlobDelete.SafeDelayTimeH, defaultDeleteDelayH)
 	defaulter.Less(&c.BlobDelete.SafeDelayTimeH, defaultDeleteNoDelay)
 	defaulter.Equal(&c.BlobDelete.MaxBatchSize, defaultMaxBatchSize)

--- a/blobstore/scheduler/startup.go
+++ b/blobstore/scheduler/startup.go
@@ -118,8 +118,7 @@ func NewService(conf *Config) (svr *Service, err error) {
 	}
 	topologyMgr := NewClusterTopologyMgr(clusterMgrCli, topoConf)
 
-	offsetMgr := base.NewKafkaOffsetMgr()
-	kafkaClient := base.NewKafkaConsumer(conf.Kafka.BrokerList, offsetMgr)
+	kafkaClient := base.NewKafkaConsumer(conf.Kafka.BrokerList)
 	shardRepairMgr, err := NewShardRepairMgr(&conf.ShardRepair, topologyMgr, switchMgr, blobnodeCli, clusterMgrCli, kafkaClient)
 	if err != nil {
 		log.Errorf("new shard repair mgr: cfg[%+v], err[%w]", conf.ShardRepair, err)
@@ -150,12 +149,11 @@ func NewService(conf *Config) (svr *Service, err error) {
 		return
 	}
 
-	err = svr.NewKafkaMonitor(conf.ClusterID, offsetMgr)
+	err = svr.NewKafkaMonitor(conf.ClusterID)
 	if err != nil {
 		log.Errorf("run kafka monitor failed: err[%w]", err)
 		return nil, err
 	}
-	svr.RunKafkaMonitors()
 
 	// all migrate manager
 	taskLogger, err := recordlog.NewEncoder(&conf.TaskLog)
@@ -266,25 +264,21 @@ func (svr *Service) RunTask() error {
 	return nil
 }
 
-func (svr *Service) NewKafkaMonitor(clusterID proto.ClusterID, access base.IConsumerOffset) error {
+func (svr *Service) NewKafkaMonitor(clusterID proto.ClusterID) error {
 	// blob delete
 	brokerList := conf.Kafka.BrokerList
-	if err := svr.newMonitor(proto.TaskTypeBlobDelete, clusterID, conf.BlobDelete.topics(),
-		brokerList, access); err != nil {
+	if err := svr.newMonitor(proto.TaskTypeBlobDelete, clusterID, conf.BlobDelete.topics(), brokerList); err != nil {
 		return err
 	}
 
 	// shard repair
-	return svr.newMonitor(proto.TaskTypeShardRepair, clusterID, conf.ShardRepair.topics(),
-		brokerList, access)
+	return svr.newMonitor(proto.TaskTypeShardRepair, clusterID, conf.ShardRepair.topics(), brokerList)
 }
 
-func (svr *Service) newMonitor(taskType proto.TaskType, clusterID proto.ClusterID,
-	topics []string, brokerList []string, access base.IConsumerOffset) error {
-	monitorIntervalS := 1
+func (svr *Service) newMonitor(taskType proto.TaskType, clusterID proto.ClusterID, topics []string, brokerList []string) error {
 	for _, topic := range topics {
 		cfg := &base.KafkaConfig{BrokerList: brokerList, Topic: topic}
-		m, err := base.NewKafkaTopicMonitor(taskType, clusterID, cfg, access, monitorIntervalS)
+		m, err := base.NewKafkaTopicMonitor(taskType, clusterID, cfg)
 		if err != nil {
 			log.Errorf("new kafka topic monitor topic failed: topic[%s], err[%+v]", topic, err)
 			return err
@@ -292,14 +286,6 @@ func (svr *Service) newMonitor(taskType proto.TaskType, clusterID proto.ClusterI
 		svr.kafkaMonitors = append(svr.kafkaMonitors, m)
 	}
 	return nil
-}
-
-func (svr *Service) RunKafkaMonitors() {
-	for _, monitor := range svr.kafkaMonitors {
-		go func(monitor *base.KafkaTopicMonitor) {
-			monitor.Run()
-		}(monitor)
-	}
 }
 
 func (svr *Service) CloseKafkaMonitors() {

--- a/blobstore/scheduler/startup_test.go
+++ b/blobstore/scheduler/startup_test.go
@@ -202,7 +202,7 @@ func TestServer(t *testing.T) {
 	kafkaOffset.EXPECT().GetConsumeOffset(any, any, any).AnyTimes().Return(int64(0), nil)
 	kafkaOffset.EXPECT().SetConsumeOffset(any, any, any, any).AnyTimes().Return(nil)
 
-	err := leaderServer.NewKafkaMonitor(proto.ClusterID(1), kafkaOffset)
+	err := leaderServer.NewKafkaMonitor(proto.ClusterID(1))
 	require.Error(t, err)
 
 	hosts := []string{leaderHost, followerHost}


### PR DESCRIPTION
**What this PR does / why we need it:**

1. The original version was ok, and it summarized all kafka partitions on CM, and the master scheduler node could get the offset/latency of all partitions at once
2. A bug was introduced in the previous version, which was that scheduler only recorded a few partitions in its own node consumption group and could not get all partition information. In this way, the master scheduler cannot be reported in aggregate, if the offset records of other partitions are through http get, or if each scheduler is reported metric separately: the Kafka consumption group will be reassigned when the node restarts, resulting in an inaccurate offset.
3. If kafka messages are consumed too quickly, resulting in a blobnode disk overload error, speed limits are required

-  Now, this version fixes the bug, and changes to the master node using kafka's admin client to obtain all the offset information of all partitions at once, and reports it at once, similar to the original implementation, but handed over to kafka unified management. (Kafka offset metirc and latency is not accurate, only a portion of all partitions can be obtained)
- this version support: If kafka messages are consumed too quickly, resulting in a blobnode disk overload error, then slow down it 

``` shell
---Scheduler Node 1---
[service@ebs-bench-test-meta1 ~]$ curl 127.0.0.1:9800/stats | jq
...show blob_delete success_per_min
blob_delete:  It can complete 55,000 kafka messages in less than 4 minutes

[service@ebs-bench-test-meta1 ~]$ curl 127.0.0.1:9800/metrics | grep kafka_topic_partition_consume_lag
...Show more accurate kafka offsets and delays 

---Scheduler Node 2---
[service@ebs-bench-test-meta2 ~]$ curl 127.0.0.1:9800/stats | jq
blob_delete:  It can complete 55,000 kafka messages in less than 5 minutes
```

**Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):**

fixes https://github.com/cubefs/cubefs/issues/2303

**Special notes for your reviewer:**

Please contract me if the pull request passed your review, and I will rebase and rearrange commit points.

**Release note:**