### PR TITLE
fix(meta): (1) CreateInodeLink() use uniqId; (2) Adjust sequence number of opFSMxxx in metanode\const.go

### DIFF
--- a/metanode/const.go
+++ b/metanode/const.go
@@ -160,16 +160,14 @@ const (
 	opFSMTxRbDentrySnapshot = 54
 
 	//quota
-	opFSMCreateInodeQuota = 55
+	opFSMCreateInodeQuota      = 55
+	opFSMSetInodeQuotaBatch    = 56
+	opFSMDeleteInodeQuotaBatch = 57
 
-	opFSMSnapFormatVersion = 56
-	opFSMApplyId           = 57
-	opFSMTxId              = 58
-	opFSMCursor            = 59
-
-	// quota batch
-	opFSMSetInodeQuotaBatch    = 60
-	opFSMDeleteInodeQuotaBatch = 61
+	opFSMSnapFormatVersion = 58
+	opFSMApplyId           = 59
+	opFSMTxId              = 60
+	opFSMCursor            = 61
 
 	// uniq checker
 	opFSMUniqID              = 62


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The uniqId feature is introduced recently, refer to https://github.com/cubefs/cubefs/pull/2283
But there were some problems merging the code, now fix them：
(1) CreateInodeLink() use uniqId;
(2) Adjust sequence number of opFSMxxx in metanode\const.go
