### PR TITLE
[WIP][Feature]: DataNode receiving processing supports speed limit

### DIFF
--- a/datanode/server.go
+++ b/datanode/server.go
@@ -309,7 +309,7 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 	}
 
 	addrs := cfg.GetSlice(proto.MasterAddr)
-	if len(addrs) == 0 {
+	if len(cfg.GetSlice(proto.MasterAddr)) == 0 {
 		return fmt.Errorf("Err:masterAddr unavalid")
 	}
 	masters := make([]string, 0, len(addrs))

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -65,10 +65,10 @@ const (
 	DefaultRaftDir             = "raft"
 	DefaultRaftLogsToRetain    = 10 // Count of raft logs per data partition
 	DefaultDiskMaxErr          = 1
-	DefaultDiskRetainMin       = 5 * util.GB   // GB
-	DefaultNameResolveInterval = 1             // minutes
-	DefaultRecvLimit           = 100 * util.MB // MB
-	DefaultPacketLimit         = repl.RequestChanSize
+	DefaultDiskRetainMin       = 5 * util.GB    // GB
+	DefaultNameResolveInterval = 1              // minutes
+	DefaultRecvFlowLimit       = 1024 * util.GB // MB
+	DefaultRecvPacketLimit     = 1024 * util.MB
 )
 
 const (
@@ -86,7 +86,6 @@ const (
 	ConfigKeyRaftReplica   = "raftReplica"     // string
 	CfgTickInterval        = "tickInterval"    // int
 	CfgRaftRecvBufSize     = "raftRecvBufSize" // int
-	ConfigKeyRecvFlowLimit = "recvFlowLimit"   // int
 
 	ConfigKeyDiskPath         = "diskPath"            // string
 	configNameResolveInterval = "nameResolveInterval" // int
@@ -133,7 +132,6 @@ type DataNode struct {
 	tickInterval    int
 	raftRecvBufSize int
 	startTime       int64
-	recvFlowLimiter *rate.Limiter
 
 	tcpListener net.Listener
 	stopC       chan bool
@@ -300,10 +298,6 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 	}
 	s.port = port
 
-	// recv limiter
-	recvLimit := cfg.GetInt64WithDefault(ConfigKeyRecvFlowLimit, DefaultRecvLimit)
-	s.recvFlowLimiter = rate.NewLimiter(rate.Limit(recvLimit), int(recvLimit))
-	log.LogDebugf("action[parseConfig] using flow speed limit %v MB per second", recvLimit/util.MB)
 	/*for _, ip := range cfg.GetSlice(proto.MasterAddr) {
 		MasterClient.AddNode(ip.(string))
 	}*/
@@ -642,13 +636,29 @@ func (s *DataNode) stopTCPService() (err error) {
 	return
 }
 
+func (s *DataNode) recvLimiterAdjust(limiter *repl.RecvLimiter, sample *repl.OperatorStatsSample) {
+	builder := strings.Builder{}
+	builder.WriteString(fmt.Sprintf("Operator Util:\t%.2f\n", sample.GetUtil()*100))
+	builder.WriteString(fmt.Sprintf("Operator Drop Packet Percent:\t%.2f\n", sample.GetDropPacketRate()*100))
+	builder.WriteString(fmt.Sprintf("Operator Queue Length:\t%v\n", sample.GetQueueLength()))
+	builder.WriteString(fmt.Sprintf("Operator Queue Capacity:\t%v\n", sample.GetQueueCapacity()))
+	builder.WriteString(fmt.Sprintf("Operator Sample Duration:\t%v\n", sample.GetSampleDuration()))
+	builder.WriteString(fmt.Sprintf("Operator Wait Time:\t%v\n", sample.GetWaitTime()))
+	builder.WriteString(fmt.Sprintf("Operator Enque Packet:\t%v\n", sample.GetEnquePacket()))
+	builder.WriteString(fmt.Sprintf("Operator Deque Packet:\t%v\n", sample.GetDequePacket()))
+	builder.WriteString(fmt.Sprintf("Operator Enque Flow:\t%v\n", sample.GetEnqueFlow()))
+	builder.WriteString(fmt.Sprintf("Operator Deque Flow:\t%v\n", sample.GetDequeFlow()))
+	log.LogInfof(builder.String())
+	// adjust receive limiter in here
+}
+
 func (s *DataNode) serveConn(conn net.Conn) {
 	space := s.space
 	space.Stats().AddConnection()
 	c, _ := conn.(*net.TCPConn)
 	c.SetKeepAlive(true)
 	c.SetNoDelay(true)
-	packetProcessor := repl.NewReplProtocol(conn, s.Prepare, s.OperatePacket, s.Post, repl.NewRecvLimiter(s.recvFlowLimiter, rate.NewLimiter(DefaultPacketLimit, DefaultPacketLimit)))
+	packetProcessor := repl.NewReplProtocol(conn, s.Prepare, s.OperatePacket, s.Post, repl.NewRecvLimiter(rate.NewLimiter(DefaultRecvFlowLimit, DefaultRecvFlowLimit), rate.NewLimiter(DefaultRecvPacketLimit, DefaultRecvPacketLimit)), s.recvLimiterAdjust)
 	packetProcessor.ServerConn()
 	space.Stats().RemoveConnection()
 }
@@ -725,7 +735,7 @@ func (s *DataNode) serveSmuxConn(conn net.Conn) {
 }
 
 func (s *DataNode) serveSmuxStream(stream *smux.Stream) {
-	packetProcessor := repl.NewReplProtocol(stream, s.Prepare, s.OperatePacket, s.Post, repl.NewRecvLimiter(s.recvFlowLimiter, rate.NewLimiter(DefaultPacketLimit, DefaultPacketLimit)))
+	packetProcessor := repl.NewReplProtocol(stream, s.Prepare, s.OperatePacket, s.Post, repl.NewRecvLimiter(rate.NewLimiter(DefaultRecvFlowLimit, DefaultRecvFlowLimit), rate.NewLimiter(DefaultRecvPacketLimit, DefaultRecvPacketLimit)), s.recvLimiterAdjust)
 	if s.enableSmuxConnPool {
 		packetProcessor.SetSmux(s.getRepairConnFunc, s.putRepairConnFunc)
 	}

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -78,7 +78,7 @@ func isColdVolExtentDelErr(p *repl.Packet) bool {
 	return false
 }
 
-func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn) (err error) {
+func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn, limiter *repl.RecvLimiter) (err error) {
 	var (
 		tpLabels map[string]string
 		tpObject *exporter.TimePointCount

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -78,7 +78,7 @@ func isColdVolExtentDelErr(p *repl.Packet) bool {
 	return false
 }
 
-func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn, limiter *repl.RecvLimiter) (err error) {
+func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn) (err error) {
 	var (
 		tpLabels map[string]string
 		tpObject *exporter.TimePointCount

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -1,0 +1,157 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl
+
+import (
+	"sync"
+	"time"
+)
+
+type OperatorStats struct {
+	lock               sync.RWMutex
+	flowEnqueCounter   uint64
+	flowDequeCounter   uint64
+	packetEnqueCounter uint64
+	packetDequeCounter uint64
+	waitTime           time.Duration
+	firstEnqueTime     time.Time
+	lastDequeTime      time.Time
+}
+
+type OperatorStatsSnapshot struct {
+	FlowEnqueCounter   uint64
+	FlowDequeCounter   uint64
+	PacketEnqueCounter uint64
+	PacketDequeCounter uint64
+	WaitTime           time.Duration
+	SnapshotTime       time.Time
+}
+
+type OperatorStatsSample struct {
+	first         OperatorStatsSnapshot
+	second        OperatorStatsSnapshot
+	queueLength   int
+	queueCapacity int
+}
+
+func (s *OperatorStats) OnEnque(flow uint64) {
+	now := time.Now()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.flowEnqueCounter += flow
+	s.packetEnqueCounter += 1
+	var zeroTime time.Time
+	if s.firstEnqueTime == zeroTime {
+		s.firstEnqueTime = now
+	}
+}
+
+func (s *OperatorStats) OnDeque(flow uint64, last bool) {
+	now := time.Now()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.flowDequeCounter += flow
+	s.packetDequeCounter += 1
+	if last {
+		var zeroTime time.Time
+		// if s.firstEnqueTime equal with zero or before s.lastDequeTime
+		// it means that OnDeque acquire the lock before OnEnque
+		// we doesn't need to record the wait time, because the duration is too short
+		if s.firstEnqueTime != zeroTime && s.firstEnqueTime.After(s.lastDequeTime) {
+			duration := now.Sub(s.firstEnqueTime)
+			s.waitTime += duration
+		}
+		s.lastDequeTime = now
+	}
+}
+
+func (s *OperatorStats) GetSnapshot() *OperatorStatsSnapshot {
+	now := time.Now()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	waitTime := s.waitTime
+	var zeroTime time.Time
+	if s.firstEnqueTime != zeroTime && (s.lastDequeTime == zeroTime || s.firstEnqueTime.After(s.lastDequeTime)) {
+		duration := now.Sub(s.firstEnqueTime)
+		waitTime += duration
+	}
+	snapshot := &OperatorStatsSnapshot{
+		FlowEnqueCounter:   s.flowDequeCounter,
+		FlowDequeCounter:   s.flowDequeCounter,
+		PacketEnqueCounter: s.packetEnqueCounter,
+		PacketDequeCounter: s.packetDequeCounter,
+		WaitTime:           waitTime,
+		SnapshotTime:       now,
+	}
+	return snapshot
+}
+
+func (s *OperatorStats) Sample(sampleDuration time.Duration, queue chan *Packet) *OperatorStatsSample {
+	first := s.GetSnapshot()
+	time.Sleep(sampleDuration)
+	second := s.GetSnapshot()
+	return &OperatorStatsSample{
+		first:         *first,
+		second:        *second,
+		queueLength:   len(queue),
+		queueCapacity: cap(queue),
+	}
+}
+
+func (s *OperatorStatsSample) GetEnqueFlow() uint64 {
+	return s.second.FlowEnqueCounter - s.first.FlowEnqueCounter
+}
+
+func (s *OperatorStatsSample) GetDequeFlow() uint64 {
+	return s.second.FlowDequeCounter - s.first.FlowDequeCounter
+}
+
+func (s *OperatorStatsSample) GetWaitFlow() uint64 {
+	return s.second.FlowEnqueCounter - s.second.FlowDequeCounter
+}
+
+func (s *OperatorStatsSample) GetEnquePacket() uint64 {
+	return s.second.PacketEnqueCounter - s.first.PacketEnqueCounter
+}
+
+func (s *OperatorStatsSample) GetDequePacket() uint64 {
+	return s.second.PacketDequeCounter - s.first.PacketDequeCounter
+}
+
+func (s *OperatorStatsSample) GetWaitPacket() uint64 {
+	return s.second.FlowEnqueCounter - s.second.FlowDequeCounter
+}
+
+func (s *OperatorStatsSample) GetSampleDuration() time.Duration {
+	return s.second.SnapshotTime.Sub(s.first.SnapshotTime)
+}
+
+func (s *OperatorStatsSample) GetWaitTime() time.Duration {
+	return s.second.WaitTime - s.first.WaitTime
+}
+
+func (s *OperatorStatsSample) GetUtil() float64 {
+	sampleDuration := s.GetSampleDuration()
+	waitTime := s.GetWaitTime()
+	return float64(waitTime.Milliseconds()) / float64(sampleDuration.Milliseconds())
+}
+
+func (s *OperatorStatsSample) GetQueueLength() int {
+	return s.queueLength
+}
+
+func (s *OperatorStatsSample) GetQueueCapacity() int {
+	return s.queueCapacity
+}

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -178,10 +178,10 @@ func (s *OperatorStatsSample) GetDropFlow() uint64 {
 }
 
 func (s *OperatorStatsSample) GetDropPacketRate() float64 {
-	if s.GetDequePacket() == 0 {
+	if s.GetDropPacket() == 0 {
 		return 0
 	}
-	return float64(s.GetDequePacket()) / float64(s.GetDequePacket()+s.GetEnquePacket())
+	return float64(s.GetDropPacket()) / float64(s.GetDropPacket()+s.GetEnquePacket())
 }
 
 func (s *OperatorStatsSample) GetDropFlowRate() float64 {

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -178,9 +178,15 @@ func (s *OperatorStatsSample) GetDropFlow() uint64 {
 }
 
 func (s *OperatorStatsSample) GetDropPacketPercent() float64 {
+	if s.GetDequePacket() == 0 {
+		return 0
+	}
 	return float64(s.GetDequePacket()) / float64(s.GetDequePacket()+s.GetEnquePacket())
 }
 
 func (s *OperatorStatsSample) GetDropFlowPercent() float64 {
+	if s.GetDequeFlow() == 0 {
+		return 0
+	}
 	return float64(s.GetDropFlow()) / float64(s.GetDropFlow()+s.GetEnqueFlow())
 }

--- a/repl/operator_stats.go
+++ b/repl/operator_stats.go
@@ -57,7 +57,7 @@ func (s *OperatorStats) OnEnque(flow uint64) {
 	s.flowEnqueCounter += flow
 	s.packetEnqueCounter += 1
 	var zeroTime time.Time
-	if s.firstEnqueTime == zeroTime {
+	if s.firstEnqueTime == zeroTime || (s.lastDequeTime != zeroTime && s.lastDequeTime.After(zeroTime)) {
 		s.firstEnqueTime = now
 	}
 }
@@ -99,7 +99,7 @@ func (s *OperatorStats) GetSnapshot() *OperatorStatsSnapshot {
 		waitTime += duration
 	}
 	snapshot := &OperatorStatsSnapshot{
-		FlowEnqueCounter:   s.flowDequeCounter,
+		FlowEnqueCounter:   s.flowEnqueCounter,
 		FlowDequeCounter:   s.flowDequeCounter,
 		FlowDropCounter:    s.flowDropCounter,
 		PacketEnqueCounter: s.packetEnqueCounter,
@@ -177,14 +177,14 @@ func (s *OperatorStatsSample) GetDropFlow() uint64 {
 	return s.second.FlowDropCounter - s.first.FlowDropCounter
 }
 
-func (s *OperatorStatsSample) GetDropPacketPercent() float64 {
+func (s *OperatorStatsSample) GetDropPacketRate() float64 {
 	if s.GetDequePacket() == 0 {
 		return 0
 	}
 	return float64(s.GetDequePacket()) / float64(s.GetDequePacket()+s.GetEnquePacket())
 }
 
-func (s *OperatorStatsSample) GetDropFlowPercent() float64 {
+func (s *OperatorStatsSample) GetDropFlowRate() float64 {
 	if s.GetDequeFlow() == 0 {
 		return 0
 	}

--- a/repl/operator_stats_test.go
+++ b/repl/operator_stats_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cubefs/cubefs/repl"
+)
+
+func TestOperatorSampleTest(t *testing.T) {
+	var stats repl.OperatorStats
+	processCh := make(chan *repl.Packet, 2048)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Wait()
+		stats.OnEnque(100)
+		time.Sleep(1 * time.Second)
+		stats.OnDeque(100, true)
+	}()
+	wg.Done()
+	sample := stats.Sample(2*time.Second, processCh)
+	t.Logf("Enque Flow:\t%v", sample.GetEnqueFlow())
+	t.Logf("Deque Flow:\t%v", sample.GetDequeFlow())
+	t.Logf("Enque Packet:\t%v", sample.GetEnquePacket())
+	t.Logf("Deque Packet:\t%v", sample.GetDequePacket())
+	t.Logf("Wait Flow:\t%v", sample.GetWaitFlow())
+	t.Logf("Wait Packet:\t%v", sample.GetWaitPacket())
+	t.Logf("Wait Time:\t%v", sample.GetWaitTime())
+	t.Logf("Sample Duration:\t%v", sample.GetSampleDuration())
+	t.Logf("Util:\t%.1f", sample.GetUtil()*100)
+	if sample.GetQueueCapacity() != 2048 {
+		t.Errorf("queue capacity should equal with 0, but get %v", sample.GetQueueCapacity())
+	}
+	if sample.GetQueueLength() != 0 {
+		t.Errorf("queue length should equal with 0, but get %v", sample.GetQueueLength())
+	}
+	if sample.GetEnqueFlow() != 100 {
+		t.Errorf("enque flow should equal with 100, but get %v", sample.GetEnqueFlow())
+	}
+	if sample.GetDequeFlow() != 100 {
+		t.Errorf("deque flow should equal with 100, but get %v", sample.GetDequeFlow())
+	}
+	if sample.GetEnquePacket() != 1 {
+		t.Errorf("enque packet should equal with 1, but get %v", sample.GetEnquePacket())
+	}
+	if sample.GetDequePacket() != 1 {
+		t.Errorf("deque packet should equal with 1, but get %v", sample.GetDequePacket())
+	}
+	if sample.GetUtil() > 0.5 {
+		t.Errorf("util should less than or equal with 0.5, but get %v", sample.GetUtil())
+	}
+}

--- a/repl/operator_stats_test.go
+++ b/repl/operator_stats_test.go
@@ -48,8 +48,8 @@ func TestOperatorSampleTest(t *testing.T) {
 	t.Logf("Util:\t%.1f", sample.GetUtil()*100)
 	t.Logf("Drop Packet:\t%v", sample.GetDequePacket())
 	t.Logf("Drop Flow:\t%v", sample.GetDropFlow())
-	t.Logf("Drop Packet Percent:\t%.1f", sample.GetDropPacketPercent()*100)
-	t.Logf("Drop Flow Percent:\t%.1f", sample.GetDropFlowPercent()*100)
+	t.Logf("Drop Packet Percent:\t%.1f", sample.GetDropPacketRate()*100)
+	t.Logf("Drop Flow Percent:\t%.1f", sample.GetDropFlowRate()*100)
 	if sample.GetQueueCapacity() != 2048 {
 		t.Errorf("queue capacity should equal with 0, but get %v", sample.GetQueueCapacity())
 	}

--- a/repl/operator_stats_test.go
+++ b/repl/operator_stats_test.go
@@ -15,6 +15,7 @@
 package repl_test
 
 import (
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ func TestOperatorSampleTest(t *testing.T) {
 	go func() {
 		wg.Wait()
 		stats.OnEnque(100)
+		stats.OnDrop(50)
 		time.Sleep(1 * time.Second)
 		stats.OnDeque(100, true)
 	}()
@@ -44,6 +46,10 @@ func TestOperatorSampleTest(t *testing.T) {
 	t.Logf("Wait Time:\t%v", sample.GetWaitTime())
 	t.Logf("Sample Duration:\t%v", sample.GetSampleDuration())
 	t.Logf("Util:\t%.1f", sample.GetUtil()*100)
+	t.Logf("Drop Packet:\t%v", sample.GetDequePacket())
+	t.Logf("Drop Flow:\t%v", sample.GetDropFlow())
+	t.Logf("Drop Packet Percent:\t%.1f", sample.GetDropPacketPercent()*100)
+	t.Logf("Drop Flow Percent:\t%.1f", sample.GetDropFlowPercent()*100)
 	if sample.GetQueueCapacity() != 2048 {
 		t.Errorf("queue capacity should equal with 0, but get %v", sample.GetQueueCapacity())
 	}
@@ -62,7 +68,13 @@ func TestOperatorSampleTest(t *testing.T) {
 	if sample.GetDequePacket() != 1 {
 		t.Errorf("deque packet should equal with 1, but get %v", sample.GetDequePacket())
 	}
-	if sample.GetUtil() > 0.5 {
-		t.Errorf("util should less than or equal with 0.5, but get %v", sample.GetUtil())
+	if math.Abs(sample.GetUtil()-0.5) > 0.01 {
+		t.Errorf("util should equal with 0.5, but get %v", sample.GetUtil())
+	}
+	if sample.GetDropPacket() != 1 {
+		t.Errorf("drop packet should equal with 1, but get %v", sample.GetDropPacket())
+	}
+	if sample.GetDropFlow() != 50 {
+		t.Errorf("drop flow should equal with 50, but get %v", sample.GetDropFlow())
 	}
 }

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -15,14 +15,17 @@
 package repl
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/cubefs/cubefs/util/log"
 	"io"
 	"net"
 	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/cubefs/cubefs/util/log"
+	"golang.org/x/time/rate"
 
 	"github.com/cubefs/cubefs/depends/tiglabs/raft"
 	"github.com/cubefs/cubefs/proto"
@@ -36,6 +39,8 @@ var (
 	ErrBadNodes       = errors.New("BadNodesErr")
 	ErrArgLenMismatch = errors.New("ArgLenMismatchErr")
 )
+
+const MaxOnceRecvSize = 128 * util.KB
 
 type Packet struct {
 	proto.Packet
@@ -333,17 +338,34 @@ func (p *Packet) PackErrorBody(action, msg string) {
 	copy(p.Data[:int(p.Size)], []byte(action+"_"+msg))
 }
 
-func (p *Packet) ReadFull(c net.Conn, opcode uint8, readSize int) (err error) {
+func (p *Packet) ReadFull(c net.Conn, opcode uint8, readSize int, limiter *rate.Limiter) (err error) {
 	if p.IsWriteOperation() && readSize == util.BlockSize {
 		p.Data, _ = proto.Buffers.Get(readSize)
 	} else {
 		p.Data = make([]byte, readSize)
 	}
-	_, err = io.ReadFull(c, p.Data[:readSize])
+	offset := 0
+	for offset != readSize {
+		size := readSize - offset
+		if size > MaxOnceRecvSize {
+			size = MaxOnceRecvSize
+		}
+
+		if !p.IsMasterCommand() && limiter != nil {
+			// recv limit
+			limiter.WaitN(context.Background(), size)
+		}
+
+		size, err = io.ReadFull(c, p.Data[offset:offset+size])
+		if err != nil {
+			return err
+		}
+		offset += size
+	}
 	return
 }
 
-func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration) (err error) {
+func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration, limiter *RecvLimiter) (err error) {
 	if deadlineTime != proto.NoReadDeadlineTime {
 		c.SetReadDeadline(time.Now().Add(deadlineTime * time.Second))
 	} else {
@@ -370,6 +392,15 @@ func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration) (er
 	}
 
 	if p.ArgLen > 0 {
+		if !p.IsMasterCommand() {
+			// wait for flow limit and packet limit
+			if limiter.Packet() != nil {
+				limiter.Packet().Wait(context.Background())
+			}
+			if limiter.Flow() != nil {
+				limiter.Flow().WaitN(context.Background(), int(p.ArgLen))
+			}
+		}
 		if err = proto.ReadFull(c, &p.Arg, int(p.ArgLen)); err != nil {
 			return
 		}
@@ -382,7 +413,7 @@ func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration) (er
 	if p.IsReadOperation() && p.ResultCode == proto.OpInitResultCode {
 		size = 0
 	}
-	return p.ReadFull(c, p.Opcode, int(size))
+	return p.ReadFull(c, p.Opcode, int(size), limiter.Flow())
 }
 
 func (p *Packet) IsMasterCommand() bool {

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -352,8 +352,11 @@ func (p *Packet) ReadFull(c net.Conn, opcode uint8, readSize int, limiter *rate.
 		}
 
 		if !p.IsMasterCommand() && limiter != nil {
-			// recv limit
-			limiter.WaitN(context.Background(), size)
+			err = limiter.WaitN(context.Background(), size)
+			if err != nil {
+				log.LogErrorf("failed to limit flow receiving %v", err.Error())
+				err = nil
+			}
 		}
 
 		size, err = io.ReadFull(c, p.Data[offset:offset+size])
@@ -395,10 +398,18 @@ func (p *Packet) ReadFromConnFromCli(c net.Conn, deadlineTime time.Duration, lim
 		if !p.IsMasterCommand() {
 			// wait for flow limit and packet limit
 			if limiter.Packet() != nil {
-				limiter.Packet().Wait(context.Background())
+				err = limiter.Packet().Wait(context.Background())
+				if err != nil {
+					log.LogErrorf("failed to limit packet receiving %v", err.Error())
+					err = nil
+				}
 			}
 			if limiter.Flow() != nil {
-				limiter.Flow().WaitN(context.Background(), int(p.ArgLen))
+				err = limiter.Flow().WaitN(context.Background(), int(p.ArgLen))
+				if err != nil {
+					log.LogErrorf("failed to limit flow receiving %v", err.Error())
+					err = nil
+				}
 			}
 		}
 		if err = proto.ReadFull(c, &p.Arg, int(p.ArgLen)); err != nil {

--- a/repl/recv_limiter.go
+++ b/repl/recv_limiter.go
@@ -21,9 +21,9 @@ type RecvLimiter struct {
 	packet *rate.Limiter
 }
 
-func NewRecvLimiter(recvLimiter *rate.Limiter, packetLimiter *rate.Limiter) *RecvLimiter {
+func NewRecvLimiter(flowLimiter *rate.Limiter, packetLimiter *rate.Limiter) *RecvLimiter {
 	return &RecvLimiter{
-		flow:   recvLimiter,
+		flow:   flowLimiter,
 		packet: packetLimiter,
 	}
 }

--- a/repl/recv_limiter.go
+++ b/repl/recv_limiter.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl
+
+import "golang.org/x/time/rate"
+
+type RecvLimiter struct {
+	flow   *rate.Limiter
+	packet *rate.Limiter
+}
+
+func NewRecvLimiter(recvLimiter *rate.Limiter, packetLimiter *rate.Limiter) *RecvLimiter {
+	return &RecvLimiter{
+		flow:   recvLimiter,
+		packet: packetLimiter,
+	}
+}
+
+func (l *RecvLimiter) Packet() *rate.Limiter {
+	return l.packet
+}
+
+func (l *RecvLimiter) Flow() *rate.Limiter {
+	return l.flow
+}

--- a/repl/recv_limiter_test.go
+++ b/repl/recv_limiter_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repl_test
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/repl"
+	"golang.org/x/time/rate"
+)
+
+const (
+	flow   = 0
+	packet = iota
+)
+
+func LimiterTest(t *testing.T, recv *repl.RecvLimiter, internal *rate.Limiter, mode int) {
+	limiter := recv.Flow()
+	if mode != flow {
+		limiter = recv.Packet()
+	}
+	internal.SetLimit(1)
+	if limiter.Limit() != 1 {
+		t.Errorf("limiter should equal with 1")
+	}
+	internal.SetBurst(1)
+	if limiter.Burst() != 1 {
+		t.Errorf("burst should equal with 1")
+	}
+	if !limiter.Allow() {
+		t.Errorf("limiter should allow 1")
+	}
+	if limiter.Allow() {
+		t.Errorf("limiter should not allow")
+	}
+}
+
+func TestRecvLimiter(t *testing.T) {
+	flowLimiter := rate.NewLimiter(10, 10)
+	packetLimiter := rate.NewLimiter(10, 10)
+	recvLimiter := repl.NewRecvLimiter(flowLimiter, packetLimiter)
+	if recvLimiter.Flow() != flowLimiter {
+		t.Errorf("flow limiter should equal with %v", flowLimiter)
+	}
+	if recvLimiter.Packet() != packetLimiter {
+		t.Errorf("packer limiter should equal witg %v", packetLimiter)
+	}
+	LimiterTest(t, recvLimiter, flowLimiter, flow)
+	LimiterTest(t, recvLimiter, packetLimiter, packet)
+}

--- a/repl/repl_protocol.go
+++ b/repl/repl_protocol.go
@@ -54,15 +54,16 @@ type ReplProtocol struct {
 	followerConnects map[string]*FollowerTransport
 	lock             sync.RWMutex
 
-	prepareFunc  func(p *Packet) error             // prepare packet
-	operatorFunc func(p *Packet, c net.Conn) error // operator
-	postFunc     func(p *Packet) error             // post-processing packet
+	prepareFunc  func(p *Packet) error                                       // prepare packet
+	operatorFunc func(p *Packet, c net.Conn, recvLimiter *RecvLimiter) error // operator
+	postFunc     func(p *Packet) error                                       // post-processing packet
 
 	getSmuxConn func(addr string) (c net.Conn, err error)
 	putSmuxConn func(conn net.Conn, force bool)
 
-	isError int32
-	replId  int64
+	isError     int32
+	replId      int64
+	recvLimiter *RecvLimiter
 }
 
 type FollowerTransport struct {
@@ -188,7 +189,7 @@ func (ft *FollowerTransport) Write(p *FollowerPacket) {
 }
 
 func NewReplProtocol(inConn net.Conn, prepareFunc func(p *Packet) error,
-	operatorFunc func(p *Packet, c net.Conn) error, postFunc func(p *Packet) error) *ReplProtocol {
+	operatorFunc func(p *Packet, c net.Conn, recvLimiter *RecvLimiter) error, postFunc func(p *Packet) error, recvLimiter *RecvLimiter) *ReplProtocol {
 	rp := new(ReplProtocol)
 	rp.packetList = list.New()
 	rp.ackCh = make(chan struct{}, RequestChanSize)
@@ -202,6 +203,7 @@ func NewReplProtocol(inConn net.Conn, prepareFunc func(p *Packet) error,
 	rp.postFunc = postFunc
 	rp.exited = ReplRuning
 	rp.replId = proto.GenerateRequestID()
+	rp.recvLimiter = recvLimiter
 	go rp.OperatorAndForwardPktGoRoutine()
 	go rp.ReceiveResponseFromFollowersGoRoutine()
 	go rp.writeResponseToClientGoRroutine()
@@ -270,7 +272,7 @@ func (rp *ReplProtocol) hasError() bool {
 
 func (rp *ReplProtocol) readPkgAndPrepare() (err error) {
 	request := NewPacket()
-	if err = request.ReadFromConnFromCli(rp.sourceConn, proto.NoReadDeadlineTime); err != nil {
+	if err = request.ReadFromConnFromCli(rp.sourceConn, proto.NoReadDeadlineTime, rp.recvLimiter); err != nil {
 		return
 	}
 	//log.LogDebugf("action[readPkgAndPrepare] packet(%v) op %v from remote(%v) conn(%v) ",
@@ -317,7 +319,7 @@ func (rp *ReplProtocol) OperatorAndForwardPktGoRoutine() {
 		select {
 		case request := <-rp.toBeProcessedCh:
 			if !request.IsForwardPacket() {
-				rp.operatorFunc(request, rp.sourceConn)
+				rp.operatorFunc(request, rp.sourceConn, rp.recvLimiter)
 				rp.putResponse(request)
 			} else {
 				index, err := rp.sendRequestToAllFollowers(request)
@@ -326,7 +328,7 @@ func (rp *ReplProtocol) OperatorAndForwardPktGoRoutine() {
 					rp.putResponse(request)
 				} else {
 					rp.pushPacketToList(request)
-					rp.operatorFunc(request, rp.sourceConn)
+					rp.operatorFunc(request, rp.sourceConn, rp.recvLimiter)
 					rp.putAck()
 				}
 			}

--- a/repl/repl_protocol.go
+++ b/repl/repl_protocol.go
@@ -32,6 +32,8 @@ var (
 	gConnPool = util.NewConnectPool()
 )
 
+const sampleDuration = 1 * time.Second
+
 // ReplProtocol defines the struct of the replication protocol.
 // 1. ServerConn reads a packet from the client socket, and analyzes the addresses of the followers.
 // 2. After the preparation, the packet is send to toBeProcessedCh. If failure happens, send it to the response channel.
@@ -61,9 +63,13 @@ type ReplProtocol struct {
 	getSmuxConn func(addr string) (c net.Conn, err error)
 	putSmuxConn func(conn net.Conn, force bool)
 
-	isError     int32
-	replId      int64
-	recvLimiter *RecvLimiter
+	isError int32
+	replId  int64
+
+	operatorStats       OperatorStats
+	recvLimiter         *RecvLimiter
+	sampleDone          chan interface{}
+	recvLimiterAdjuster func(recvLimiter *RecvLimiter, sample *OperatorStatsSample)
 }
 
 type FollowerTransport struct {
@@ -189,7 +195,8 @@ func (ft *FollowerTransport) Write(p *FollowerPacket) {
 }
 
 func NewReplProtocol(inConn net.Conn, prepareFunc func(p *Packet) error,
-	operatorFunc func(p *Packet, c net.Conn) error, postFunc func(p *Packet) error, recvLimiter *RecvLimiter) *ReplProtocol {
+	operatorFunc func(p *Packet, c net.Conn) error, postFunc func(p *Packet) error,
+	recvLimiter *RecvLimiter, recvLimiterAdjuster func(recvLimiter *RecvLimiter, sample *OperatorStatsSample)) *ReplProtocol {
 	rp := new(ReplProtocol)
 	rp.packetList = list.New()
 	rp.ackCh = make(chan struct{}, RequestChanSize)
@@ -204,6 +211,11 @@ func NewReplProtocol(inConn net.Conn, prepareFunc func(p *Packet) error,
 	rp.exited = ReplRuning
 	rp.replId = proto.GenerateRequestID()
 	rp.recvLimiter = recvLimiter
+	rp.recvLimiterAdjuster = recvLimiterAdjuster
+	if rp.recvLimiterAdjuster != nil {
+		rp.sampleDone = make(chan interface{})
+		go rp.startOperatorSample()
+	}
 	go rp.OperatorAndForwardPktGoRoutine()
 	go rp.ReceiveResponseFromFollowersGoRoutine()
 	go rp.writeResponseToClientGoRroutine()
@@ -308,6 +320,20 @@ func (rp *ReplProtocol) sendRequestToAllFollowers(request *Packet) (index int, e
 	return
 }
 
+func (rp *ReplProtocol) startOperatorSample() {
+	for {
+		select {
+		case <-rp.sampleDone:
+			return
+		default:
+			// sample process will block current goroutine
+			// we not need to sleep, it will not cause busy loop
+			sample := rp.operatorStats.Sample(sampleDuration, rp.toBeProcessedCh)
+			rp.recvLimiterAdjuster(rp.recvLimiter, sample)
+		}
+	}
+}
+
 // OperatorAndForwardPktGoRoutine reads packets from the to-be-processed channel and writes responses to the client.
 // 1. Read a packet from toBeProcessCh, and determine if it needs to be forwarded or not. If the answer is no, then
 // 	  process the packet locally and put it into responseCh.
@@ -332,6 +358,7 @@ func (rp *ReplProtocol) OperatorAndForwardPktGoRoutine() {
 					rp.putAck()
 				}
 			}
+			rp.operatorStats.OnDeque(uint64(request.Size+request.ArgLen), len(rp.toBeProcessedCh) == 0)
 		case <-rp.exitC:
 			rp.exitedMu.Lock()
 			if atomic.AddInt32(&rp.exited, -1) == ReplHasExited {
@@ -592,8 +619,10 @@ func (rp *ReplProtocol) putResponse(reply *Packet) (err error) {
 func (rp *ReplProtocol) putToBeProcess(request *Packet) (err error) {
 	select {
 	case rp.toBeProcessedCh <- request:
+		rp.operatorStats.OnEnque(uint64(request.Size + request.ArgLen))
 		return
 	default:
+		rp.operatorStats.OnDrop(uint64(request.Size + request.ArgLen))
 		return fmt.Errorf("toBeProcessedCh Chan has full (%v)", len(rp.toBeProcessedCh))
 	}
 }

--- a/repl/repl_protocol.go
+++ b/repl/repl_protocol.go
@@ -596,6 +596,9 @@ func (rp *ReplProtocol) cleanResource() {
 	rp.packetList = nil
 	rp.followerConnects = nil
 	rp.packetListLock.Unlock()
+	if rp.sampleDone != nil {
+		close(rp.sampleDone)
+	}
 }
 
 func (rp *ReplProtocol) deletePacket(reply *Packet, e *list.Element) (success bool) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Add speed limit to receiving processing.
* Support to adjust speed limit.
* Add operation phase statistics to help adjust limit.
* Add peer connection operation phase statistics sampler(`sampleDuration` is `1*time.Second` by default).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

fixes #1906

**Special notes for your reviewer**:

These  operation phase statistics include:
* `EnqueFlow`: The number of bytes enqueued.
* `DequeFlow`: The number of bytes dequeued.
* `DropFlow`: The number of bytes discarded because the queue was full.
* `EnquePacket`: The number of packets enqueued.
* `DequePacket`: The number of packets dequeued.
* `DropPacket`: The number of packets discarded because the queue was full.
* `WaitTime`: How long the queue was not empty during the sampling duration.
* `Util`: Operator utilization rate(`WaitTime/SampleDuration`).
* `DropPacketRate`: The proportion of dropped packets to all packets.
* `DropFlowRate`: The proportion of dropped bytes to all bytes.

Due to my inexperience, I didn't finish setting up the limit adjust strategy, current policy as follows(it only works as a log):
```go
func (s *DataNode) recvLimiterAdjust(limiter *repl.RecvLimiter, sample *repl.OperatorStatsSample) {
	builder := strings.Builder{}
	builder.WriteString(fmt.Sprintf("Operator Util:\t%.2f\n", sample.GetUtil()*100))
	builder.WriteString(fmt.Sprintf("Operator Drop Packet Percent:\t%.2f\n", sample.GetDropPacketRate()*100))
	builder.WriteString(fmt.Sprintf("Operator Queue Length:\t%v\n", sample.GetQueueLength()))
	builder.WriteString(fmt.Sprintf("Operator Queue Capacity:\t%v\n", sample.GetQueueCapacity()))
	builder.WriteString(fmt.Sprintf("Operator Sample Duration:\t%v\n", sample.GetSampleDuration()))
	builder.WriteString(fmt.Sprintf("Operator Wait Time:\t%v\n", sample.GetWaitTime()))
	builder.WriteString(fmt.Sprintf("Operator Enque Packet:\t%v\n", sample.GetEnquePacket()))
	builder.WriteString(fmt.Sprintf("Operator Deque Packet:\t%v\n", sample.GetDequePacket()))
	builder.WriteString(fmt.Sprintf("Operator Enque Flow:\t%v\n", sample.GetEnqueFlow()))
	builder.WriteString(fmt.Sprintf("Operator Deque Flow:\t%v\n", sample.GetDequeFlow()))
	log.LogInfof(builder.String())
	// adjust receive limiter in here
}
```

On my computer it produces these worthwhile logs.

Datanode 1:
```log
...
2023/06/29 08:09:00.230690 [INFO ] server.go:626: Operator Util:	19.20
Operator Drop Packet Percent:	0.00
Operator Queue Length:	0
Operator Queue Capacity:	2048
Operator Sample Duration:	1.000120115s
Operator Wait Time:	192.321455ms
Operator Enque Packet:	857
Operator Deque Packet:	857
Operator Enque Flow:	112361270
Operator Deque Flow:	0
```

The logs of datanode 2, datanode 3 and datanode 4 are omitted.

Full logs can be found in [here](https://github.com/NaturalSelect/logs/tree/main/dataNode-recv)

Please contract me if the pull request passed review, and I will rebase and rearrange commint points .

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
