### PR TITLE
feat(master): support listing nodesets and displaying space capacity

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -102,6 +102,20 @@ func formatNodeView(view *proto.NodeView, tableRow bool) string {
 	return sb.String()
 }
 
+var nodeViewTableRowPatternForNodeSet = "%-6v    %-65v    %-8v    %-8v    %-10v    %-10v    %-10v"
+
+func formatNodeViewTableHeaderForNodeSet() string {
+	return fmt.Sprintf(nodeViewTableRowPatternForNodeSet, "ID", "ADDRESS", "WRITABLE", "STATUS", "TOTAL", "USED", "AVAIL")
+}
+
+func formatNodeViewForNodeSet(view *proto.NodeStatView) string {
+	return fmt.Sprintf(nodeViewTableRowPatternForNodeSet, view.ID, formatAddr(view.Addr, view.DomainAddr),
+		formatYesNo(view.IsWritable), formatNodeStatus(view.Status),
+		formatSize(view.Total),
+		formatSize(view.Used),
+		formatSize(view.Avail))
+}
+
 func formatSimpleVolView(svv *proto.SimpleVolView) string {
 
 	var sb = strings.Builder{}
@@ -761,6 +775,43 @@ func formatMetaNodeDetail(mn *proto.MetaNodeInfo, rowTable bool) string {
 	sb.WriteString(fmt.Sprintf("  Partition count     : %v\n", mn.MetaPartitionCount))
 	sb.WriteString(fmt.Sprintf("  Persist partitions  : %v\n", mn.PersistenceMetaPartitions))
 	sb.WriteString(fmt.Sprintf("  CpuUtil             : %.1f%%\n", mn.CpuUtil))
+	return sb.String()
+}
+
+func formatNodeSetView(ns *proto.NodeSetStatInfo) string {
+	var sb = strings.Builder{}
+	sb.WriteString(fmt.Sprintf("NodeSet ID:    %v\n", ns.ID))
+	sb.WriteString(fmt.Sprintf("Capacity:      %v\n", ns.Capacity))
+	sb.WriteString(fmt.Sprintf("Zone:          %v\n", ns.Zone))
+	var dataTotal, dataUsed, dataAvail, metaTotal, metaUsed, metaAvail uint64
+	for _, dn := range ns.DataNodes {
+		dataTotal += dn.Total
+		dataUsed += dn.Used
+		dataAvail += dn.Avail
+	}
+	for _, mn := range ns.MetaNodes {
+		metaTotal += mn.Total
+		metaUsed += mn.Used
+		metaAvail += mn.Avail
+	}
+	sb.WriteString(fmt.Sprintf("DataTotal:     %v\n", formatSize(dataTotal)))
+	sb.WriteString(fmt.Sprintf("DataUsed:      %v\n", formatSize(dataUsed)))
+	sb.WriteString(fmt.Sprintf("DataAvail:     %v\n", formatSize(dataAvail)))
+	sb.WriteString(fmt.Sprintf("MetaTotal:     %v\n", formatSize(metaTotal)))
+	sb.WriteString(fmt.Sprintf("MetaUsed:      %v\n", formatSize(metaUsed)))
+	sb.WriteString(fmt.Sprintf("MetaAvail:     %v\n", formatSize(metaAvail)))
+	sb.WriteString(fmt.Sprintf("\n"))
+	sb.WriteString(fmt.Sprintf("DataNodes[%v]:\n", len(ns.DataNodes)))
+	sb.WriteString(fmt.Sprintf("  %v\n", formatNodeViewTableHeaderForNodeSet()))
+	for _, dn := range ns.DataNodes {
+		sb.WriteString(fmt.Sprintf("  %v\n", formatNodeViewForNodeSet(dn)))
+	}
+	sb.WriteString(fmt.Sprintf("\n"))
+	sb.WriteString(fmt.Sprintf("MetaNodes[%v]:\n", len(ns.MetaNodes)))
+	sb.WriteString(fmt.Sprintf("  %v\n", formatNodeViewTableHeaderForNodeSet()))
+	for _, mn := range ns.MetaNodes {
+		sb.WriteString(fmt.Sprintf("  %v\n", formatNodeViewForNodeSet(mn)))
+	}
 	return sb.String()
 }
 

--- a/cli/cmd/nodeset.go
+++ b/cli/cmd/nodeset.go
@@ -1,0 +1,101 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/sdk/master"
+	"github.com/spf13/cobra"
+)
+
+const (
+	cmdNodeSetUse   = "nodeset [COMMAND]"
+	cmdNodeSetShort = "Manage nodeset"
+)
+
+func newNodeSetCmd(client *master.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   cmdNodeSetUse,
+		Short: cmdNodeSetShort,
+		Args:  cobra.MinimumNArgs(0),
+	}
+	cmd.AddCommand(
+		newNodeSetListCmd(client),
+		newNodeSetInfoCmd(client),
+	)
+	return cmd
+}
+
+const (
+	cmdNodeSetListShort = "List cluster nodeSets"
+	cmdGetNodeSetShort  = "Show nodeSet information"
+)
+
+func newNodeSetListCmd(client *master.MasterClient) *cobra.Command {
+	var zoneName string
+	var cmd = &cobra.Command{
+		Use:   CliOpList,
+		Short: cmdNodeSetListShort,
+		Run: func(cmd *cobra.Command, args []string) {
+			var nodeSetStats []*proto.NodeSetStat
+			var err error
+			defer func() {
+				if err != nil {
+					errout("Error: %v\n", err)
+				}
+			}()
+			if nodeSetStats, err = client.AdminAPI().ListNodeSets(zoneName); err != nil {
+				return
+			}
+			zoneTablePattern := "%-6v %-6v %-12v %-10v %-10v\n"
+			stdout(zoneTablePattern, "ID", "Cap", "Zone", "MetaNum", "DataNum")
+			zoneDataPattern := "%-6v %-6v %-12v %-10v %-10v\n"
+			for _, nodeSet := range nodeSetStats {
+				stdout(zoneDataPattern, nodeSet.ID, nodeSet.Capacity, nodeSet.Zone, nodeSet.MetaNodeNum, nodeSet.DataNodeNum)
+			}
+			return
+		},
+	}
+
+	cmd.Flags().StringVar(&zoneName, CliFlagZoneName, "", "List nodeSets in the specified zone")
+
+	return cmd
+}
+
+func newNodeSetInfoCmd(client *master.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   CliOpInfo,
+		Short: cmdGetNodeSetShort,
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var nodeSetStatInfo *proto.NodeSetStatInfo
+			var err error
+			defer func() {
+				if err != nil {
+					errout("Error: %v\n", err)
+				}
+			}()
+
+			nodeSetId := args[0]
+
+			if nodeSetStatInfo, err = client.AdminAPI().GetNodeSet(nodeSetId); err != nil {
+				return
+			}
+			stdout(formatNodeSetView(nodeSetStatInfo))
+			return
+		},
+	}
+	return cmd
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -73,6 +73,7 @@ func NewRootCmd(client *master.MasterClient) *CubeFSCmd {
 		newMetaPartitionCmd(client),
 		newConfigCmd(),
 		newZoneCmd(client),
+		newNodeSetCmd(client),
 		newAclCmd(client),
 		newUidCmd(client),
 		newQuotaCmd(client),

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -309,6 +309,108 @@ func (m *Server) listZone(w http.ResponseWriter, r *http.Request) {
 	sendOkReply(w, r, newSuccessHTTPReply(zoneViews))
 }
 
+func (m *Server) listNodeSets(w http.ResponseWriter, r *http.Request) {
+	metric := exporter.NewTPCnt(apiToMetricsName(proto.GetAllNodeSets))
+	defer func() {
+		doStatAndMetric(proto.GetAllNodeSets, metric, nil, nil)
+	}()
+
+	var zones []*Zone
+
+	// if zoneName is empty, list all nodeSets, otherwise list node sets in the specified zone
+	zoneName := r.FormValue(zoneNameKey)
+	if zoneName == "" {
+		zones = m.cluster.t.getAllZones()
+	} else {
+		zone, err := m.cluster.t.getZone(zoneName)
+		if err != nil {
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeZoneNotExists, Msg: err.Error()})
+			return
+		}
+		zones = []*Zone{zone}
+	}
+
+	nodeSetStats := make([]*proto.NodeSetStat, 0)
+
+	for _, zone := range zones {
+		nsc := zone.getAllNodeSet()
+		for _, ns := range nsc {
+			nsStat := &proto.NodeSetStat{
+				ID:          ns.ID,
+				Capacity:    ns.Capacity,
+				Zone:        zone.name,
+				DataNodeNum: ns.dataNodeLen(),
+				MetaNodeNum: ns.metaNodeLen(),
+			}
+			nodeSetStats = append(nodeSetStats, nsStat)
+		}
+	}
+
+	sendOkReply(w, r, newSuccessHTTPReply(nodeSetStats))
+}
+
+func (m *Server) getNodeSet(w http.ResponseWriter, r *http.Request) {
+	metric := exporter.NewTPCnt(apiToMetricsName(proto.GetNodeSet))
+	defer func() {
+		doStatAndMetric(proto.GetNodeSet, metric, nil, nil)
+	}()
+
+	nodeSetStr := r.FormValue(nodesetIdKey)
+	if nodeSetStr == "" {
+		err := keyNotFound(nodesetIdKey)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	nodeSetId, err := strconv.ParseUint(nodeSetStr, 10, 64)
+	if err != nil {
+		err = fmt.Errorf("invalid nodeSetId: %v", nodeSetStr)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	ns, err := m.cluster.t.getNodeSetByNodeSetId(nodeSetId)
+	if err != nil {
+		err := nodeSetNotFound(nodeSetId)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeNodeSetNotExists, Msg: err.Error()})
+		return
+	}
+
+	nsStat := &proto.NodeSetStatInfo{
+		ID:       ns.ID,
+		Capacity: ns.Capacity,
+		Zone:     ns.zoneName,
+	}
+	ns.dataNodes.Range(func(key, value interface{}) bool {
+		dn := value.(*DataNode)
+		nsStat.DataNodes = append(nsStat.DataNodes, &proto.NodeStatView{
+			Addr:       dn.Addr,
+			Status:     dn.isActive,
+			DomainAddr: dn.DomainAddr,
+			ID:         dn.ID,
+			IsWritable: dn.isWriteAble(),
+			Total:      dn.Total,
+			Used:       dn.Used,
+			Avail:      dn.Total - dn.Used,
+		})
+		return true
+	})
+	ns.metaNodes.Range(func(key, value interface{}) bool {
+		mn := value.(*MetaNode)
+		nsStat.MetaNodes = append(nsStat.MetaNodes, &proto.NodeStatView{
+			Addr:       mn.Addr,
+			Status:     mn.IsActive,
+			DomainAddr: mn.DomainAddr,
+			ID:         mn.ID,
+			IsWritable: mn.isWritable(),
+			Total:      mn.Total,
+			Used:       mn.Used,
+			Avail:      mn.Total - mn.Used,
+		})
+		return true
+	})
+
+	sendOkReply(w, r, newSuccessHTTPReply(nsStat))
+}
+
 func (m *Server) clusterStat(w http.ResponseWriter, r *http.Request) {
 	metric := exporter.NewTPCnt(apiToMetricsName(proto.AdminClusterStat))
 	defer func() {

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -629,11 +629,10 @@ func TestDataPartitionDecommission(t *testing.T) {
 	partition.isRecover = false
 }
 
-//func TestGetAllVols(t *testing.T) {
-//	reqURL := fmt.Sprintf("%v%v", hostAddr, proto.GetALLVols)
-//	process(reqURL, t)
-//}
-//
+//	func TestGetAllVols(t *testing.T) {
+//		reqURL := fmt.Sprintf("%v%v", hostAddr, proto.GetALLVols)
+//		process(reqURL, t)
+//	}
 func TestGetMetaPartitions(t *testing.T) {
 	reqURL := fmt.Sprintf("%v%v?name=%v", hostAddr, proto.ClientMetaPartitions, commonVolName)
 	process(reqURL, t)
@@ -995,6 +994,22 @@ func TestDeleteUser(t *testing.T) {
 
 func TestListUsersOfVol(t *testing.T) {
 	reqURL := fmt.Sprintf("%v%v?name=%v", hostAddr, proto.UsersOfVol, "test_create_vol")
+	fmt.Println(reqURL)
+	process(reqURL, t)
+}
+
+func TestListNodeSets(t *testing.T) {
+	reqURL := fmt.Sprintf("%v%v", hostAddr, proto.GetAllNodeSets)
+	fmt.Println(reqURL)
+	process(reqURL, t)
+
+	reqURL = fmt.Sprintf("%v%v?zoneName=%v", hostAddr, proto.GetAllNodeSets, testZone2)
+	fmt.Println(reqURL)
+	process(reqURL, t)
+}
+
+func TestGetNodeSets(t *testing.T) {
+	reqURL := fmt.Sprintf("%v%v?nodesetId=1", hostAddr, proto.GetNodeSet)
 	fmt.Println(reqURL)
 	process(reqURL, t)
 }

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -601,6 +601,12 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.GetAllZones).
 		HandlerFunc(m.listZone)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.GetAllNodeSets).
+		HandlerFunc(m.listNodeSets)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.GetNodeSet).
+		HandlerFunc(m.getNodeSet)
 
 	// Quota
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -232,6 +232,10 @@ func zoneNotFound(name string) (err error) {
 	return notFoundMsg(fmt.Sprintf("zone[%v]", name))
 }
 
+func nodeSetNotFound(id uint64) (err error) {
+	return notFoundMsg(fmt.Sprintf("node set[%v]", id))
+}
+
 func dataNodeNotFound(addr string) (err error) {
 	return notFoundMsg(fmt.Sprintf("data node[%v]", addr))
 }

--- a/master/topology.go
+++ b/master/topology.go
@@ -1253,6 +1253,17 @@ func (t *topology) getZoneByIndex(index int) (zone *Zone) {
 	return t.zones[index]
 }
 
+func (t *topology) getNodeSetByNodeSetId(nodeSetId uint64) (nodeSet *nodeSet, err error) {
+	zones := t.getAllZones()
+	for _, zone := range zones {
+		nodeSet, err = zone.getNodeSet(nodeSetId)
+		if err == nil {
+			return nodeSet, nil
+		}
+	}
+	return nil, errors.NewErrorf("set %v not found", nodeSetId)
+}
+
 func calculateDemandWriteNodes(zoneNum int, replicaNum int) (demandWriteNodes int) {
 	if zoneNum == 1 {
 		demandWriteNodes = replicaNum

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -189,6 +189,8 @@ const (
 	GetTopologyView = "/topo/get"
 	UpdateZone      = "/zone/update"
 	GetAllZones     = "/zone/list"
+	GetAllNodeSets  = "/nodeSet/list"
+	GetNodeSet      = "/nodeSet/get"
 
 	// Header keys
 	SkipOwnerValidation = "Skip-Owner-Validation"

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -93,6 +93,7 @@ var (
 	ErrNoSuchLifecycleConfiguration            = errors.New("The lifecycle configuration does not exist")
 	ErrNoNodeSetToUpdateDecommissionDiskFactor = errors.New("no node set available for updating decommission disk factor")
 	ErrNoNodeSetToQueryDecommissionDiskLimit   = errors.New("no node set available for query decommission disk limit")
+	ErrNodeSetNotExists                        = errors.New("node set not exists")
 )
 
 // http response error code and error message definitions
@@ -158,6 +159,7 @@ const (
 	ErrCodeIsOwner
 	ErrCodeZoneNumError
 	ErrCodeVersionOpError
+	ErrCodeNodeSetNotExists
 )
 
 // Err2CodeMap error map to code
@@ -221,6 +223,7 @@ var Err2CodeMap = map[error]int32{
 	ErrIsOwner:                         ErrCodeIsOwner,
 	ErrZoneNum:                         ErrCodeZoneNumError,
 	ErrCodeVersionOp:                   ErrCodeVersionOpError,
+	ErrNodeSetNotExists:                ErrCodeNodeSetNotExists,
 }
 
 func ParseErrorCode(code int32) error {
@@ -291,6 +294,7 @@ var code2ErrMap = map[int32]error{
 	ErrCodeIsOwner:                         ErrIsOwner,
 	ErrCodeZoneNumError:                    ErrZoneNum,
 	ErrCodeVersionOpError:                  ErrCodeVersionOp,
+	ErrCodeNodeSetNotExists:                ErrNodeSetNotExists,
 }
 
 type GeneralResp struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -191,6 +191,33 @@ type ZoneNodesStat struct {
 	WritableNodes int
 }
 
+type NodeSetStat struct {
+	ID          uint64
+	Capacity    int
+	Zone        string
+	MetaNodeNum int
+	DataNodeNum int
+}
+
+type NodeSetStatInfo struct {
+	ID        uint64
+	Capacity  int
+	Zone      string
+	MetaNodes []*NodeStatView
+	DataNodes []*NodeStatView
+}
+
+type NodeStatView struct {
+	Addr       string
+	Status     bool
+	DomainAddr string
+	ID         uint64
+	IsWritable bool
+	Total      uint64
+	Used       uint64
+	Avail      uint64
+}
+
 type NodeStatInfo struct {
 	TotalGB     uint64
 	UsedGB      uint64

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -102,6 +102,34 @@ func (api *AdminAPI) ListZones() (zoneViews []*proto.ZoneView, err error) {
 	}
 	return
 }
+func (api *AdminAPI) ListNodeSets(zoneName string) (nodeSetStats []*proto.NodeSetStat, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.GetAllNodeSets)
+	if zoneName != "" {
+		request.addParam("zoneName", zoneName)
+	}
+	var buf []byte
+	if buf, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	nodeSetStats = make([]*proto.NodeSetStat, 0)
+	if err = json.Unmarshal(buf, &nodeSetStats); err != nil {
+		return
+	}
+	return
+}
+func (api *AdminAPI) GetNodeSet(nodeSetId string) (nodeSetStatInfo *proto.NodeSetStatInfo, err error) {
+	var request = newAPIRequest(http.MethodGet, proto.GetNodeSet)
+	request.addParam("nodesetId", nodeSetId)
+	var buf []byte
+	if buf, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	nodeSetStatInfo = &proto.NodeSetStatInfo{}
+	if err = json.Unmarshal(buf, &nodeSetStatInfo); err != nil {
+		return
+	}
+	return
+}
 func (api *AdminAPI) Topo() (topo *proto.TopologyView, err error) {
 	var buf []byte
 	var request = newAPIRequest(http.MethodGet, proto.GetTopologyView)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support listing nodesets and displaying space capacity

**Which issue this PR fixes**
The third point of issue #1894: **The total amount of nodeset, space, etc.**

## http
request: `http://127.0.0.1:8080/nodeSet/list`
```json
{
    "code": 0,
    "msg": "success",
    "data": [
        {
            "ID": 1,
            "Capacity": 18,
            "Zone": "zone1",
            "MetaNodeNum": 2,
            "DataNodeNum": 2
        },
        {
            "ID": 4,
            "Capacity": 18,
            "Zone": "zone2",
            "MetaNodeNum": 4,
            "DataNodeNum": 4
        }
    ]
}
```

request: `http://127.0.0.1:8080/nodeSet/list?zoneName=zone2`
```json
{
    "code": 0,
    "msg": "success",
    "data": [
        {
            "ID": 4,
            "Capacity": 18,
            "Zone": "zone2",
            "MetaNodeNum": 4,
            "DataNodeNum": 4
        }
    ]
}
```

request: `http://127.0.0.1:8080/nodeSet/get?nodesetId=1`
```json
{
    "code": 0,
    "msg": "success",
    "data": {
        "ID": 1,
        "Capacity": 18,
        "Zone": "zone1",
        "MetaNodes": [
            {
                "Addr": "127.0.0.1:8101",
                "Status": true,
                "DomainAddr": "localhost:8101",
                "ID": 9,
                "IsWritable": true,
                "Total": 10737418240,
                "Used": 1073741824,
                "Avail": 9663676416
            },
            {
                "Addr": "127.0.0.1:8102",
                "Status": true,
                "DomainAddr": "localhost:8102",
                "ID": 10,
                "IsWritable": true,
                "Total": 10737418240,
                "Used": 1073741824,
                "Avail": 9663676416
            }
        ],
        "DataNodes": [
            {
                "Addr": "127.0.0.1:9101",
                "Status": true,
                "DomainAddr": "localhost:9101",
                "ID": 2,
                "IsWritable": true,
                "Total": 1099511627776,
                "Used": 5368709120,
                "Avail": 1094142918656
            },
            {
                "Addr": "127.0.0.1:9102",
                "Status": true,
                "DomainAddr": "localhost:9102",
                "ID": 3,
                "IsWritable": true,
                "Total": 1099511627776,
                "Used": 5368709120,
                "Avail": 1094142918656
            }
        ]
    }
}
```

## cli
```shell
$ cfs-cli nodeset list -h
List cluster nodeSets

Usage:
  cfs-cli nodeset list [flags]

Aliases:
  list, ls

Flags:
  -h, --help               help for list
      --zone-name string   List nodeSets in the specified zone
```
```
$ cfs-cli nodeset list
ID     Cap    Zone         MetaNum    DataNum   
1      18     default      4          4         
11     18     test         0          0         
14     6      test2        0          0         
19     6      test2        0          0         
$ cfs-cli nodeset list --zone-name=test2
ID     Cap    Zone         MetaNum    DataNum   
14     6      test2        0          0         
19     6      test2        0          0         
```
```
$ cfs-cli nodeset info 1
NodeSet ID:    1
Capacity:      18
Zone:          default
DataTotal:     215.53 GB
DataUsed:      175.13 GB
DataAvail:     40.40 GB
MetaTotal:     9.77 GB
MetaUsed:      457.20 MB
MetaAvail:     9.32 GB

DataNodes[4]:
  ID        ADDRESS                                                              WRITABLE    STATUS      TOTAL         USED          AVAIL     
  9         172.16.1.104:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  
  8         172.16.1.103:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  
  6         172.16.1.101:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  
  7         172.16.1.102:17310                                                   No          Active      53.88 GB      43.78 GB      10.10 GB  

MetaNodes[4]:
  ID        ADDRESS                                                              WRITABLE    STATUS      TOTAL         USED          AVAIL     
  3         172.16.1.102:17210                                                   Yes         Active      2.44 GB       156.75 MB     2.29 GB   
  5         172.16.1.104:17210                                                   Yes         Active      2.44 GB       121.94 MB     2.32 GB   
  4         172.16.1.103:17210                                                   Yes         Active      2.44 GB       85.04 MB      2.36 GB   
  2         172.16.1.101:17210                                                   Yes         Active      2.44 GB       93.47 MB      2.35 GB  
```