### PR TITLE
feat(master): partitions support displaying in which nodeSet

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -435,6 +435,11 @@ func formatDataPartitionInfo(partition *proto.DataPartitionInfo) string {
 		sb.WriteString(fmt.Sprintf("  [%v]", zone))
 	}
 	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("NodeSets :\n"))
+	for _, nodeSet := range partition.NodeSets {
+		sb.WriteString(fmt.Sprintf("  [%v]", nodeSet))
+	}
+	sb.WriteString("\n")
 	sb.WriteString("\n")
 	sb.WriteString(fmt.Sprintf("MissingNodes :\n"))
 	for partitionHost, id := range partition.MissingNodes {
@@ -477,6 +482,11 @@ func formatMetaPartitionInfo(partition *proto.MetaPartitionInfo) string {
 	sb.WriteString(fmt.Sprintf("Zones :\n"))
 	for _, zone := range partition.Zones {
 		sb.WriteString(fmt.Sprintf("  [%v]", zone))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(fmt.Sprintf("NodeSets :\n"))
+	for _, nodeSet := range partition.NodeSets {
+		sb.WriteString(fmt.Sprintf("  [%v]", nodeSet))
 	}
 	sb.WriteString("\n")
 	sb.WriteString("\n")

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -4310,10 +4310,12 @@ func (m *Server) getMetaPartition(w http.ResponseWriter, r *http.Request) {
 		defer mp.RUnlock()
 		var replicas = make([]*proto.MetaReplicaInfo, len(mp.Replicas))
 		zones := make([]string, len(mp.Hosts))
+		nodeSets := make([]uint64, len(mp.Hosts))
 		for idx, host := range mp.Hosts {
 			metaNode, err := m.cluster.metaNode(host)
 			if err == nil {
 				zones[idx] = metaNode.ZoneName
+				nodeSets[idx] = metaNode.NodeSetID
 			}
 		}
 		for i := 0; i < len(replicas); i++ {
@@ -4344,6 +4346,7 @@ func (m *Server) getMetaPartition(w http.ResponseWriter, r *http.Request) {
 			Hosts:         mp.Hosts,
 			Peers:         mp.Peers,
 			Zones:         zones,
+			NodeSets:      nodeSets,
 			MissNodes:     mp.MissNodes,
 			OfflinePeerID: mp.OfflinePeerID,
 			LoadResponse:  mp.LoadResponse,

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -921,10 +921,12 @@ func (partition *DataPartition) buildDpInfo(c *Cluster) *proto.DataPartitionInfo
 	}
 
 	zones := make([]string, len(partition.Hosts))
+	nodeSets := make([]uint64, len(partition.Hosts))
 	for idx, host := range partition.Hosts {
 		dataNode, err := c.dataNode(host)
 		if err == nil {
 			zones[idx] = dataNode.ZoneName
+			nodeSets[idx] = dataNode.NodeSetID
 		}
 	}
 
@@ -939,6 +941,7 @@ func (partition *DataPartition) buildDpInfo(c *Cluster) *proto.DataPartitionInfo
 		Hosts:                    partition.Hosts,
 		Peers:                    partition.Peers,
 		Zones:                    zones,
+		NodeSets:                 nodeSets,
 		MissingNodes:             partition.MissingNodes,
 		VolName:                  partition.VolName,
 		VolID:                    partition.VolID,

--- a/proto/model.go
+++ b/proto/model.go
@@ -84,6 +84,7 @@ type MetaPartitionInfo struct {
 	Hosts         []string
 	Peers         []Peer
 	Zones         []string
+	NodeSets      []uint64
 	OfflinePeerID uint64
 	MissNodes     map[string]int64
 	LoadResponse  []*MetaPartitionLoadResponse
@@ -210,6 +211,7 @@ type DataPartitionInfo struct {
 	Hosts                    []string // host addresses
 	Peers                    []Peer
 	Zones                    []string
+	NodeSets                 []uint64
 	MissingNodes             map[string]int64 // key: address of the missing node, value: when the node is missing
 	VolName                  string
 	VolID                    uint64


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
partition command support displaying in which nodeSet

**Which issue this PR fixes**
The first point of issue #1894: **realize the display of dp and mp across nodeset**

## partition command support displaying in which nodeSet
```shell
$ cfs-cli datapartition info 1

...

Hosts :
  [172.16.1.101:17310]  [172.16.1.104:17310]  [172.16.1.102:17310]
Zones :
  [default]  [default]  [default]
NodeSets :
  [1]  [1]  [1]

...

```
```shell
$ cfs-cli metapartition info 1

...

Hosts :
  [172.16.1.101:17310]  [172.16.1.104:17310]  [172.16.1.102:17310]
Zones :
  [default]  [default]  [default]
NodeSets :
  [1]  [1]  [1]

...

```
