### PR TITLE
Fix bug that func `TxUnlinkInode` return result code is wrong when submit raft failed.

### DIFF
--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -199,8 +199,8 @@ func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packe
 				status = proto.OpErr
 				reply = []byte(err.Error())
 			}
+			p.PacketErrorWithBody(status, reply)
 		}
-		p.PacketErrorWithBody(status, reply)
 	}()
 
 	ino := NewInode(req.Inode, 0)
@@ -213,6 +213,7 @@ func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packe
 				respIno = item.(*Inode)
 			}
 
+			p.ResultCode = status
 			log.LogWarnf("TxUnlinkInode: inode is already unlink before, req %v, rbIno %s", req, respIno.String())
 			return nil
 		}
@@ -245,6 +246,7 @@ func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packe
 	if msg.Msg != nil {
 		respIno = msg.Msg
 	}
+	p.ResultCode = status
 	return
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix bug that func `TxUnlinkInode` return result code is wrong when submit raft failed.

**Which issue this PR fixes**: fixes #2366

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
