### PR TITLE
fix(meta): do retry in the case that submit to raft fail when raft no…

### DIFF
--- a/metanode/transaction.go
+++ b/metanode/transaction.go
@@ -737,7 +737,7 @@ func (tm *TransactionManager) setTransactionState(txId string, state int32) (sta
 	resp, err = tm.txProcessor.mp.submit(opFSMTxSetState, val)
 	if err != nil {
 		log.LogWarnf("setTransactionState: set transaction[%v] state to [%v] failed, err[%v]", txId, state, err)
-		return proto.OpTxSetStateErr, err
+		return proto.OpAgain, err
 	}
 	status = resp.(uint8)
 
@@ -761,7 +761,7 @@ func (tm *TransactionManager) delTxFromRM(txId string) (status uint8, err error)
 	resp, err := tm.txProcessor.mp.submit(opFSMTxDelete, val)
 	if err != nil {
 		log.LogWarnf("delTxFromRM: delTxFromRM transaction[%v] failed, err[%v]", txId, err)
-		return proto.OpTxCommitErr, err
+		return proto.OpAgain, err
 	}
 
 	status = resp.(uint8)
@@ -813,7 +813,7 @@ func (tm *TransactionManager) commitTx(txId string, skipSetStat bool) (status ui
 	resp, err := tm.txProcessor.mp.submit(opFSMTxCommit, val)
 	if err != nil {
 		log.LogWarnf("commitTx: commit transaction[%v] failed, err[%v]", txId, err)
-		return proto.OpTxCommitErr, err
+		return proto.OpAgain, err
 	}
 
 	status = resp.(uint8)
@@ -935,7 +935,7 @@ func (tm *TransactionManager) rollbackTx(txId string, skipSetStat bool) (status 
 
 	if err != nil {
 		log.LogWarnf("commitTx: rollback transaction[%v]  failed, err[%v]", txId, err)
-		return proto.OpTxCommitErr, err
+		return proto.OpAgain, err
 	}
 
 	status = resp.(uint8)


### PR DESCRIPTION
… leader.

Closes #2360

<!-- Thanks for sending a pull request! -->
The error return is not right when submit to raft failed, so client will not do retry request when no leader, and will fail.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
