### PR TITLE
fix(workflow): issue permission changes to `write`

### DIFF
--- a/.github/workflows/issue_inactive.yml
+++ b/.github/workflows/issue_inactive.yml
@@ -7,7 +7,7 @@ on:
 # labels: inactive-one-week, inactive-one-month, inactive-three-month, inactive-one-year, inactive-two-year
 
 permissions:
-  issues: read|write
+  issues: write
 
 jobs:
   check-inactive:

--- a/.github/workflows/issue_similarity.yml
+++ b/.github/workflows/issue_similarity.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited]
 
 permissions:
-  issues: read|write
+  issues: write
 
 jobs:
   similarity-analysis:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When github action executes these two files, an error will be reported:
```
The workflow is not valid. .github/workflows/issue_similarity.yml (Line: 8, Col: 11): Unexpected value 'read|write'
The workflow is not valid. .github/workflows/issue_inactive.yml (Line: 10, Col: 11): Unexpected value 'read|write'
```

`read|write` is not a valid permission setting, you need to specify `read` or `write` for each permission. We have to change it to the following code:
```
permissions:
   issues: write
```
This means that this GitHub Action has the right to write (and read) issues. The `write` permission will include the `read` permission