### PR TITLE
[Feature]: add Pre-vote capability to CubeFS Raft 

### DIFF
--- a/depends/tiglabs/raft/config.go
+++ b/depends/tiglabs/raft/config.go
@@ -89,7 +89,12 @@ type Config struct {
 	RetainLogs uint64
 	// LeaseCheck whether to use the lease mechanism.
 	// The default value is false.
+	// (this equal etcd's raft checkQuorum)
 	LeaseCheck bool
+	// PreVote enables the Pre-Vote algorithm described in raft thesis section
+	// 9.6. This prevents disruption when a node that has been partitioned away
+	// rejoins the cluster.
+	PreVote bool
 	// ReadOnlyOption specifies how the read only request is processed.
 	//
 	// ReadOnlySafe guarantees the linearizability of the read only request by

--- a/depends/tiglabs/raft/diff_test.go
+++ b/depends/tiglabs/raft/diff_test.go
@@ -1,0 +1,65 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func diffu(a, b string) string {
+	if a == b {
+		return ""
+	}
+	aname, bname := mustTemp("base", a), mustTemp("other", b)
+	defer os.Remove(aname)
+	defer os.Remove(bname)
+	cmd := exec.Command("diff", "-u", aname, bname)
+	buf, err := cmd.CombinedOutput()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			// do nothing
+			return string(buf)
+		}
+		panic(err)
+	}
+	return string(buf)
+}
+
+func mustTemp(pre, body string) string {
+	f, err := ioutil.TempFile("", pre)
+	if err != nil {
+		panic(err)
+	}
+	_, err = io.Copy(f, strings.NewReader(body))
+	if err != nil {
+		panic(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func ltoa(l *raftLog) string {
+	s := fmt.Sprintf("committed: %d\n", l.committed)
+	s += fmt.Sprintf("applied:  %d\n", l.applied)
+	for i, e := range l.allEntries() {
+		s += fmt.Sprintf("#%d: %+v\n", i, e)
+	}
+	return s
+}

--- a/depends/tiglabs/raft/proto/proto.go
+++ b/depends/tiglabs/raft/proto/proto.go
@@ -27,15 +27,15 @@ type (
 
 const (
 	ReqMsgAppend MsgType = iota
-	ReqMsgVote
+	ReqMsgPreVote
 	ReqMsgHeartBeat
 	ReqMsgSnapShot
-	ReqMsgPreVote
+	ReqMsgVote
 	RespMsgAppend
-	RespMsgVote
+	RespMsgPreVote
 	RespMsgHeartBeat
 	RespMsgSnapShot
-	RespMsgPreVote
+	RespMsgVote
 	LocalMsgHup
 	LocalMsgProp
 	LeaseMsgOffline
@@ -134,23 +134,23 @@ func (t MsgType) String() string {
 	case 0:
 		return "ReqMsgAppend"
 	case 1:
-		return "ReqMsgVote"
+		return "ReqMsgPreVote"
 	case 2:
 		return "ReqMsgHeartBeat"
 	case 3:
 		return "ReqMsgSnapShot"
 	case 4:
-		return "ReqMsgPreVote"
+		return "ReqMsgVote"
 	case 5:
 		return "RespMsgAppend"
 	case 6:
-		return "RespMsgVote"
+		return "RespMsgPreVote"
 	case 7:
 		return "RespMsgHeartBeat"
 	case 8:
 		return "RespMsgSnapShot"
 	case 9:
-		return "RespMsgPreVote"
+		return "RespMsgVote"
 	case 10:
 		return "LocalMsgHup"
 	case 11:

--- a/depends/tiglabs/raft/proto/proto.go
+++ b/depends/tiglabs/raft/proto/proto.go
@@ -30,12 +30,12 @@ const (
 	ReqMsgVote
 	ReqMsgHeartBeat
 	ReqMsgSnapShot
-	ReqMsgElectAck
+	ReqMsgPreVote
 	RespMsgAppend
 	RespMsgVote
 	RespMsgHeartBeat
 	RespMsgSnapShot
-	RespMsgElectAck
+	RespMsgPreVote
 	LocalMsgHup
 	LocalMsgProp
 	LeaseMsgOffline
@@ -140,7 +140,7 @@ func (t MsgType) String() string {
 	case 3:
 		return "ReqMsgSnapShot"
 	case 4:
-		return "ReqMsgElectAck"
+		return "ReqMsgPreVote"
 	case 5:
 		return "RespMsgAppend"
 	case 6:
@@ -150,7 +150,7 @@ func (t MsgType) String() string {
 	case 8:
 		return "RespMsgSnapShot"
 	case 9:
-		return "RespMsgElectAck"
+		return "RespMsgPreVote"
 	case 10:
 		return "LocalMsgHup"
 	case 11:
@@ -210,12 +210,12 @@ func (cc *ConfChange) String() string {
 
 func (m *Message) IsResponseMsg() bool {
 	return m.Type == RespMsgAppend || m.Type == RespMsgHeartBeat || m.Type == RespMsgVote ||
-		m.Type == RespMsgElectAck || m.Type == RespMsgSnapShot || m.Type == RespCheckQuorum
+		m.Type == RespMsgPreVote || m.Type == RespMsgSnapShot || m.Type == RespCheckQuorum
 }
 
 func (m *Message) IsElectionMsg() bool {
 	return m.Type == ReqMsgHeartBeat || m.Type == RespMsgHeartBeat || m.Type == ReqMsgVote || m.Type == RespMsgVote ||
-		m.Type == ReqMsgElectAck || m.Type == RespMsgElectAck || m.Type == LeaseMsgOffline || m.Type == LeaseMsgTimeout
+		m.Type == ReqMsgPreVote || m.Type == RespMsgPreVote || m.Type == LeaseMsgOffline || m.Type == LeaseMsgTimeout
 }
 
 func (m *Message) IsHeartbeatMsg() bool {

--- a/depends/tiglabs/raft/raft_fsm.go
+++ b/depends/tiglabs/raft/raft_fsm.go
@@ -400,8 +400,8 @@ func (r *raftFsm) reset(term, lasti uint64, isLeader bool) {
 func (r *raftFsm) resetRandomizedElectionTimeout() {
 	randTick := r.rand.Intn(r.config.ElectionTick)
 	r.randElectionTick = r.config.ElectionTick + randTick
-	logger.Debug("raft[%v] random election timeout randElectionTick=%v, config.ElectionTick=%v, randTick=%v", r.id,
-		r.randElectionTick, r.config.ElectionTick, randTick)
+	logger.Debug("raft[%v,%v] random election timeout randElectionTick=%v, config.ElectionTick=%v, randTick=%v",
+		r.id, r.config.ReplicateAddr, r.randElectionTick, r.config.ElectionTick, randTick)
 }
 
 func (r *raftFsm) pastElectionTimeout() bool {

--- a/depends/tiglabs/raft/raft_fsm.go
+++ b/depends/tiglabs/raft/raft_fsm.go
@@ -214,8 +214,8 @@ func (r *raftFsm) Step(m *proto.Message) {
 				return
 			}
 
-			if logger.IsEnableDebug() {
-				logger.Debug("[raft->Step][%v] is starting a new election at term[%d].", r.id, r.term)
+			if logger.IsEnableInfo() {
+				logger.Info("[raft->Step][%v] is starting a new election at term[%d].", r.id, r.term)
 			}
 			// only transfer leader will set forceVote=true.
 			// Leadership transfers never use pre-vote even if r.preVote is true; we
@@ -306,15 +306,15 @@ func (r *raftFsm) Step(m *proto.Message) {
 			// Before Pre-Vote enable, there may have candidate with higher term,
 			// but less log. After update to Pre-Vote, the cluster may deadlock if
 			// we drop messages with a lower term.
-			if logger.IsEnableDebug() {
-				logger.Debug("%x [logterm: %d, index: %d, vote: %x] rejected %s from %x [logterm: %d, index: %d] at term %d",
+			if logger.IsEnableInfo() {
+				logger.Info("%x [logterm: %d, index: %d, vote: %x] rejected %s from %x [logterm: %d, index: %d] at term %d",
 					r.id, r.raftLog.lastTerm(), r.raftLog.lastIndex(), r.vote, m.Type, m.From, m.LogTerm, m.Index, r.term)
 			}
 			r.send(&proto.Message{To: m.From, Term: r.term, Type: proto.RespMsgPreVote, Reject: true})
 		} else {
 			// ignore other cases
-			if logger.IsEnableDebug() {
-				logger.Debug("%x [term: %d] ignored a %s message with lower term from %x [term: %d]",
+			if logger.IsEnableInfo() {
+				logger.Info("%x [term: %d] ignored a %s message with lower term from %x [term: %d]",
 					r.id, r.term, m.Type, m.From, m.Term)
 			}
 		}

--- a/depends/tiglabs/raft/raft_fsm_candidate.go
+++ b/depends/tiglabs/raft/raft_fsm_candidate.go
@@ -34,7 +34,7 @@ func (r *raftFsm) becomeCandidate() {
 	r.vote = r.config.NodeID
 	r.state = stateCandidate
 	if logger.IsEnableDebug() {
-		logger.Debug("raft[%v] became candidate at term %d.", r.id, r.term)
+		logger.Debug("raft[%v,%v] became candidate at term %d.", r.id, r.config.TransportConfig.ReplicateAddr, r.term)
 	}
 }
 
@@ -114,8 +114,8 @@ func (r *raftFsm) campaign(force bool) {
 		}
 		li, lt := r.raftLog.lastIndexAndTerm()
 		if logger.IsEnableDebug() {
-			logger.Debug("[raft->campaign][%v logterm: %d, index: %d] sent "+
-				"vote request to %v at term %d.   raftFSM[%p]", r.id, lt, li, id, r.term, r)
+			logger.Debug("[raft->campaign][%v,%v logterm: %d, index: %d] sent "+
+				"vote request to %v at term %d.   raftFSM[%p]", r.id, r.config.ReplicateAddr, lt, li, id, r.term, r)
 		}
 
 		m := proto.GetMessage()
@@ -131,9 +131,9 @@ func (r *raftFsm) campaign(force bool) {
 func (r *raftFsm) poll(id uint64, v bool) (granted int) {
 	if logger.IsEnableDebug() {
 		if v {
-			logger.Debug("raft[%v] received vote from %v at term %d.", r.id, id, r.term)
+			logger.Debug("raft[%v,%v] received vote from %v at term %d.", r.id, r.config.ReplicateAddr, id, r.term)
 		} else {
-			logger.Debug("raft[%v] received vote rejection from %v at term %d.", r.id, id, r.term)
+			logger.Debug("raft[%v,%v] received vote rejection from %v at term %d.", r.id, r.config.ReplicateAddr, id, r.term)
 		}
 	}
 	if _, ok := r.votes[id]; !ok {

--- a/depends/tiglabs/raft/raft_fsm_candidate_test.go
+++ b/depends/tiglabs/raft/raft_fsm_candidate_test.go
@@ -1,0 +1,232 @@
+// Copyright 2015 The etcd Authors
+// Modified work copyright 2018 The tiglabs Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	stor "github.com/cubefs/cubefs/depends/tiglabs/raft/storage"
+)
+
+func TestDuelingCandidates(t *testing.T) {
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	c := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	nt := newNetwork(a, b, c)
+	nt.cut(1, 3)
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	// 1 becomes leader since it receives votes from 1 and 2
+	sm := nt.peers[1].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("state = %s, want %v", sm.state, stateLeader)
+	}
+
+	// 3 stays as candidate since it receives a vote from 3 and a rejection from 2
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != stateCandidate {
+		t.Errorf("state = %s, want %v", sm.state, stateCandidate)
+	}
+
+	nt.recover()
+
+	// candidate 3 now increases its term and tries to vote again
+	// we expect it to disrupt the leader 1 since it has a higher term
+	// 3 will be follower again since both 1 and 2 rejects its vote request since 3 does not have a long enough log
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	wlog := &raftLog{
+		storage:   &stor.MemoryStorage{},
+		committed: 1,
+		unstable:  unstable{offset: 2},
+	}
+	wlog.storage.StoreEntries([]*proto.Entry{{}, {Data: nil, Term: 1, Index: 1}})
+
+	dlog, _ := newRaftLog(stor.DefaultMemoryStorage())
+	tests := []struct {
+		sm      *raftFsm
+		state   fsmState
+		term    uint64
+		raftLog *raftLog
+	}{
+		{a, stateFollower, 2, wlog},
+		{b, stateFollower, 2, wlog},
+		{c, stateFollower, 2, dlog},
+	}
+
+	for i, tt := range tests {
+		if g := tt.sm.state; g != tt.state {
+			t.Errorf("#%d: state = %s, want %s", i, g, tt.state)
+		}
+		if g := tt.sm.term; g != tt.term {
+			t.Errorf("#%d: term = %d, want %d", i, g, tt.term)
+		}
+		base := ltoa(tt.raftLog)
+		if sm, ok := nt.peers[1+uint64(i)].(*raftFsm); ok {
+			l := ltoa(sm.raftLog)
+			if g := diffu(base, l); g != "" {
+				t.Errorf("#%d: diff:\n%s", i, g)
+			}
+		} else {
+			t.Logf("#%d: empty log", i)
+		}
+	}
+}
+
+func TestDuelingPreCandidates(t *testing.T) {
+
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	c := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	a.config.PreVote = true
+	b.config.PreVote = true
+	c.config.PreVote = true
+
+	nt := newNetwork(a, b, c)
+	nt.cut(1, 3)
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	// 1 becomes leader since it receives votes from 1 and 2
+	sm := nt.peers[1].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("state = %s, want %v", sm.state, stateLeader)
+	}
+
+	// 3 campaigns then reverts to follower when its PreVote is rejected
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != stateFollower {
+		t.Errorf("state = %s, want %s", sm.state, stateFollower)
+	}
+
+	nt.recover()
+
+	// Candidate 3 now increases its term and tries to vote again.
+	// With PreVote, it does not disrupt the leader.
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	wlog := &raftLog{
+		storage:   &stor.MemoryStorage{},
+		committed: 1,
+		unstable:  unstable{offset: 2},
+	}
+	wlog.storage.StoreEntries([]*proto.Entry{{}, {Data: nil, Term: 1, Index: 1}})
+	dlog, _ := newRaftLog(stor.DefaultMemoryStorage())
+	tests := []struct {
+		sm      *raftFsm
+		state   fsmState
+		term    uint64
+		raftLog *raftLog
+	}{
+		{a, stateLeader, 1, wlog},
+		{b, stateFollower, 1, wlog},
+		{c, stateFollower, 1, dlog},
+	}
+
+	for i, tt := range tests {
+		if g := tt.sm.state; g != tt.state {
+			t.Errorf("#%d: state = %s, want %s", i, g, tt.state)
+		}
+		if g := tt.sm.term; g != tt.term {
+			t.Errorf("#%d: term = %d, want %d", i, g, tt.term)
+		}
+		base := ltoa(tt.raftLog)
+		if sm, ok := nt.peers[1+uint64(i)].(*raftFsm); ok {
+			l := ltoa(sm.raftLog)
+			if g := diffu(base, l); g != "" {
+				t.Errorf("#%d: diff:\n%s", i, g)
+			}
+		} else {
+			t.Logf("#%d: empty log", i)
+		}
+	}
+}
+
+//func TestCandidateConcede(t *testing.T) {
+//	tt := newNetwork(nil, nil, nil)
+//	tt.isolate(1)
+//
+//	tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//	tt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+//
+//	// heal the partition
+//	tt.recover()
+//	// send heartbeat; reset wait
+//	tt.send(proto.Message{From: 3, To: 3, Type: proto.MsgBeat})
+//	data := []byte("force follower")
+//	// send a proposal to 3 to flush out a MsgApp to 1
+//	tt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Data: data}}})
+//	// send heartbeat; flush out commit
+//	tt.send(proto.Message{From: 3, To: 3, Type: proto.MsgBeat})
+//
+//	a := tt.peers[1].(*raftFsm)
+//	if g := a.state; g != stateFollower {
+//		t.Errorf("state = %s, want %s", g, stateFollower)
+//	}
+//	if g := a.term; g != 1 {
+//		t.Errorf("term = %d, want %d", g, 1)
+//	}
+//	storage := stor.DefaultMemoryStorage()
+//	storage.StoreEntries([]*proto.Entry{{}, {Data: nil, Term: 1, Index: 1}, {Term: 1, Index: 2, Data: data}})
+//	wantLog := ltoa(&raftLog{
+//		storage: storage,
+//		unstable:  unstable{offset: 3},
+//		committed: 2,
+//	})
+//
+//	for i, p := range tt.peers {
+//		if sm, ok := p.(*raftFsm); ok {
+//			l := ltoa(sm.raftLog)
+//			if g := diffu(wantLog, l); g != "" {
+//				t.Errorf("#%d: diff:\n%s", i, g)
+//			}
+//		} else {
+//			t.Logf("#%d: empty log", i)
+//		}
+//	}
+//}
+
+func TestSingleNodeCandidate(t *testing.T) {
+	tt := newNetwork(nil)
+	tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	sm := tt.peers[1].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("state = %d, want %d", sm.state, stateLeader)
+	}
+}
+
+func TestSingleNodePreCandidate(t *testing.T) {
+	tt := newNetworkWithConfig(preVoteConfig, nil)
+	tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	sm := tt.peers[1].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("state = %d, want %d", sm.state, stateLeader)
+	}
+}

--- a/depends/tiglabs/raft/raft_fsm_follower.go
+++ b/depends/tiglabs/raft/raft_fsm_follower.go
@@ -29,7 +29,7 @@ func (r *raftFsm) becomeFollower(term, lead uint64) {
 	r.leader = lead
 	r.state = stateFollower
 	if logger.IsEnableDebug() {
-		logger.Debug("[raft][%v] became follower at term[%d] leader[%d].", r.id, r.term, r.leader)
+		logger.Debug("[raft][%v,%v] became follower at term[%d] leader[%d].", r.id, r.config.ReplicateAddr, r.term, r.leader)
 	}
 }
 

--- a/depends/tiglabs/raft/raft_fsm_follower.go
+++ b/depends/tiglabs/raft/raft_fsm_follower.go
@@ -187,6 +187,6 @@ func (r *raftFsm) handleAppendEntries(m *proto.Message) {
 
 func (r *raftFsm) promotable() bool {
 	// todo check snapshot
-	_, ok := r.replicas[r.config.NodeID]
-	return ok
+	pr, ok := r.replicas[r.config.NodeID]
+	return ok && pr.state != replicaStateSnapshot
 }

--- a/depends/tiglabs/raft/raft_fsm_follower.go
+++ b/depends/tiglabs/raft/raft_fsm_follower.go
@@ -58,11 +58,11 @@ func stepFollower(r *raftFsm, m *proto.Message) {
 		r.leader = m.From
 		return
 
-	case proto.ReqMsgElectAck:
+	case proto.ReqMsgPreVote:
 		r.electionElapsed = 0
 		r.leader = m.From
 		nmsg := proto.GetMessage()
-		nmsg.Type = proto.RespMsgElectAck
+		nmsg.Type = proto.RespMsgPreVote
 		nmsg.To = m.From
 		r.send(nmsg)
 		proto.ReturnMessage(m)
@@ -186,6 +186,7 @@ func (r *raftFsm) handleAppendEntries(m *proto.Message) {
 }
 
 func (r *raftFsm) promotable() bool {
+	// todo check snapshot
 	_, ok := r.replicas[r.config.NodeID]
 	return ok
 }

--- a/depends/tiglabs/raft/raft_fsm_leader.go
+++ b/depends/tiglabs/raft/raft_fsm_leader.go
@@ -57,7 +57,7 @@ func (r *raftFsm) becomeLeader() {
 
 	r.appendEntry(&proto.Entry{Term: r.term, Index: lasti + 1, Data: nil})
 	if logger.IsEnableDebug() {
-		logger.Debug("raft[%v] became leader at term %d.", r.id, r.term)
+		logger.Debug("raft[%v,%v] became leader at term %d.index:%d", r.id, r.config.ReplicateAddr, r.term, lasti+1)
 	}
 }
 

--- a/depends/tiglabs/raft/raft_fsm_leader_test.go
+++ b/depends/tiglabs/raft/raft_fsm_leader_test.go
@@ -16,59 +16,98 @@
 package raft
 
 import (
-	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	"encoding/json"
+	"reflect"
 	"testing"
+
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	stor "github.com/cubefs/cubefs/depends/tiglabs/raft/storage"
 )
 
-//func TestLeaderElection(t *testing.T) {
-//	testLeaderElection(t, false)
-//}
-//
-//func TestLeaderElectionPreVote(t *testing.T) {
-//	testLeaderElection(t, true)
-//}
-//
-//func testLeaderElection(t *testing.T, preVote bool) {
-//	var cfg func(*Config)
-//	candState := stateCandidate
-//	candTerm := uint64(1)
-//	if preVote {
-//		cfg = preVoteConfig
-//		// In pre-vote mode, an election that fails to complete
-//		// leaves the node in pre-candidate state without advancing
-//		// the term.
-//		candState = statePreCandidate
-//		candTerm = 0
-//	}
-//	tests := []struct {
-//		*network
-//		state   fsmState
-//		expTerm uint64
-//	}{
-//		{newNetworkWithConfig(cfg, nil, nil, nil), stateLeader, 1},
-//		{newNetworkWithConfig(cfg, nil, nil, nopStepper), stateLeader, 1},
-//		{newNetworkWithConfig(cfg, nil, nopStepper, nopStepper), candState, candTerm},
-//		{newNetworkWithConfig(cfg, nil, nopStepper, nopStepper, nil), candState, candTerm},
-//		{newNetworkWithConfig(cfg, nil, nopStepper, nopStepper, nil, nil), stateLeader, 1},
-//
-//		// three logs further along than 0, but in the same term so rejections
-//		// are returned instead of the votes being ignored.
-//		{newNetworkWithConfig(cfg,
-//			nil, entsWithConfig(cfg, 1), entsWithConfig(cfg, 1), entsWithConfig(cfg, 1, 1), nil),
-//			stateFollower, 1},
-//	}
-//
-//	for i, tt := range tests {
-//		tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
-//		sm := tt.network.peers[1].(*raftFsm)
-//		if sm.state != tt.state {
-//			t.Errorf("#%d: state = %s, want %s", i, sm.state, tt.state)
-//		}
-//		if g := sm.term; g != tt.expTerm {
-//			t.Errorf("#%d: term = %d, want %d", i, g, tt.expTerm)
-//		}
-//	}
-//}
+func TestLeaderElection(t *testing.T) {
+	testLeaderElection(t, false)
+}
+
+func TestLeaderElectionPreVote(t *testing.T) {
+	testLeaderElection(t, true)
+}
+
+var nopStepper = &blackHole{}
+
+func testLeaderElection(t *testing.T, preVote bool) {
+	var rf func(*raftFsm)
+	candState := stateCandidate
+	candTerm := uint64(1)
+	if preVote {
+		rf = preVoteConfig
+		// In pre-vote mode, an election that fails to complete
+		// leaves the node in pre-candidate state without advancing
+		// the term.
+		candState = statePreCandidate
+		candTerm = 0
+	}
+	tests := []struct {
+		*network
+		state   fsmState
+		expTerm uint64
+	}{
+		{newNetworkWithConfig(rf, nil, nil, nil), stateLeader, 1},
+		{newNetworkWithConfig(rf, nil, nil, nopStepper), stateLeader, 1},
+		{newNetworkWithConfig(rf, nil, nopStepper, nopStepper), fsmState(candState), candTerm},
+		{newNetworkWithConfig(rf, nil, nopStepper, nopStepper, nil), fsmState(candState), candTerm},
+		{newNetworkWithConfig(rf, nil, nopStepper, nopStepper, nil, nil), stateLeader, 1},
+
+		// three logs further along than 0, but in the same term so rejections
+		// are returned instead of the votes being ignored.
+		{newNetworkWithConfig(rf,
+			nil, entsWithConfig(rf, 1), entsWithConfig(rf, 1), entsWithConfig(rf, 1, 1), nil),
+			stateFollower, 1},
+	}
+
+	for i, tt := range tests {
+		tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+		sm := tt.network.peers[1].(*raftFsm)
+		if sm.state != tt.state {
+			t.Errorf("#%d: state = %s, want %s", i, sm.state, tt.state)
+		}
+		if g := sm.term; g != tt.expTerm {
+			t.Errorf("#%d: term = %d, want %d", i, g, tt.expTerm)
+		}
+	}
+}
+
+func entsWithConfig(configFunc func(fsm *raftFsm), terms ...uint64) *raftFsm {
+	storage := stor.DefaultMemoryStorage()
+
+	for i, term := range terms {
+		storage.StoreEntries([]*proto.Entry{{Index: uint64(i + 1), Term: term}})
+	}
+	sm := newTestRaftFsm(5, 1,
+		newTestRaftConfig(1, withStorage(storage)))
+
+	if configFunc != nil {
+		configFunc(sm)
+	}
+
+	sm.reset(terms[len(terms)-1], uint64(1), false)
+
+	return sm
+}
+
+// votedWithConfig creates a raft state machine with Vote and Term set
+// to the given value but no log entries (indicating that it voted in
+// the given term but has not received any logs).
+func votedWithConfig(configFunc func(fsm *raftFsm), vote, term uint64) *raftFsm {
+	storage := stor.DefaultMemoryStorage()
+	storage.StoreHardState(proto.HardState{Vote: vote, Term: term})
+	sm := newTestRaftFsm(5, 1,
+		newTestRaftConfig(1, withStorage(storage)))
+
+	if configFunc != nil {
+		configFunc(sm)
+	}
+	return sm
+}
 
 func TestLeaderCycle(t *testing.T) {
 	testLeaderCycle(t, false)
@@ -105,74 +144,1035 @@ func testLeaderCycle(t *testing.T, preVote bool) {
 // newly-elected leader does *not* have the newest (i.e. highest term)
 // log entries, and must overwrite higher-term log entries with
 // lower-term ones.
-//func TestLeaderElectionOverwriteNewerLogs(t *testing.T) {
-//	testLeaderElectionOverwriteNewerLogs(t, false)
-//}
+func TestLeaderElectionOverwriteNewerLogs(t *testing.T) {
+	testLeaderElectionOverwriteNewerLogs(t, false)
+}
+
+func TestLeaderElectionOverwriteNewerLogsPreVote(t *testing.T) {
+	testLeaderElectionOverwriteNewerLogs(t, true)
+}
+
+func testLeaderElectionOverwriteNewerLogs(t *testing.T, preVote bool) {
+	var rf func(*raftFsm)
+	if preVote {
+		rf = preVoteConfig
+	}
+	// This network represents the results of the following sequence of
+	// events:
+	// - Node 1 won the election in term 1.
+	// - Node 1 replicated a log entry to node 2 but died before sending
+	//   it to other nodes.
+	// - Node 3 won the second election in term 2.
+	// - Node 3 wrote an entry to its logs but died without sending it
+	//   to any other nodes.
+	//
+	// At this point, nodes 1, 2, and 3 all have uncommitted entries in
+	// their logs and could win an election at term 3. The winner's log
+	// entry overwrites the losers'. (TestLeaderSyncFollowerLog tests
+	// the case where older log entries are overwritten, so this test
+	// focuses on the case where the newer entries are lost).
+	n := newNetworkWithConfig(rf,
+		entsWithConfig(rf, 1),     // Node 1: Won first election
+		entsWithConfig(rf, 1),     // Node 2: Got logs from node 1
+		entsWithConfig(rf, 2),     // Node 3: Won second election
+		votedWithConfig(rf, 3, 2), // Node 4: Voted but didn't get logs
+		votedWithConfig(rf, 3, 2)) // Node 5: Voted but didn't get logs
+
+	// Node 1 campaigns. The election fails because a quorum of nodes
+	// know about the election that already happened at term 2. Node 1's
+	// term is pushed ahead to 2.
+	n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	sm1 := n.peers[1].(*raftFsm)
+	if sm1.state != stateFollower {
+		t.Errorf("state = %s, want stateFollower", sm1.state)
+	}
+	if sm1.term != 2 {
+		t.Errorf("term = %d, want 2", sm1.term)
+	}
+
+	// Node 1 campaigns again with a higher term. This time it succeeds.
+	n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	if sm1.state != stateLeader {
+		t.Errorf("state = %s, want stateLeader", sm1.state)
+	}
+	if sm1.term != 3 {
+		t.Errorf("term = %d, want 3", sm1.term)
+	}
+
+	// Now all nodes agree on a log entry with term 1 at index 1 (and
+	// term 3 at index 2).
+	for i := range n.peers {
+		sm := n.peers[i].(*raftFsm)
+		entries := sm.raftLog.allEntries()
+		if len(entries) != 2 {
+			t.Fatalf("node %d: len(entries) == %d, want 2", i, len(entries))
+		}
+		if entries[0].Term != 1 {
+			t.Errorf("node %d: term at index 1 == %d, want 1", i, entries[0].Term)
+		}
+		if entries[1].Term != 3 {
+			t.Errorf("node %d: term at index 2 == %d, want 3", i, entries[1].Term)
+		}
+	}
+}
+
+// TestCannotCommitWithoutNewTermEntry tests the entries cannot be committed
+// when leader changes, no new proposal comes in and ChangeTerm proposal is
+// filtered.
+func TestCannotCommitWithoutNewTermEntry(t *testing.T) {
+	tt := newNetwork(nil, nil, nil, nil, nil)
+	tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// 0 cannot reach 2,3,4
+	tt.cut(1, 3)
+	tt.cut(1, 4)
+	tt.cut(1, 5)
+
+	tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: 2, Term: 1, Data: []byte("some data")}}})
+	tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: 3, Term: 1, Data: []byte("some data")}}})
+
+	sm := tt.peers[1].(*raftFsm)
+	if sm.raftLog.committed != 1 {
+		t.Errorf("committed = %d, want %d", sm.raftLog.committed, 1)
+	}
+
+	// network recovery
+	tt.recover()
+	// avoid committing ChangeTerm proposal
+	tt.ignore(proto.ReqMsgAppend)
+
+	// elect 2 as the new leader with term 2
+	tt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+
+	// no log entries from previous term should be committed
+	sm = tt.peers[2].(*raftFsm)
+	if sm.raftLog.committed != 1 {
+		t.Errorf("committed = %d, want %d", sm.raftLog.committed, 1)
+	}
+
+	tt.recover()
+
+	// tell other nodes, network has recover
+	tt.send(proto.Message{From: 2, To: 1, Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 0, Entries: []*proto.Entry{{Data: nil, Index: 4, Term: 2}}})
+	tt.send(proto.Message{From: 2, To: 3, Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 0, Entries: []*proto.Entry{{Data: nil, Index: 4, Term: 2}}})
+	tt.send(proto.Message{From: 2, To: 4, Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 0, Entries: []*proto.Entry{{Data: nil, Index: 4, Term: 2}}})
+	tt.send(proto.Message{From: 2, To: 5, Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 0, Entries: []*proto.Entry{{Data: nil, Index: 4, Term: 2}}})
+
+	// append an entry at current term
+	tt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: 5, Term: 2, Data: []byte("some data")}}})
+	// expect the committed to be advanced
+
+	if sm.raftLog.committed != 5 {
+		t.Errorf("committed = %d, want %d", sm.raftLog.committed, 5)
+	}
+}
+
+func TestCommit(t *testing.T) {
+	tests := []struct {
+		matches []uint64
+		logs    []*proto.Entry
+		smTerm  uint64
+		w       uint64
+	}{
+		// single
+		{[]uint64{1}, []*proto.Entry{{Index: 1, Term: 1}}, 1, 1},
+		{[]uint64{1}, []*proto.Entry{{Index: 1, Term: 1}}, 2, 0},
+		{[]uint64{2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}, 2, 2},
+		{[]uint64{1}, []*proto.Entry{{Index: 1, Term: 2}}, 2, 1},
+
+		// odd
+		{[]uint64{2, 1, 1}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}, 1, 1},
+		{[]uint64{2, 1, 1}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1}}, 2, 0},
+		{[]uint64{2, 1, 2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}, 2, 2},
+		{[]uint64{2, 1, 2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1}}, 2, 0},
+
+		// even
+		{[]uint64{2, 1, 1, 1}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}, 1, 1},
+		{[]uint64{2, 1, 1, 1}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1}}, 2, 0},
+		{[]uint64{2, 1, 1, 2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}, 1, 1},
+		{[]uint64{2, 1, 1, 2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1}}, 2, 0},
+		{[]uint64{2, 1, 2, 2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}, 2, 2},
+		{[]uint64{2, 1, 2, 2}, []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1}}, 2, 0},
+	}
+
+	for i, tt := range tests {
+		s := stor.DefaultMemoryStorage()
+		s.StoreEntries(tt.logs)
+		s.StoreHardState(proto.HardState{Term: tt.smTerm})
+		cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+		sm := newTestRaftFsm(10, 1, cfg)
+
+		for j := 0; j < len(tt.matches); j++ {
+			id := uint64(j) + 1
+			if id > 1 {
+				sm.applyConfChange(&proto.ConfChange{Type: proto.ConfAddNode, Peer: proto.Peer{PeerID: id, ID: id, Type: proto.PeerNormal}})
+			}
+			pr := sm.replicas[id]
+			pr.match, pr.next = tt.matches[j], tt.matches[j]+1
+		}
+		sm.maybeCommit()
+		if g := sm.raftLog.committed; g != tt.w {
+			t.Errorf("#%d: committed = %d, want %d", i, g, tt.w)
+		}
+	}
+}
+
+// TestHandleMsgApp ensures:
+// 1. Reply false if log doesn’t contain an entry at prevLogIndex whose term matches prevLogTerm.
+// 2. If an existing entry conflicts with a new one (same index but different terms),
+//    delete the existing entry and all that follow it; append any new entries not already in the log.
+// 3. If leaderCommit > commitIndex, set commitIndex = min(leaderCommit, index of last new entry).
+func TestHandleMsgApp(t *testing.T) {
+	tests := []struct {
+		m       *proto.Message
+		wIndex  uint64
+		wCommit uint64
+		wReject bool
+	}{
+		// Ensure 1
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 3, Index: 2, Commit: 3}, 2, 0, true}, // previous log mismatch
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 3, Index: 3, Commit: 3}, 2, 0, true}, // previous log non-exist
+
+		// Ensure 2
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 1, Index: 1, Commit: 1}, 2, 1, false},
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 0, Index: 0, Commit: 1, Entries: []*proto.Entry{{Index: 1, Term: 2}}}, 1, 1, false},
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 2, Commit: 3, Entries: []*proto.Entry{{Index: 3, Term: 2}, {Index: 4, Term: 2}}}, 4, 3, false},
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 2, Commit: 4, Entries: []*proto.Entry{{Index: 3, Term: 2}}}, 3, 3, false},
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 1, Index: 1, Commit: 4, Entries: []*proto.Entry{{Index: 2, Term: 2}}}, 2, 2, false},
+
+		// Ensure 3
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 1, LogTerm: 1, Index: 1, Commit: 3}, 2, 1, false},                                               // match entry 1, commit up to last new entry 1
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 1, LogTerm: 1, Index: 1, Commit: 3, Entries: []*proto.Entry{{Index: 2, Term: 2}}}, 2, 2, false}, // match entry 1, commit up to last new entry 2
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 2, Commit: 3}, 2, 2, false},                                               // match entry 2, commit up to last new entry 2
+		{&proto.Message{Type: proto.ReqMsgAppend, Term: 2, LogTerm: 2, Index: 2, Commit: 4}, 2, 2, false},                                               // commit up to log.last()
+	}
+
+	for i, tt := range tests {
+		s := stor.DefaultMemoryStorage()
+		s.StoreEntries([]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}})
+		cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+		sm := newTestRaftFsm(10, 1, cfg)
+
+		sm.handleAppendEntries(tt.m)
+		if sm.raftLog.lastIndex() != tt.wIndex {
+			t.Errorf("#%d: lastIndex = %d, want %d", i, sm.raftLog.lastIndex(), tt.wIndex)
+		}
+		if sm.raftLog.committed != tt.wCommit {
+			t.Errorf("#%d: committed = %d, want %d", i, sm.raftLog.committed, tt.wCommit)
+		}
+		m := sm.readMessages()
+		if len(m) != 1 {
+			t.Fatalf("#%d: msg = nil, want 1", i)
+		}
+		if m[0].Reject != tt.wReject {
+			t.Errorf("#%d: reject = %v, want %v", i, m[0].Reject, tt.wReject)
+		}
+	}
+}
+
+// TestMsgAppRespWaitReset verifies the resume behavior of a leader
+// MsgAppResp.
+func TestMsgAppRespWaitReset(t *testing.T) {
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3))
+	sm := newTestRaftFsm(5, 1, cfg)
+	sm.becomeCandidate()
+	sm.becomeLeader()
+
+	// The new leader has just emitted a new Term 4 entry; consume those messages
+	// from the outgoing queue.
+	sm.bcastAppend()
+	sm.readMessages()
+
+	// Node 2 acks the first entry, making it committed.
+	sm.Step(&proto.Message{
+		From:  2,
+		Type:  proto.RespMsgAppend,
+		Index: 1,
+	})
+	if sm.raftLog.committed != 1 {
+		t.Fatalf("expected committed to be 1, got %d", sm.raftLog.committed)
+	}
+	// Also consume the MsgApp messages that update Commit on the followers.
+	sm.readMessages()
+
+	// A new command is now proposed on node 1.
+	sm.Step(&proto.Message{
+		From:    1,
+		To:      1,
+		Type:    proto.LocalMsgProp,
+		Entries: []*proto.Entry{{Term: 1, Index: 2, Data: nil}},
+	})
+
+	// The command is broadcast to all nodes not in the wait state.
+	// Node 2 left the wait state due to its MsgAppResp, but node 3 is still waiting.
+	msgs := sm.readMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Type != proto.ReqMsgAppend || msgs[0].To != 2 {
+		t.Errorf("expected MsgApp to node 2, got %v to %d", msgs[0].Type, msgs[0].To)
+	}
+	if len(msgs[0].Entries) != 1 || msgs[0].Entries[0].Index != 2 {
+		t.Errorf("expected to send entry 2, but got %v", msgs[0].Entries)
+	}
+
+	// Now Node 3 acks the first entry. This releases the wait and entry 2 is sent.
+	sm.Step(&proto.Message{
+		From:  3,
+		Type:  proto.RespMsgAppend,
+		Index: 1,
+	})
+	msgs = sm.readMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Type != proto.ReqMsgAppend || msgs[0].To != 3 {
+		t.Errorf("expected MsgApp to node 3, got %v to %d", msgs[0].Type, msgs[0].To)
+	}
+	if len(msgs[0].Entries) != 1 || msgs[0].Entries[0].Index != 2 {
+		t.Errorf("expected to send entry 2, but got %v", msgs[0].Entries)
+	}
+}
+
+func TestLeaderAppResp(t *testing.T) {
+	// initial progress: match = 0; next = 3
+	tests := []struct {
+		index  uint64
+		reject bool
+		// progress
+		wmatch uint64
+		wnext  uint64
+		// message
+		wmsgNum    int
+		windex     uint64
+		wcommitted uint64
+	}{
+		{3, true, 0, 3, 0, 0, 0},  // stale resp; no replies
+		{2, true, 0, 2, 1, 1, 0},  // denied resp; leader does not commit; decrease next and send probing msg
+		{2, false, 2, 4, 2, 2, 2}, // accept resp; leader commits; broadcast with commit index
+		{0, false, 0, 3, 0, 0, 0}, // ignore heartbeat replies
+	}
+
+	for i, tt := range tests {
+		// sm term is 1 after it becomes the leader.
+		// thus the last log term must be 1 to be committed.
+		s := stor.DefaultMemoryStorage()
+		s.StoreEntries([]*proto.Entry{{}, {Index: 1, Term: 0}, {Index: 2, Term: 1}})
+		cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3))
+		sm := newTestRaftFsm(5, 1, cfg)
+		sm.raftLog.unstable = unstable{offset: 3}
+		sm.becomeCandidate()
+		sm.becomeLeader()
+		sm.readMessages()
+		sm.Step(&proto.Message{
+			From:        2,
+			Type:        proto.RespMsgAppend,
+			Index:       tt.index,
+			Term:        sm.term,
+			Reject:      tt.reject,
+			RejectIndex: tt.index},
+		)
+
+		p := sm.replicas[2]
+		if p.match != tt.wmatch {
+			t.Errorf("#%d match = %d, want %d", i, p.match, tt.wmatch)
+		}
+		if p.next != tt.wnext {
+			t.Errorf("#%d next = %d, want %d", i, p.next, tt.wnext)
+		}
+
+		msgs := sm.readMessages()
+
+		if len(msgs) != tt.wmsgNum {
+			t.Errorf("#%d msgNum = %d, want %d", i, len(msgs), tt.wmsgNum)
+		}
+		for j, msg := range msgs {
+			if msg.Index != tt.windex {
+				t.Errorf("#%d.%d index = %d, want %d", i, j, msg.Index, tt.windex)
+			}
+			if msg.Commit != tt.wcommitted {
+				t.Errorf("#%d.%d commit = %d, want %d", i, j, msg.Commit, tt.wcommitted)
+			}
+		}
+	}
+}
+
+func TestLeaderIncreaseNext(t *testing.T) {
+	previousEnts := []*proto.Entry{{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3}}
+	tests := []struct {
+		// progress
+		state replicaState
+		next  uint64
+
+		wnext uint64
+	}{
+		// state replicate, optimistically increase next
+		// previous entries + noop entry + propose + 1
+		{replicaStateReplicate, 2, uint64(len(previousEnts) + 1 + 1 + 1)},
+		// state probe, not optimistically increase next
+		{replicaStateProbe, 2, 2},
+	}
+
+	for i, tt := range tests {
+		s := stor.DefaultMemoryStorage()
+		s.StoreEntries(previousEnts)
+		cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2))
+		sm := newTestRaftFsm(5, 1, cfg)
+		sm.becomeCandidate()
+		sm.becomeLeader()
+		sm.replicas[2].state = tt.state
+		sm.replicas[2].next = tt.next
+		// Index = 3(old data) + 1(leader send nil data to other) + 1(new index) = 5
+		sm.Step(&proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Term: 1, Index: 5, Data: []byte("somedata")}}})
+
+		p := sm.replicas[2]
+		if p.next != tt.wnext {
+			t.Errorf("#%d next = %d, want %d", i, p.next, tt.wnext)
+		}
+	}
+}
+
+func mustAppendEntry(r *raftFsm, ents ...*proto.Entry) {
+	for _, entry := range ents {
+		r.appendEntry(entry)
+	}
+}
+
+func TestSendAppendForProgressReplicate(t *testing.T) {
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2))
+	r := newTestRaftFsm(5, 1, cfg)
+	r.becomeCandidate()
+	r.becomeLeader()
+	r.readMessages()
+	r.replicas[2].becomeReplicate()
+
+	for i := 0; i < 10; i++ {
+		mustAppendEntry(r, &proto.Entry{Data: []byte("somedata")})
+		r.sendAppend(2)
+		msgs := r.readMessages()
+		if len(msgs) != 1 {
+			t.Errorf("len(msg) = %d, want %d", len(msgs), 1)
+		}
+	}
+}
+
+func TestRestore(t *testing.T) {
+	peers := make([]proto.Peer, 0)
+	for _, p := range []uint64{1, 2} {
+		peers = append(peers, proto.Peer{Type: 0, Priority: 0, ID: p, PeerID: p})
+	}
+	snap := proto.SnapshotMeta{
+		Index: 11, // magic number
+		Term:  11, // magic number
+		Peers: peers}
+
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2))
+	sm := newTestRaftFsm(5, 1, cfg)
+	sm.restore(snap)
+	if err := sm.raftLog.storage.ApplySnapshot(snap); err != nil {
+		t.Fatal("restore fail, want succeed")
+	}
+
+	if sm.raftLog.lastIndex() != snap.Index {
+		t.Errorf("log.lastIndex = %d, want %d", sm.raftLog.lastIndex(), snap.Index)
+	}
+	if mustTerm(sm.raftLog.term(snap.Index)) != snap.Term {
+		t.Errorf("log.lastTerm = %d, want %d", mustTerm(sm.raftLog.term(snap.Index)), snap.Term)
+	}
+	sg := sm.peers()
+	if !reflect.DeepEqual(sg, snap.Peers) {
+		t.Errorf("sm.Voters = %+v, want %+v", sg, snap.Peers)
+	}
+	// mark node 1 as snapshot state ?
+	sm.replicas[1].becomeSnapshot(12)
+
+	//todo  It should not campaign before actually applying data.
+	for i := 0; i < sm.randElectionTick; i++ {
+		sm.tick()
+	}
+	if sm.state != stateFollower {
+		t.Errorf("state = %d, want %d", sm.state, stateFollower)
+	}
+}
+
+func TestRestoreIgnoreSnapshot(t *testing.T) {
+	peers := make([]proto.Peer, 0)
+	for _, p := range []uint64{1, 2} {
+		peers = append(peers, proto.Peer{Type: 0, Priority: 0, ID: p, PeerID: p})
+	}
+	previousEnts := []*proto.Entry{{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3}}
+	commit := uint64(1)
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2))
+	sm := newTestRaftFsm(5, 1, cfg)
+	sm.raftLog.append(previousEnts...)
+	sm.raftLog.commitTo(commit)
+
+	meta := proto.SnapshotMeta{
+		Index: commit,
+		Term:  1,
+		Peers: peers,
+	}
+
+	// ignore snapshot
+	sm.restore(meta)
+	if sm.raftLog.committed != commit {
+		t.Errorf("commit = %d, want %d", sm.raftLog.committed, commit)
+	}
+
+	// ignore snapshot and fast forward commit
+	meta.Index = commit + 1
+	sm.restore(meta)
+	if sm.raftLog.committed != commit+1 {
+		t.Errorf("commit = %d, want %d", sm.raftLog.committed, commit+1)
+	}
+}
+
+type testFsmStateMachine struct {
+	applyIndex uint64
+}
+
+func (sm *testFsmStateMachine) Apply(command []byte, index uint64) (interface{}, error) {
+	return nil, nil
+}
+func (sm *testFsmStateMachine) ApplyMemberChange(cc *proto.ConfChange, index uint64) (interface{}, error) {
+	return nil, nil
+}
+func (sm *testFsmStateMachine) Snapshot() (proto.Snapshot, error) {
+	return &testSnapshot{applyIndex: sm.applyIndex}, nil
+}
+func (sm *testFsmStateMachine) ApplySnapshot(peers []proto.Peer, iter proto.SnapIterator) error {
+	return nil
+}
+func (sm *testFsmStateMachine) HandleLeaderChange(leader uint64) {}
+func (sm *testFsmStateMachine) HandleFatalEvent(err *FatalError) {}
+
+type testSnapshot struct {
+	applyIndex uint64
+}
+
+func (ts *testSnapshot) ApplyIndex() uint64    { return ts.applyIndex }
+func (ts *testSnapshot) Close()                {}
+func (ts *testSnapshot) Next() ([]byte, error) { return nil, nil }
+
+func TestProvideSnap(t *testing.T) {
+	// restore the state machine from a snapshot so it has a compacted log and a snapshot
+	peers := make([]proto.Peer, 0)
+	for _, p := range []uint64{1, 2} {
+		peers = append(peers, proto.Peer{Type: 0, Priority: 0, ID: p, PeerID: p})
+	}
+	meta := proto.SnapshotMeta{
+		Index: 11, // magic number
+		Term:  11, // magic number
+		Peers: peers,
+	}
+	s := stor.DefaultMemoryStorage()
+	s.ApplySnapshot(meta)
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+	sm := newTestRaftFsm(5, 1, cfg)
+	sm.restore(meta)
+
+	sm.sm = &testFsmStateMachine{applyIndex: 13}
+
+	sm.becomeCandidate()
+	sm.becomeLeader()
+
+	// force set the next of node 2, so that node 2 needs a snapshot
+	sm.replicas[2].next = sm.raftLog.firstIndex()
+	sm.Step(&proto.Message{From: 2, To: 1, Type: proto.RespMsgAppend, Index: sm.replicas[2].next - 1, Reject: true})
+
+	msgs := sm.readMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs) = %d, want 1", len(msgs))
+	}
+	m := msgs[0]
+	if m.Type != proto.ReqMsgSnapShot {
+		t.Errorf("m.Type = %v, want %v", m.Type, proto.ReqMsgSnapShot)
+	}
+}
+
+func TestIgnoreProvidingSnap(t *testing.T) {
+	// restore the state machine from a snapshot so it has a compacted log and a snapshot
+	peers := make([]proto.Peer, 0)
+	for _, p := range []uint64{1, 2} {
+		peers = append(peers, proto.Peer{Type: 0, Priority: 0, ID: p, PeerID: p})
+	}
+	meta := proto.SnapshotMeta{
+		Index: 11, // magic number
+		Term:  11, // magic number
+		Peers: peers,
+	}
+	s := stor.DefaultMemoryStorage()
+	s.ApplySnapshot(meta)
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+	sm := newTestRaftFsm(5, 1, cfg)
+	sm.restore(meta)
+
+	sm.sm = &testFsmStateMachine{applyIndex: 13}
+
+	sm.becomeCandidate()
+	sm.becomeLeader()
+
+	// force set the next of node 2, so that node 2 needs a snapshot
+	// change node 2 to be inactive, expect node 1 ignore sending snapshot to 2
+	sm.replicas[2].next = sm.raftLog.firstIndex() - 1
+	sm.replicas[2].active = false
+
+	sm.Step(&proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Term: 12, Index: 13, Data: []byte("somedata")}}})
+
+	msgs := sm.readMessages()
+	if len(msgs) != 0 {
+		t.Errorf("len(msgs) = %d, want 0", len(msgs))
+	}
+}
+
+// TestAddNode tests that addNode could update nodes correctly.
+func TestAddNode(t *testing.T) {
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+	r := newTestRaftFsm(5, 1, cfg)
+	r.applyConfChange(&proto.ConfChange{Peer: proto.Peer{Type: 0, ID: 2, PeerID: 2, Priority: 0}, Type: proto.ConfAddNode})
+	nodes := r.replicas
+	if len(nodes) != 2 {
+		t.Errorf("nodes = %v, want %v", len(nodes), 2)
+	}
+}
+
+// TestAddNodeCheckQuorum tests that addNode does not trigger a leader election
+// immediately when checkQuorum is set.
+func TestAddNodeCheckQuorum(t *testing.T) {
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+	r := newTestRaftFsm(5, 1, cfg)
+	r.config.LeaseCheck = true
+	r.becomeCandidate()
+	r.becomeLeader()
+
+	for i := 0; i < r.electionElapsed-1; i++ {
+		r.tick()
+	}
+
+	r.applyConfChange(&proto.ConfChange{Peer: proto.Peer{Type: 0, ID: 2, PeerID: 2, Priority: 0}, Type: proto.ConfAddNode})
+
+	// This tick will reach electionTimeout, which triggers a quorum check.
+	r.tick()
+
+	// Node 1 should still be the leader after a single tick.
+	if r.state != stateLeader {
+		t.Errorf("state = %v, want %v", r.state, stateLeader)
+	}
+
+	// After another electionTimeout ticks without hearing from node 2,
+	// node 1 should step down.
+	for i := 0; i < r.electionElapsed; i++ {
+		r.tick()
+	}
+
+	if r.state != stateFollower {
+		t.Errorf("state = %v, want %v", r.state, stateFollower)
+	}
+}
+
+// TestRemoveNode tests that removeNode could update nodes and
+// and removed list correctly.
+func TestRemoveNode(t *testing.T) {
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2))
+	r := newTestRaftFsm(5, 1, cfg)
+	r.applyConfChange(&proto.ConfChange{Peer: proto.Peer{Type: 0, ID: 2, PeerID: 2, Priority: 0}, Type: proto.ConfRemoveNode})
+	w := []uint64{1}
+	if g := r.peers(); len(g) != len(w) {
+		t.Errorf("nodes = %v, want %v", g, w)
+	}
+
+	//todo Removing the remaining voter will panic?
+	//defer func() {
+	//	if r := recover(); r == nil {
+	//		t.Error("did not panic")
+	//	}
+	//}()
+	//r.applyConfChange(&proto.ConfChange{Peer: proto.Peer{Type: 0, ID: 1, PeerID: 1, Priority: 0}, Type: proto.ConfRemoveNode})
+}
+
+func TestPromotable(t *testing.T) {
+	id := uint64(1)
+	tests := []struct {
+		peers []uint64
+		wp    bool
+	}{
+		{[]uint64{1}, true},
+		{[]uint64{1, 2, 3}, true},
+		{[]uint64{}, false},
+		{[]uint64{2, 3}, false},
+	}
+	for i, tt := range tests {
+		s := stor.DefaultMemoryStorage()
+		cfg := newTestRaftConfig(id, withStorage(s), withPeers(tt.peers...))
+		r := newTestRaftFsm(5, 1, cfg)
+		if g := r.promotable(); g != tt.wp {
+			t.Errorf("#%d: promotable = %v, want %v", i, g, tt.wp)
+		}
+	}
+}
+
+func TestCampaignWhileLeader(t *testing.T) {
+	testCampaignWhileLeader(t, false)
+}
+
+func TestPreCampaignWhileLeader(t *testing.T) {
+	testCampaignWhileLeader(t, true)
+}
+
+func testCampaignWhileLeader(t *testing.T, preVote bool) {
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1))
+	r := newTestRaftFsm(5, 1, cfg)
+	r.config.PreVote = preVote
+	if r.state != stateFollower {
+		t.Errorf("expected new node to be follower but got %s", r.state)
+	}
+	// We don't call campaign() directly because it comes after the check
+	// for our current state.
+	r.Step(&proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	if r.state != stateLeader {
+		t.Errorf("expected single-node election to become leader but got %s", r.state)
+	}
+	term := r.term
+	r.Step(&proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	if r.state != stateLeader {
+		t.Errorf("expected to remain leader but got %s", r.state)
+	}
+	if r.term != term {
+		t.Errorf("expected to remain in term %v but got %v", term, r.term)
+	}
+}
+
+// nextEnts returns the appliable entries and updates the applied index
+func nextEnts(r *raftFsm, s *stor.MemoryStorage) (ents []*proto.Entry) {
+	// Transfer all unstable entries to "stable" storage.
+	s.StoreEntries(r.raftLog.unstableEntries())
+	r.raftLog.stableTo(r.raftLog.lastIndex(), r.raftLog.lastTerm())
+
+	ents = r.raftLog.nextEnts(1024)
+	r.raftLog.appliedTo(r.raftLog.committed)
+	return ents
+}
+
+// TestCommitAfterRemoveNode verifies that pending commands can become
+// committed when a config change reduces the quorum requirements.
+func TestCommitAfterRemoveNode(t *testing.T) {
+	// Create a cluster with two nodes.
+	s := stor.DefaultMemoryStorage()
+	cfg := newTestRaftConfig(1, withStorage(s), withPeers(1, 2))
+	r := newTestRaftFsm(5, 1, cfg)
+	r.becomeCandidate()
+	r.becomeLeader()
+
+	// Begin to remove the second node.
+	cc := proto.ConfChange{
+		Type: proto.ConfRemoveNode,
+		Peer: proto.Peer{PeerID: 2, ID: 2},
+	}
+	ccData, err := json.Marshal(cc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Step(&proto.Message{
+		Type: proto.LocalMsgProp,
+		Entries: []*proto.Entry{
+			{Type: proto.EntryConfChange, Data: ccData, Index: 2, Term: 1},
+		},
+	})
+	// Stabilize the log and make sure nothing is committed yet.
+	if ents := nextEnts(r, s); len(ents) > 0 {
+		t.Fatalf("unexpected committed entries: %v", ents)
+	}
+	ccIndex := r.raftLog.lastIndex()
+
+	// While the config change is pending, make another proposal.
+	r.Step(&proto.Message{
+		Type: proto.LocalMsgProp,
+		Entries: []*proto.Entry{
+			{Type: proto.EntryNormal, Data: []byte("hello"), Index: 3, Term: 1},
+		},
+	})
+
+	// Node 2 acknowledges the config change, committing it.
+	r.Step(&proto.Message{
+		Type:  proto.RespMsgAppend,
+		From:  2,
+		To:    1,
+		Index: ccIndex,
+	})
+	ents := nextEnts(r, s)
+	if len(ents) != 2 {
+		t.Fatalf("expected two committed entries, got %v", ents)
+	}
+	if ents[0].Type != proto.EntryNormal || ents[0].Data != nil {
+		t.Fatalf("expected ents[0] to be empty, but got %v", ents[0])
+	}
+	if ents[1].Type != proto.EntryConfChange {
+		t.Fatalf("expected ents[1] to be EntryConfChange, got %v", ents[1])
+	}
+
+	// Apply the config change. This reduces quorum requirements so the
+	// pending command can now commit.
+	r.applyConfChange(&cc)
+	ents = nextEnts(r, s)
+	if len(ents) != 1 || ents[0].Type != proto.EntryNormal ||
+		string(ents[0].Data) != "hello" {
+		t.Fatalf("expected one committed EntryNormal, got %v", ents)
+	}
+}
+
+func checkLeaderTransferState(t *testing.T, r *raftFsm, state fsmState, lead uint64) {
+	if r.state != state || r.leader != lead {
+		t.Fatalf("after transferring, node has state %v lead %v, want state %v lead %v", r.state, r.leader, state, lead)
+	}
+	//if r.leadTransferee != None {
+	//	t.Fatalf("after transferring, node has leadTransferee %v, want leadTransferee %v", r.leadTransferee, None)
+	//}
+}
+
+// TestLeaderTransferToUpToDateNode verifies transferring should succeed
+// if the transferee has the most up-to-date log entries when transfer starts.
+func TestLeaderTransferToUpToDateNode(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	lead := nt.peers[1].(*raftFsm)
+
+	if lead.leader != 1 {
+		t.Fatalf("after election leader is %x, want 1", lead.leader)
+	}
+
+	// Transfer leadership to 2.
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup, ForceVote: true})
+
+	checkLeaderTransferState(t, lead, stateFollower, 2)
+
+	// After some log replication, transfer leadership back to 1.
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, ForceVote: true})
+
+	nt.send(proto.Message{From: 1, To: 2, Type: proto.LeaseMsgOffline})
+
+	checkLeaderTransferState(t, lead, stateLeader, 1)
+}
+
+// TestLeaderTransferToUpToDateNodeFromFollower verifies transferring should succeed
+// if the transferee has the most up-to-date log entries when transfer starts.
+// Not like TestLeaderTransferToUpToDateNode, where the leader transfer message
+// is sent to the leader, in this test case every leader transfer message is sent
+// to the follower.
+func TestLeaderTransferToUpToDateNodeFromFollower(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	lead := nt.peers[1].(*raftFsm)
+
+	if lead.leader != 1 {
+		t.Fatalf("after election leader is %x, want 1", lead.leader)
+	}
+
+	// Transfer leadership to 2.
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup, ForceVote: true})
+
+	checkLeaderTransferState(t, lead, stateFollower, 2)
+
+	// After some log replication, transfer leadership back to 1.
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup, ForceVote: true})
+
+	checkLeaderTransferState(t, lead, stateLeader, 1)
+}
+
+// setRandomizedElectionTimeout set up the value by caller instead of choosing
+// by system, in some test scenario we need to fill in some expected value to
+// ensure the certainty
+func setRandomizedElectionTimeout(r *raftFsm, v int) {
+	r.randElectionTick = v
+}
+
+// TestLeaderTransferWithCheckQuorum ensures transferring leader still works
+// even the current leader is still under its leader lease
+func TestLeaderTransferWithCheckQuorum(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	for i := 1; i < 4; i++ {
+		r := nt.peers[uint64(i)].(*raftFsm)
+		r.config.LeaseCheck = true
+		setRandomizedElectionTimeout(r, r.electionElapsed+i)
+	}
+
+	// Letting peer 2 electionElapsed reach to timeout so that it can vote for peer 1
+	f := nt.peers[2].(*raftFsm)
+	for i := 0; i < f.electionElapsed; i++ {
+		f.tick()
+	}
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	lead := nt.peers[1].(*raftFsm)
+
+	if lead.leader != 1 {
+		t.Fatalf("after election leader is %x, want 1", lead.leader)
+	}
+
+	// Transfer leadership to 2.
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup, ForceVote: true})
+
+	checkLeaderTransferState(t, lead, stateFollower, 2)
+
+	// After some log replication, transfer leadership back to 1.
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup, ForceVote: true})
+
+	checkLeaderTransferState(t, lead, stateLeader, 1)
+}
+
+func TestLeaderTransferToSlowFollower(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	nt.isolate(3)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+
+	nt.recover()
+	lead := nt.peers[1].(*raftFsm)
+	if lead.replicas[3].match != 1 {
+		t.Fatalf("node 1 has match %x for node 3, want %x", lead.replicas[3].match, 1)
+	}
+
+	// Transfer leadership to 3 when node 3 is lack of log.
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup, ForceVote: true})
+
+	checkLeaderTransferState(t, lead, stateFollower, 3)
+}
+
+//func TestLeaderTransferAfterSnapshot(t *testing.T) {
+//	nt := newNetwork(nil, nil, nil)
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.MsgHup})
 //
-//func TestLeaderElectionOverwriteNewerLogsPreVote(t *testing.T) {
-//	testLeaderElectionOverwriteNewerLogs(t, true)
-//}
+//	nt.isolate(3)
 //
-//func testLeaderElectionOverwriteNewerLogs(t *testing.T, preVote bool) {
-//	var cfg func(*Config)
-//	if preVote {
-//		cfg = preVoteConfig
-//	}
-//	// This network represents the results of the following sequence of
-//	// events:
-//	// - Node 1 won the election in term 1.
-//	// - Node 1 replicated a log entry to node 2 but died before sending
-//	//   it to other nodes.
-//	// - Node 3 won the second election in term 2.
-//	// - Node 3 wrote an entry to its logs but died without sending it
-//	//   to any other nodes.
-//	//
-//	// At this point, nodes 1, 2, and 3 all have uncommitted entries in
-//	// their logs and could win an election at term 3. The winner's log
-//	// entry overwrites the losers'. (TestLeaderSyncFollowerLog tests
-//	// the case where older log entries are overwritten, so this test
-//	// focuses on the case where the newer entries are lost).
-//	n := newNetworkWithConfig(cfg,
-//		entsWithConfig(cfg, 1),     // Node 1: Won first election
-//		entsWithConfig(cfg, 1),     // Node 2: Got logs from node 1
-//		entsWithConfig(cfg, 2),     // Node 3: Won second election
-//		votedWithConfig(cfg, 3, 2), // Node 4: Voted but didn't get logs
-//		votedWithConfig(cfg, 3, 2)) // Node 5: Voted but didn't get logs
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.MsgProp, Entries: []proto.Entry{{}}})
+//	lead := nt.peers[1].(*raft)
+//	nextEnts(lead, nt.storage[1])
+//	nt.storage[1].CreateSnapshot(lead.raftLog.applied, &proto.ConfState{Voters: lead.prs.VoterNodes()}, nil)
+//	nt.storage[1].Compact(lead.raftLog.applied)
 //
-//	// Node 1 campaigns. The election fails because a quorum of nodes
-//	// know about the election that already happened at term 2. Node 1's
-//	// term is pushed ahead to 2.
-//	n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
-//	sm1 := n.peers[1].(*raftFsm)
-//	if sm1.state != stateFollower {
-//		t.Errorf("state = %s, want stateFollower", sm1.state)
-//	}
-//	if sm1.term != 2 {
-//		t.Errorf("term = %d, want 2", sm1.term)
+//	nt.recover()
+//	if lead.prs.Progress[3].Match != 1 {
+//		t.Fatalf("node 1 has match %x for node 3, want %x", lead.prs.Progress[3].Match, 1)
 //	}
 //
-//	// Node 1 campaigns again with a higher term. This time it succeeds.
-//	n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
-//	if sm1.state != stateLeader {
-//		t.Errorf("state = %s, want stateLeader", sm1.state)
-//	}
-//	if sm1.term != 3 {
-//		t.Errorf("term = %d, want 3", sm1.term)
-//	}
-//
-//	// Now all nodes agree on a log entry with term 1 at index 1 (and
-//	// term 3 at index 2).
-//	for i := range n.peers {
-//		sm := n.peers[i].(*raftFsm)
-//		entries := sm.raftLog.allEntries()
-//		if len(entries) != 2 {
-//			t.Fatalf("node %d: len(entries) == %d, want 2", i, len(entries))
+//	filtered := proto.Message{}
+//	// Snapshot needs to be applied before sending MsgAppResp
+//	nt.msgHook = func(m proto.Message) bool {
+//		if m.Type != proto.MsgAppResp || m.From != 3 || m.Reject {
+//			return true
 //		}
-//		if entries[0].term != 1 {
-//			t.Errorf("node %d: term at index 1 == %d, want 1", i, entries[0].term)
-//		}
-//		if entries[1].term != 3 {
-//			t.Errorf("node %d: term at index 2 == %d, want 3", i, entries[1].term)
-//		}
+//		filtered = m
+//		return false
 //	}
+//	// Transfer leadership to 3 when node 3 is lack of snapshot.
+//	nt.send(proto.Message{From: 3, To: 1, Type: proto.MsgTransferLeader})
+//	if lead.state != StateLeader {
+//		t.Fatalf("node 1 should still be leader as snapshot is not applied, got %x", lead.state)
+//	}
+//	if reflect.DeepEqual(filtered, proto.Message{}) {
+//		t.Fatalf("Follower should report snapshot progress automatically.")
+//	}
+//
+//	// Apply snapshot and resume progress
+//	follower := nt.peers[3].(*raft)
+//	ready := newReady(follower, &SoftState{}, proto.HardState{})
+//	nt.storage[3].ApplySnapshot(ready.Snapshot)
+//	follower.advance(ready)
+//	nt.msgHook = nil
+//	nt.send(filtered)
+//
+//	checkLeaderTransferState(t, lead, StateFollower, 3)
 //}
+
+func TestLeaderTransferToSelf(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	lead := nt.peers[1].(*raftFsm)
+
+	// Transfer leadership to self, there will be noop.
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup, ForceVote: true})
+	checkLeaderTransferState(t, lead, stateLeader, 1)
+}
+
+func TestLeaderTransferToNonExistingNode(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	lead := nt.peers[1].(*raftFsm)
+	// Transfer leadership to non-existing node, there will be noop.
+	nt.send(proto.Message{From: 4, To: 1, Type: proto.LocalMsgProp, ForceVote: true})
+	checkLeaderTransferState(t, lead, stateLeader, 1)
+}
+
+func TestLeaderTransferTimeout(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	nt.isolate(3)
+
+	lead := nt.peers[1].(*raftFsm)
+
+	// Transfer leadership to isolated node, wait for timeout.
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup, ForceVote: true})
+
+	for i := 0; i < lead.heartbeatElapsed; i++ {
+		lead.tick()
+	}
+
+	for i := 0; i < lead.electionElapsed-lead.heartbeatElapsed; i++ {
+		lead.tick()
+	}
+
+	checkLeaderTransferState(t, lead, stateLeader, 1)
+}
+
+func TestLeaderTransferIgnoreProposal(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	nt.isolate(3)
+
+	lead := nt.peers[1].(*raftFsm)
+
+	// Transfer leadership to isolated node to let transfer pending, then send proposal.
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+	lead.Step(&proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+
+	if lead.replicas[1].match != 1 {
+		t.Fatalf("node 1 has match %x, want %x", lead.replicas[1].match, 1)
+	}
+}
+
+func TestLeaderTransferReceiveHigherTermVote(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	nt.isolate(3)
+
+	lead := nt.peers[1].(*raftFsm)
+
+	// Transfer leadership to isolated node to let transfer pending.
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup, Index: 1, Term: 2})
+
+	checkLeaderTransferState(t, lead, stateFollower, 2)
+}

--- a/depends/tiglabs/raft/raft_fsm_leader_test.go
+++ b/depends/tiglabs/raft/raft_fsm_leader_test.go
@@ -1,0 +1,178 @@
+// Copyright 2015 The etcd Authors
+// Modified work copyright 2018 The tiglabs Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	"testing"
+)
+
+//func TestLeaderElection(t *testing.T) {
+//	testLeaderElection(t, false)
+//}
+//
+//func TestLeaderElectionPreVote(t *testing.T) {
+//	testLeaderElection(t, true)
+//}
+//
+//func testLeaderElection(t *testing.T, preVote bool) {
+//	var cfg func(*Config)
+//	candState := stateCandidate
+//	candTerm := uint64(1)
+//	if preVote {
+//		cfg = preVoteConfig
+//		// In pre-vote mode, an election that fails to complete
+//		// leaves the node in pre-candidate state without advancing
+//		// the term.
+//		candState = statePreCandidate
+//		candTerm = 0
+//	}
+//	tests := []struct {
+//		*network
+//		state   fsmState
+//		expTerm uint64
+//	}{
+//		{newNetworkWithConfig(cfg, nil, nil, nil), stateLeader, 1},
+//		{newNetworkWithConfig(cfg, nil, nil, nopStepper), stateLeader, 1},
+//		{newNetworkWithConfig(cfg, nil, nopStepper, nopStepper), candState, candTerm},
+//		{newNetworkWithConfig(cfg, nil, nopStepper, nopStepper, nil), candState, candTerm},
+//		{newNetworkWithConfig(cfg, nil, nopStepper, nopStepper, nil, nil), stateLeader, 1},
+//
+//		// three logs further along than 0, but in the same term so rejections
+//		// are returned instead of the votes being ignored.
+//		{newNetworkWithConfig(cfg,
+//			nil, entsWithConfig(cfg, 1), entsWithConfig(cfg, 1), entsWithConfig(cfg, 1, 1), nil),
+//			stateFollower, 1},
+//	}
+//
+//	for i, tt := range tests {
+//		tt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//		sm := tt.network.peers[1].(*raftFsm)
+//		if sm.state != tt.state {
+//			t.Errorf("#%d: state = %s, want %s", i, sm.state, tt.state)
+//		}
+//		if g := sm.term; g != tt.expTerm {
+//			t.Errorf("#%d: term = %d, want %d", i, g, tt.expTerm)
+//		}
+//	}
+//}
+
+func TestLeaderCycle(t *testing.T) {
+	testLeaderCycle(t, false)
+}
+
+func TestLeaderCyclePreVote(t *testing.T) {
+	testLeaderCycle(t, true)
+}
+
+// testLeaderCycle verifies that each node in a cluster can campaign
+// and be elected in turn. This ensures that elections (including
+// pre-vote) work when not starting from a clean slate (as they do in
+// TestLeaderElection)
+func testLeaderCycle(t *testing.T, preVote bool) {
+	n := newNetworkWithConfig(preVoteConfig, nil, nil, nil)
+	for campaignerID := uint64(1); campaignerID <= 3; campaignerID++ {
+		n.send(proto.Message{From: campaignerID, To: campaignerID, Type: proto.LocalMsgHup})
+
+		for _, peer := range n.peers {
+			sm := peer.(*raftFsm)
+			if sm.id == campaignerID && sm.state != stateLeader {
+				t.Errorf("preVote=%v: campaigning node %d state = %v, want stateLeader",
+					preVote, sm.id, sm.state)
+			} else if sm.id != campaignerID && sm.state != stateFollower {
+				t.Errorf("preVote=%v: after campaign of node %d, "+
+					"node %d had state = %v, want stateFollower",
+					preVote, campaignerID, sm.id, sm.state)
+			}
+		}
+	}
+}
+
+// TestLeaderElectionOverwriteNewerLogs tests a scenario in which a
+// newly-elected leader does *not* have the newest (i.e. highest term)
+// log entries, and must overwrite higher-term log entries with
+// lower-term ones.
+//func TestLeaderElectionOverwriteNewerLogs(t *testing.T) {
+//	testLeaderElectionOverwriteNewerLogs(t, false)
+//}
+//
+//func TestLeaderElectionOverwriteNewerLogsPreVote(t *testing.T) {
+//	testLeaderElectionOverwriteNewerLogs(t, true)
+//}
+//
+//func testLeaderElectionOverwriteNewerLogs(t *testing.T, preVote bool) {
+//	var cfg func(*Config)
+//	if preVote {
+//		cfg = preVoteConfig
+//	}
+//	// This network represents the results of the following sequence of
+//	// events:
+//	// - Node 1 won the election in term 1.
+//	// - Node 1 replicated a log entry to node 2 but died before sending
+//	//   it to other nodes.
+//	// - Node 3 won the second election in term 2.
+//	// - Node 3 wrote an entry to its logs but died without sending it
+//	//   to any other nodes.
+//	//
+//	// At this point, nodes 1, 2, and 3 all have uncommitted entries in
+//	// their logs and could win an election at term 3. The winner's log
+//	// entry overwrites the losers'. (TestLeaderSyncFollowerLog tests
+//	// the case where older log entries are overwritten, so this test
+//	// focuses on the case where the newer entries are lost).
+//	n := newNetworkWithConfig(cfg,
+//		entsWithConfig(cfg, 1),     // Node 1: Won first election
+//		entsWithConfig(cfg, 1),     // Node 2: Got logs from node 1
+//		entsWithConfig(cfg, 2),     // Node 3: Won second election
+//		votedWithConfig(cfg, 3, 2), // Node 4: Voted but didn't get logs
+//		votedWithConfig(cfg, 3, 2)) // Node 5: Voted but didn't get logs
+//
+//	// Node 1 campaigns. The election fails because a quorum of nodes
+//	// know about the election that already happened at term 2. Node 1's
+//	// term is pushed ahead to 2.
+//	n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//	sm1 := n.peers[1].(*raftFsm)
+//	if sm1.state != stateFollower {
+//		t.Errorf("state = %s, want stateFollower", sm1.state)
+//	}
+//	if sm1.term != 2 {
+//		t.Errorf("term = %d, want 2", sm1.term)
+//	}
+//
+//	// Node 1 campaigns again with a higher term. This time it succeeds.
+//	n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//	if sm1.state != stateLeader {
+//		t.Errorf("state = %s, want stateLeader", sm1.state)
+//	}
+//	if sm1.term != 3 {
+//		t.Errorf("term = %d, want 3", sm1.term)
+//	}
+//
+//	// Now all nodes agree on a log entry with term 1 at index 1 (and
+//	// term 3 at index 2).
+//	for i := range n.peers {
+//		sm := n.peers[i].(*raftFsm)
+//		entries := sm.raftLog.allEntries()
+//		if len(entries) != 2 {
+//			t.Fatalf("node %d: len(entries) == %d, want 2", i, len(entries))
+//		}
+//		if entries[0].term != 1 {
+//			t.Errorf("node %d: term at index 1 == %d, want 1", i, entries[0].term)
+//		}
+//		if entries[1].term != 3 {
+//			t.Errorf("node %d: term at index 2 == %d, want 3", i, entries[1].term)
+//		}
+//	}
+//}

--- a/depends/tiglabs/raft/raft_fsm_state.go
+++ b/depends/tiglabs/raft/raft_fsm_state.go
@@ -21,10 +21,10 @@ type (
 )
 
 const (
-	stateFollower    fsmState = 0
-	stateCandidate            = 1
-	stateLeader               = 2
-	stateElectionACK          = 3
+	stateFollower     fsmState = 0
+	stateCandidate             = 1
+	stateLeader                = 2
+	statePreCandidate          = 3
 
 	replicaStateProbe     replicaState = 0
 	replicaStateReplicate              = 1
@@ -40,7 +40,7 @@ func (st fsmState) String() string {
 	case 2:
 		return "StateLeader"
 	case 3:
-		return "StateElectionACK"
+		return "statePreCandidate"
 	}
 	return ""
 }

--- a/depends/tiglabs/raft/raft_fsm_state.go
+++ b/depends/tiglabs/raft/raft_fsm_state.go
@@ -22,13 +22,13 @@ type (
 
 const (
 	stateFollower     fsmState = 0
-	stateCandidate             = 1
-	stateLeader                = 2
-	statePreCandidate          = 3
+	stateCandidate    fsmState = 1
+	stateLeader       fsmState = 2
+	statePreCandidate fsmState = 3
 
 	replicaStateProbe     replicaState = 0
-	replicaStateReplicate              = 1
-	replicaStateSnapshot               = 2
+	replicaStateReplicate replicaState = 1
+	replicaStateSnapshot  replicaState = 2
 )
 
 func (st fsmState) String() string {

--- a/depends/tiglabs/raft/raft_fsm_test.go
+++ b/depends/tiglabs/raft/raft_fsm_test.go
@@ -1,0 +1,253 @@
+// Copyright 2015 The etcd Authors
+// Modified work copyright 2018 The tiglabs Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"fmt"
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	stor "github.com/cubefs/cubefs/depends/tiglabs/raft/storage"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+)
+
+type connem struct {
+	from, to uint64
+}
+
+type network struct {
+	peers   map[uint64]stateMachine
+	storage map[uint64]*stor.MemoryStorage
+	dropm   map[connem]float64
+	ignorem map[proto.MsgType]bool
+
+	// msgHook is called for each message sent. It may inspect the
+	// message and return true to send it or false to drop it.
+	msgHook func(proto.Message) bool
+}
+
+// newNetwork initializes a network from peers.
+// A nil node will be replaced with a new *stateMachine.
+// A *stateMachine will get its k, id.
+// When using stateMachine, the address list is always [1, n].
+func newNetwork(peers ...stateMachine) *network {
+	return newNetworkWithConfig(nil, peers...)
+}
+
+// newNetworkWithConfig is like newNetwork but calls the given func to
+// modify the configuration of any state machines it creates.
+func newNetworkWithConfig(configFunc func(*Config), peers ...stateMachine) *network {
+	size := len(peers)
+	peerAddrs := idsBySize(size)
+
+	npeers := make(map[uint64]stateMachine, size)
+	nstorage := make(map[uint64]*stor.MemoryStorage, size)
+
+	for j, p := range peers {
+		id := peerAddrs[j]
+		switch v := p.(type) {
+		case nil:
+			s := stor.DefaultMemoryStorage()
+			r := newTestRaftFsm(10, 1, newTestRaftConfig(id, withStorage(s), withPeers(peerAddrs...)))
+			npeers[id] = r
+		case *raftFsm:
+			//learners := make(map[uint64]bool, len(v.prs.Learners))
+			//for i := range v.prs.Learners {
+			//	learners[i] = true
+			//}
+			//v.id = id
+			//v.prs = tracker.MakeProgressTracker(v.prs.MaxInflight)
+			//if len(learners) > 0 {
+			//	v.prs.Learners = map[uint64]struct{}{}
+			//}
+			//for i := 0; i < size; i++ {
+			//	pr := &tracker.Progress{}
+			//	if _, ok := learners[peerAddrs[i]]; ok {
+			//		pr.IsLearner = true
+			//		v.prs.Learners[peerAddrs[i]] = struct{}{}
+			//	} else {
+			//		v.prs.Voters[0][peerAddrs[i]] = struct{}{}
+			//	}
+			//	v.prs.Progress[peerAddrs[i]] = pr
+			//}
+			//v.reset(v.term)
+			npeers[id] = v
+		case *blackHole:
+			npeers[id] = v
+		default:
+			panic(fmt.Sprintf("unexpected state machine type: %T", p))
+		}
+	}
+	return &network{
+		peers:   npeers,
+		storage: nstorage,
+		dropm:   make(map[connem]float64),
+		ignorem: make(map[proto.MsgType]bool),
+	}
+}
+
+func (nw *network) send(msgs ...proto.Message) {
+	for len(msgs) > 0 {
+		m := msgs[0]
+		p := nw.peers[m.To]
+		p.Step(&m)
+		msgs = append(msgs[1:], nw.filter(p.readMessages())...)
+	}
+}
+
+func (nw *network) drop(from, to uint64, perc float64) {
+	nw.dropm[connem{from, to}] = perc
+}
+
+func (nw *network) cut(one, other uint64) {
+	nw.drop(one, other, 2.0) // always drop
+	nw.drop(other, one, 2.0) // always drop
+}
+
+func (nw *network) isolate(id uint64) {
+	for i := 0; i < len(nw.peers); i++ {
+		nid := uint64(i) + 1
+		if nid != id {
+			nw.drop(id, nid, 1.0) // always drop
+			nw.drop(nid, id, 1.0) // always drop
+		}
+	}
+}
+
+func (nw *network) ignore(t proto.MsgType) {
+	nw.ignorem[t] = true
+}
+
+func (nw *network) recover() {
+	nw.dropm = make(map[connem]float64)
+	nw.ignorem = make(map[proto.MsgType]bool)
+}
+
+func (nw *network) filter(msgs []proto.Message) []proto.Message {
+	mm := []proto.Message{}
+	for _, m := range msgs {
+		if nw.ignorem[m.Type] {
+			continue
+		}
+		switch m.Type {
+		case proto.LocalMsgHup:
+			// hups never go over the network, so don't drop them but panic
+			panic("unexpected msgHup")
+		default:
+			perc := nw.dropm[connem{m.From, m.To}]
+			if n := rand.Float64(); n < perc {
+				continue
+			}
+		}
+		if nw.msgHook != nil {
+			if !nw.msgHook(m) {
+				continue
+			}
+		}
+		mm = append(mm, m)
+	}
+	return mm
+}
+
+type stateMachine interface {
+	Step(m *proto.Message)
+	readMessages() []proto.Message
+}
+
+type blackHole struct{}
+
+func (blackHole) Step(*proto.Message)           {}
+func (blackHole) readMessages() []proto.Message { return nil }
+
+// simulate rolling update a cluster for Pre-Vote. cluster has 3 nodes [n1, n2, n3].
+// n1 is leader with term 2
+// n2 is follower with term 2
+// n3 is partitioned, with term 4 and less log, state is candidate
+func newPreVoteMigrationCluster(t *testing.T) *network {
+	n1 := newTestRaftFsmWithLeaseCheck(2, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n2 := newTestRaftFsmWithLeaseCheck(2, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n3 := newTestRaftFsmWithLeaseCheck(2, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	n1.becomeFollower(1, NoLeader)
+	n2.becomeFollower(1, NoLeader)
+	n3.becomeFollower(1, NoLeader)
+
+	// We intentionally do not enable PreVote for n3, this is done so in order
+	// to simulate a rolling restart process where it's possible to have a mixed
+	// version cluster with replicas with PreVote enabled, and replicas without.
+
+	nt := newNetwork(n1, n2, n3)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// Cause a network partition to isolate n3.
+	nt.isolate(3)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Data: []byte("some data")}}})
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	// check state
+	// n1.state == stateLeader
+	// n2.state == stateFollower
+	// n3.state == StateCandidate
+	if n1.state != stateLeader {
+		t.Fatalf("node 1 state: %s, want %d", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Fatalf("node 2 state: %s, want %d", n2.state, stateFollower)
+	}
+	if n3.state != stateCandidate {
+		t.Fatalf("node 3 state: %s, want %d", n3.state, stateCandidate)
+	}
+
+	// check term
+	// n1.term == 2
+	// n2.term == 2
+	// n3.term == 4
+	if n1.term != 2 {
+		t.Fatalf("node 1 term: %d, want %d", n1.term, 2)
+	}
+	if n2.term != 2 {
+		t.Fatalf("node 2 term: %d, want %d", n2.term, 2)
+	}
+	if n3.term != 4 {
+		t.Fatalf("node 3 term: %d, want %d", n3.term, 4)
+	}
+
+	// recover the network
+	nt.recover()
+
+	return nt
+}
+
+func TestPreVoteMigrationCanCompleteElection(t *testing.T) {
+	nt := newPreVoteMigrationCluster(t)
+
+	// n1 is leader with term 2
+	// n2 is follower with term 2
+	// n3 is candidate with term 4, and less log
+	n1 := nt.peers[1].(*raftFsm)
+	n3 := nt.peers[3].(*raftFsm)
+
+	require.Equal(t, int(n1.state), stateLeader)
+	// todo n3 less log will not be leader
+	//nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	//require.Equal(t, int(n3.state), stateCandidate)
+	require.GreaterOrEqual(t, int(n3.term), 4)
+
+}

--- a/depends/tiglabs/raft/raft_fsm_test.go
+++ b/depends/tiglabs/raft/raft_fsm_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
 	stor "github.com/cubefs/cubefs/depends/tiglabs/raft/storage"
-	"github.com/stretchr/testify/require"
+	"math"
 	"math/rand"
 	"testing"
 )
@@ -49,7 +49,7 @@ func newNetwork(peers ...stateMachine) *network {
 
 // newNetworkWithConfig is like newNetwork but calls the given func to
 // modify the configuration of any state machines it creates.
-func newNetworkWithConfig(configFunc func(*Config), peers ...stateMachine) *network {
+func newNetworkWithConfig(configFunc func(fsm *raftFsm), peers ...stateMachine) *network {
 	size := len(peers)
 	peerAddrs := idsBySize(size)
 
@@ -61,7 +61,11 @@ func newNetworkWithConfig(configFunc func(*Config), peers ...stateMachine) *netw
 		switch v := p.(type) {
 		case nil:
 			s := stor.DefaultMemoryStorage()
-			r := newTestRaftFsm(10, 1, newTestRaftConfig(id, withStorage(s), withPeers(peerAddrs...)))
+			cfg := newTestRaftConfig(id, withStorage(s), withPeers(peerAddrs...))
+			r := newTestRaftFsm(10, 1, cfg)
+			if configFunc != nil {
+				configFunc(r)
+			}
 			npeers[id] = r
 		case *raftFsm:
 			//learners := make(map[uint64]bool, len(v.prs.Learners))
@@ -162,6 +166,22 @@ func (nw *network) filter(msgs []proto.Message) []proto.Message {
 	return mm
 }
 
+// voteResponseType maps vote and prevote message types to their corresponding responses.
+func voteRespMsgType(msgt proto.MsgType) proto.MsgType {
+	switch msgt {
+	case proto.ReqMsgVote:
+		return proto.RespMsgVote
+	case proto.ReqMsgPreVote:
+		return proto.RespMsgPreVote
+	default:
+		panic(fmt.Sprintf("not a vote message: %s", msgt))
+	}
+}
+
+func preVoteConfig(r *raftFsm) {
+	r.config.PreVote = true
+}
+
 type stateMachine interface {
 	Step(m *proto.Message)
 	readMessages() []proto.Message
@@ -172,22 +192,405 @@ type blackHole struct{}
 func (blackHole) Step(*proto.Message)           {}
 func (blackHole) readMessages() []proto.Message { return nil }
 
-// simulate rolling update a cluster for Pre-Vote. cluster has 3 nodes [n1, n2, n3].
-// n1 is leader with term 2
-// n2 is follower with term 2
-// n3 is partitioned, with term 4 and less log, state is candidate
-func newPreVoteMigrationCluster(t *testing.T) *network {
-	n1 := newTestRaftFsmWithLeaseCheck(2, 1,
+func TestVoteFromAnyState(t *testing.T) {
+	testVoteFromAnyState(t, proto.ReqMsgVote)
+}
+
+func TestPreVoteFromAnyState(t *testing.T) {
+	testVoteFromAnyState(t, proto.ReqMsgPreVote)
+}
+
+func testVoteFromAnyState(t *testing.T, vt proto.MsgType) {
+	for st := fsmState(0); st < 4; st++ {
+		r := newTestRaftFsm(10, 1,
+			newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+		r.term = 1
+
+		switch st {
+		case stateFollower:
+			r.becomeFollower(r.term, 3)
+		case statePreCandidate:
+			r.becomePreCandidate()
+		case stateCandidate:
+			r.becomeCandidate()
+		case stateLeader:
+			r.becomeCandidate()
+			r.becomeLeader()
+		}
+
+		// Note that setting our state above may have advanced r.term
+		// past its initial value.
+		origTerm := r.term
+		newTerm := r.term + 1
+
+		msg := &proto.Message{
+			From:    2,
+			To:      1,
+			Type:    vt,
+			Term:    newTerm,
+			LogTerm: newTerm,
+			Index:   42,
+		}
+		r.Step(msg)
+		if len(r.msgs) != 1 {
+			t.Errorf("%s,%s: %d response messages, want 1: %+v", vt, st, len(r.msgs), r.msgs)
+		} else {
+			resp := r.msgs[0]
+			if resp.Type != voteRespMsgType(vt) {
+				t.Errorf("%s,%s: response message is %s, want %s",
+					vt, st, resp.Type, voteRespMsgType(vt))
+			}
+			if resp.Reject {
+				t.Errorf("%s,%s: unexpected rejection", vt, st)
+			}
+		}
+
+		// If this was a real vote, we reset our state and term.
+		if vt == proto.ReqMsgVote {
+			if r.state != stateFollower {
+				t.Errorf("%s,%s: state %s, want %s", vt, st, r.state, stateFollower)
+			}
+			if r.term != newTerm {
+				t.Errorf("%s,%s: term %d, want %d", vt, st, r.term, newTerm)
+			}
+			if r.vote != 2 {
+				t.Errorf("%s,%s: vote %d, want 2", vt, st, r.vote)
+			}
+		} else {
+			// In a prevote, nothing changes.
+			if r.state != st {
+				t.Errorf("%s,%s: state %s, want %s", vt, st, r.state, st)
+			}
+			if r.term != origTerm {
+				t.Errorf("%s,%s: term %d, want %d", vt, st, r.term, origTerm)
+			}
+			// if st == stateFollower or statePreCandidate, r hasn't voted yet.
+			// In stateCandidate or stateLeader, it's voted for itself.
+			if r.vote != NoLeader && r.vote != 1 {
+				t.Errorf("%s,%s: vote %d, want %d or 1", vt, st, r.vote, NoLeader)
+			}
+		}
+	}
+}
+
+func TestPastElectionTimeout(t *testing.T) {
+	tests := []struct {
+		elapse       int
+		wprobability float64
+		round        bool
+	}{
+		{5, 0, false},
+		{10, 0.1, true},
+		{13, 0.4, true},
+		{15, 0.6, true},
+		{18, 0.9, true},
+		{20, 1, false},
+	}
+
+	for i, tt := range tests {
+		sm := newTestRaftFsm(10, 1,
+			newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+		sm.electionElapsed = tt.elapse
+		c := 0
+		for j := 0; j < 10000; j++ {
+			sm.resetRandomizedElectionTimeout()
+			if sm.pastElectionTimeout() {
+				c++
+			}
+		}
+		got := float64(c) / 10000.0
+		if tt.round {
+			got = math.Floor(got*10+0.5) / 10.0
+		}
+		if got != tt.wprobability {
+			t.Errorf("#%d: probability = %v, want %v", i, got, tt.wprobability)
+		}
+	}
+}
+
+// TestStepIgnoreOldTermMsg to ensure that the Step function ignores the message
+// from old term and does not pass it to the actual stepX function.
+func TestStepIgnoreOldTermMsg(t *testing.T) {
+	called := false
+	fakeStep := func(r *raftFsm, m *proto.Message) {
+		called = true
+	}
+	sm := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1)))
+	sm.step = fakeStep
+	sm.term = 2
+	sm.Step(&proto.Message{Type: proto.ReqMsgAppend, Term: sm.term - 1})
+	if called {
+		t.Errorf("stepFunc called = %v , want %v", called, false)
+	}
+}
+
+// TestTransferNonMember verifies that when a MsgTimeoutNow arrives at
+// a node that has been removed from the group, nothing happens.
+// (previously, if the node also got votes, it would panic as it
+// transitioned to stateLeader)
+func TestTransferNonMember(t *testing.T) {
+	r := newTestRaftFsm(5, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(2, 3, 4)))
+	// todo
+	//r.Step(proto.Message{From: 2, To: 1, Type: proto.MsgTimeoutNow})
+
+	r.Step(&proto.Message{From: 2, To: 1, Type: proto.RespMsgPreVote})
+	r.Step(&proto.Message{From: 3, To: 1, Type: proto.RespMsgPreVote})
+	if r.state != stateFollower {
+		t.Fatalf("state is %s, want stateFollower", r.state)
+	}
+}
+
+// TestNodeWithSmallerTermCanCompleteElection tests the scenario where a node
+// that has been partitioned away (and fallen behind) rejoins the cluster at
+// about the same time the leader node gets partitioned away.
+// Previously the cluster would come to a standstill when run with PreVote
+// enabled.
+func TestNodeWithSmallerTermCanCompleteElection(t *testing.T) {
+	n1 := newTestRaftFsm(10, 1,
 		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
-	n2 := newTestRaftFsmWithLeaseCheck(2, 1,
+	n2 := newTestRaftFsm(10, 1,
 		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
-	n3 := newTestRaftFsmWithLeaseCheck(2, 1,
+	n3 := newTestRaftFsm(10, 1,
 		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
 
 	n1.becomeFollower(1, NoLeader)
 	n2.becomeFollower(1, NoLeader)
 	n3.becomeFollower(1, NoLeader)
 
+	n1.config.PreVote = true
+	n2.config.PreVote = true
+	n3.config.PreVote = true
+
+	// cause a network partition to isolate node 3
+	nt := newNetwork(n1, n2, n3)
+	nt.cut(1, 3)
+	nt.cut(2, 3)
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	sm := nt.peers[1].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("peer 1 state: %s, want %v", sm.state, stateLeader)
+	}
+
+	sm = nt.peers[2].(*raftFsm)
+	if sm.state != stateFollower {
+		t.Errorf("peer 2 state: %s, want %v", sm.state, stateFollower)
+	}
+
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != statePreCandidate {
+		t.Errorf("peer 3 state: %s, want %v", sm.state, statePreCandidate)
+	}
+
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+
+	// check whether the term values are expected
+	// n1.term == 3
+	// n2.term == 3
+	// n3.term == 1
+	sm = nt.peers[1].(*raftFsm)
+	if sm.term != 3 {
+		t.Errorf("peer 1 term: %d, want %d", sm.term, 3)
+	}
+
+	sm = nt.peers[2].(*raftFsm)
+	if sm.term != 3 {
+		t.Errorf("peer 2 term: %d, want %d", sm.term, 3)
+	}
+
+	sm = nt.peers[3].(*raftFsm)
+	if sm.term != 1 {
+		t.Errorf("peer 3 term: %d, want %d", sm.term, 1)
+	}
+
+	// check state
+	// n1 == follower
+	// n2 == leader
+	// n3 == pre-candidate
+	sm = nt.peers[1].(*raftFsm)
+	if sm.state != stateFollower {
+		t.Errorf("peer 1 state: %s, want %v", sm.state, stateFollower)
+	}
+	sm = nt.peers[2].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("peer 2 state: %s, want %v", sm.state, stateLeader)
+	}
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != statePreCandidate {
+		t.Errorf("peer 3 state: %s, want %v", sm.state, statePreCandidate)
+	}
+
+	// recover the network then immediately isolate b which is currently
+	// the leader, this is to emulate the crash of b.
+	nt.recover()
+	nt.cut(2, 1)
+	nt.cut(2, 3)
+
+	// call for election
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// do we have a leader?
+	sma := nt.peers[1].(*raftFsm)
+	smb := nt.peers[3].(*raftFsm)
+	if sma.state != stateLeader && smb.state != stateLeader {
+		t.Errorf("no leader")
+	}
+}
+
+// TestPreVoteWithSplitVote verifies that after split vote, cluster can complete
+// election in next round.
+func TestPreVoteWithSplitVote(t *testing.T) {
+	n1 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n2 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n3 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	n1.becomeFollower(1, NoLeader)
+	n2.becomeFollower(1, NoLeader)
+	n3.becomeFollower(1, NoLeader)
+
+	n1.config.PreVote = true
+	n2.config.PreVote = true
+	n3.config.PreVote = true
+
+	nt := newNetwork(n1, n2, n3)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// simulate leader down. followers start split vote.
+	nt.isolate(1)
+	nt.send([]proto.Message{
+		{From: 2, To: 2, Type: proto.LocalMsgHup},
+		{From: 3, To: 3, Type: proto.LocalMsgHup},
+	}...)
+
+	// check whether the term values are expected
+	// n2.term == 3
+	// n3.term == 3
+	sm := nt.peers[2].(*raftFsm)
+	if sm.term != 3 {
+		t.Errorf("peer 2 term: %d, want %d", sm.term, 3)
+	}
+	sm = nt.peers[3].(*raftFsm)
+	if sm.term != 3 {
+		t.Errorf("peer 3 term: %d, want %d", sm.term, 3)
+	}
+
+	// check state
+	// n2 == candidate
+	// n3 == candidate
+	sm = nt.peers[2].(*raftFsm)
+	if sm.state != stateCandidate {
+		t.Errorf("peer 2 state: %s, want %v", sm.state, stateCandidate)
+	}
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != stateCandidate {
+		t.Errorf("peer 3 state: %s, want %v", sm.state, stateCandidate)
+	}
+
+	// node 2 election timeout first
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+
+	// check whether the term values are expected
+	// n2.term == 4
+	// n3.term == 4
+	sm = nt.peers[2].(*raftFsm)
+	if sm.term != 4 {
+		t.Errorf("peer 2 term: %d, want %d", sm.term, 4)
+	}
+	sm = nt.peers[3].(*raftFsm)
+	if sm.term != 4 {
+		t.Errorf("peer 3 term: %d, want %d", sm.term, 4)
+	}
+
+	// check state
+	// n2 == leader
+	// n3 == follower
+	sm = nt.peers[2].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Errorf("peer 2 state: %s, want %v", sm.state, stateLeader)
+	}
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != stateFollower {
+		t.Errorf("peer 3 state: %s, want %v", sm.state, stateFollower)
+	}
+}
+
+// TestPreVoteWithCheckQuorum ensures that after a node become pre-candidate,
+// it will checkQuorum correctly.
+func TestPreVoteWithCheckQuorum(t *testing.T) {
+	n1 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n2 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n3 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	n1.becomeFollower(1, NoLeader)
+	n2.becomeFollower(1, NoLeader)
+	n3.becomeFollower(1, NoLeader)
+
+	n1.config.PreVote = true
+	n2.config.PreVote = true
+	n3.config.PreVote = true
+
+	//n1.config.LeaseCheck  = true
+	//n2.config.LeaseCheck  = true
+	//n3.config.LeaseCheck  = true
+
+	nt := newNetwork(n1, n2, n3)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// isolate node 1. node 2 and node 3 have leader info
+	nt.isolate(1)
+
+	// check state
+	sm := nt.peers[1].(*raftFsm)
+	if sm.state != stateLeader {
+		t.Fatalf("peer 1 state: %s, want %v", sm.state, stateLeader)
+	}
+	sm = nt.peers[2].(*raftFsm)
+	if sm.state != stateFollower {
+		t.Fatalf("peer 2 state: %s, want %v", sm.state, stateFollower)
+	}
+	sm = nt.peers[3].(*raftFsm)
+	if sm.state != stateFollower {
+		t.Fatalf("peer 3 state: %s, want %v", sm.state, stateFollower)
+	}
+
+	// node 2 will ignore node 3's PreVote
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+
+	// Do we have a leader?
+	if n2.state != stateLeader && n3.state != stateFollower {
+		t.Errorf("no leader")
+	}
+}
+
+// simulate rolling update a cluster for Pre-Vote. cluster has 3 nodes [n1, n2, n3].
+// n1 is leader with term 2
+// n2 is follower with term 2
+// n3 is partitioned, with term 4 and less log, state is candidate
+func newPreVoteMigrationCluster(t *testing.T) *network {
+	n1 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n2 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n3 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n1.becomeFollower(1, NoLeader)
+	n2.becomeFollower(1, NoLeader)
+	n3.becomeFollower(1, NoLeader)
+
+	n1.config.PreVote = true
+	n2.config.PreVote = true
 	// We intentionally do not enable PreVote for n3, this is done so in order
 	// to simulate a rolling restart process where it's possible to have a mixed
 	// version cluster with replicas with PreVote enabled, and replicas without.
@@ -204,7 +607,7 @@ func newPreVoteMigrationCluster(t *testing.T) *network {
 	// check state
 	// n1.state == stateLeader
 	// n2.state == stateFollower
-	// n3.state == StateCandidate
+	// n3.state == stateCandidate
 	if n1.state != stateLeader {
 		t.Fatalf("node 1 state: %s, want %d", n1.state, stateLeader)
 	}
@@ -212,7 +615,7 @@ func newPreVoteMigrationCluster(t *testing.T) *network {
 		t.Fatalf("node 2 state: %s, want %d", n2.state, stateFollower)
 	}
 	if n3.state != stateCandidate {
-		t.Fatalf("node 3 state: %s, want %d", n3.state, stateCandidate)
+		t.Fatalf("node 3 state: %s, want %d", n3.state, statePreCandidate)
 	}
 
 	// check term
@@ -230,6 +633,7 @@ func newPreVoteMigrationCluster(t *testing.T) *network {
 	}
 
 	// recover the network
+	n3.config.PreVote = true
 	nt.recover()
 
 	return nt
@@ -240,14 +644,1272 @@ func TestPreVoteMigrationCanCompleteElection(t *testing.T) {
 
 	// n1 is leader with term 2
 	// n2 is follower with term 2
-	// n3 is candidate with term 4, and less log
-	n1 := nt.peers[1].(*raftFsm)
+	// n3 is pre-candidate with term 4, and less log
+	n2 := nt.peers[2].(*raftFsm)
 	n3 := nt.peers[3].(*raftFsm)
 
-	require.Equal(t, int(n1.state), stateLeader)
-	// todo n3 less log will not be leader
-	//nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
-	//require.Equal(t, int(n3.state), stateCandidate)
-	require.GreaterOrEqual(t, int(n3.term), 4)
+	// simulate leader down
+	nt.isolate(1)
+
+	// Call for elections from both n2 and n3.
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+
+	// check state
+	// n2.state == Follower
+	// n3.state == PreCandidate
+	if n2.state != stateFollower {
+		t.Errorf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != statePreCandidate {
+		t.Errorf("node 3 state: %s, want %v", n3.state, statePreCandidate)
+	}
+
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+
+	// Do we have a leader?
+	if n2.state != stateLeader && n3.state != stateFollower {
+		t.Errorf("no leader")
+	}
 
 }
+
+func TestPreVoteMigrationWithFreeStuckPreCandidate(t *testing.T) {
+	nt := newPreVoteMigrationCluster(t)
+
+	// n1 is leader with term 2
+	// n2 is follower with term 2
+	// n3 is pre-candidate with term 4, and less log
+	n1 := nt.peers[1].(*raftFsm)
+	n2 := nt.peers[2].(*raftFsm)
+	n3 := nt.peers[3].(*raftFsm)
+
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if n1.state != stateLeader {
+		t.Errorf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Errorf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != statePreCandidate {
+		t.Errorf("node 3 state: %s, want %v", n3.state, statePreCandidate)
+	}
+
+	// Pre-Vote again for safety
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if n1.state != stateLeader {
+		t.Errorf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Errorf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != statePreCandidate {
+		t.Errorf("node 3 state: %s, want %v", n3.state, statePreCandidate)
+	}
+
+	nt.send(proto.Message{From: 1, To: 3, Type: proto.ReqMsgHeartBeat, Term: n1.term})
+
+	// Disrupt the leader so that the stuck peer is freed
+	if n1.state != stateFollower {
+		t.Errorf("state = %s, want %v", n1.state, stateFollower)
+	}
+	if n3.term != n1.term {
+		t.Errorf("term = %d, want %d", n3.term, n1.term)
+	}
+}
+
+// TestMsgAppRespWaitReset verifies the resume behavior of a leader
+// MsgAppResp.
+//func TestMsgAppRespWaitReset(t *testing.T) {
+//	sm := newTestRaftFsm(5, 1,
+//		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//	sm.becomeCandidate()
+//	sm.becomeLeader()
+//
+//	// The new leader has just emitted a new Term 4 entry; consume those messages
+//	// from the outgoing queue.
+//	sm.bcastAppend()
+//	sm.readMessages()
+//
+//	// Node 2 acks the first entry, making it committed.
+//	sm.Step(&proto.Message{
+//		From:  2,
+//		Type:  proto.RespMsgAppend,
+//		Index: 1,
+//	})
+//	if sm.raftLog.committed != 1 {
+//		t.Fatalf("expected committed to be 1, got %d", sm.raftLog.committed)
+//	}
+//	// Also consume the MsgApp messages that update Commit on the followers.
+//	sm.readMessages()
+//
+//	// A new command is now proposed on node 1.
+//	sm.Step(&proto.Message{
+//		From:    1,
+//		Type:    proto.LocalMsgProp,
+//		Entries: []*proto.Entry{{}},
+//	})
+//
+//	// The command is broadcast to all nodes not in the wait state.
+//	// Node 2 left the wait state due to its MsgAppResp, but node 3 is still waiting.
+//	msgs := sm.readMessages()
+//	if len(msgs) != 1 {
+//		t.Fatalf("expected 1 message, got %d: %+v", len(msgs), msgs)
+//	}
+//	if msgs[0].Type != proto.ReqMsgAppend || msgs[0].To != 2 {
+//		t.Errorf("expected MsgApp to node 2, got %v to %d", msgs[0].Type, msgs[0].To)
+//	}
+//	if len(msgs[0].Entries) != 1 || msgs[0].Entries[0].Index != 2 {
+//		t.Errorf("expected to send entry 2, but got %v", msgs[0].Entries)
+//	}
+//
+//	// Now Node 3 acks the first entry. This releases the wait and entry 2 is sent.
+//	sm.Step(&proto.Message{
+//		From:  3,
+//		Type:  proto.RespMsgAppend,
+//		Index: 1,
+//	})
+//	msgs = sm.readMessages()
+//	if len(msgs) != 1 {
+//		t.Fatalf("expected 1 message, got %d: %+v", len(msgs), msgs)
+//	}
+//	if msgs[0].Type != proto.ReqMsgAppend || msgs[0].To != 3 {
+//		t.Errorf("expected MsgApp to node 3, got %v to %d", msgs[0].Type, msgs[0].To)
+//	}
+//	if len(msgs[0].Entries) != 1 || msgs[0].Entries[0].Index != 2 {
+//		t.Errorf("expected to send entry 2, but got %v", msgs[0].Entries)
+//	}
+//}
+
+func TestRecvReqMsgVote(t *testing.T) {
+	testRecvReqMsgVote(t, proto.ReqMsgVote)
+}
+
+func TestRecvMsgPreVote(t *testing.T) {
+	testRecvReqMsgVote(t, proto.ReqMsgPreVote)
+}
+
+func testRecvReqMsgVote(t *testing.T, msgType proto.MsgType) {
+	tests := []struct {
+		state          fsmState
+		index, logTerm uint64
+		voteFor        uint64
+		wreject        bool
+	}{
+		{stateFollower, 0, 0, NoLeader, true},
+		{stateFollower, 0, 1, NoLeader, true},
+		{stateFollower, 0, 2, NoLeader, true},
+		{stateFollower, 0, 3, NoLeader, false},
+
+		{stateFollower, 1, 0, NoLeader, true},
+		{stateFollower, 1, 1, NoLeader, true},
+		{stateFollower, 1, 2, NoLeader, true},
+		{stateFollower, 1, 3, NoLeader, false},
+
+		{stateFollower, 2, 0, NoLeader, true},
+		{stateFollower, 2, 1, NoLeader, true},
+		{stateFollower, 2, 2, NoLeader, false},
+		{stateFollower, 2, 3, NoLeader, false},
+
+		{stateFollower, 3, 0, NoLeader, true},
+		{stateFollower, 3, 1, NoLeader, true},
+		{stateFollower, 3, 2, NoLeader, false},
+		{stateFollower, 3, 3, NoLeader, false},
+
+		{stateFollower, 3, 2, 2, false},
+		{stateFollower, 3, 2, 1, true},
+
+		{stateLeader, 3, 3, 1, true},
+		{statePreCandidate, 3, 3, 1, true},
+		{stateCandidate, 3, 3, 1, true},
+	}
+
+	max := func(a, b uint64) uint64 {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	for i, tt := range tests {
+		sm := newTestRaftFsm(1, 10, newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1)))
+		sm.state = tt.state
+		switch tt.state {
+		case stateFollower:
+			sm.step = stepFollower
+		case stateCandidate, statePreCandidate:
+			sm.step = stepCandidate
+		case stateLeader:
+			sm.step = stepLeader
+		}
+		sm.vote = tt.voteFor
+		sm.raftLog = &raftLog{
+			storage:  &stor.MemoryStorage{},
+			unstable: unstable{offset: 3},
+		}
+		sm.raftLog.append([]*proto.Entry{{}, {Index: 1, Term: 2}, {Index: 2, Term: 2}}...)
+
+		// raft.term is greater than or equal to raft.raftLog.lastTerm. In this
+		// test we're only testing ReqMsgVote responses when the campaigning node
+		// has a different raft log compared to the recipient node.
+		// Additionally we're verifying behaviour when the recipient node has
+		// already given out its vote for its current term. We're not testing
+		// what the recipient node does when receiving a message with a
+		// different term number, so we simply initialize both term numbers to
+		// be the same.
+		term := max(sm.raftLog.lastTerm(), tt.logTerm)
+		sm.term = term
+		sm.Step(&proto.Message{Type: msgType, Term: term, From: 2, Index: tt.index, LogTerm: tt.logTerm})
+
+		msgs := sm.readMessages()
+		if g := len(msgs); g != 1 {
+			t.Fatalf("#%d: len(msgs) = %d, want 1", i, g)
+			continue
+		}
+		if g := msgs[0].Type; g != voteRespMsgType(msgType) {
+			t.Errorf("#%d, m.Type = %v, want %v", i, g, voteRespMsgType(msgType))
+		}
+		if g := msgs[0].Reject; g != tt.wreject {
+			t.Errorf("#%d, m.Reject = %v, want %v", i, g, tt.wreject)
+		}
+	}
+}
+
+func TestStateTransition(t *testing.T) {
+	tests := []struct {
+		from   fsmState
+		to     fsmState
+		wallow bool
+		wterm  uint64
+		wlead  uint64
+	}{
+		{stateFollower, stateFollower, true, 1, NoLeader},
+		{stateFollower, statePreCandidate, true, 0, NoLeader},
+		{stateFollower, stateCandidate, true, 1, NoLeader},
+		{stateFollower, stateLeader, false, 0, NoLeader},
+
+		{statePreCandidate, stateFollower, true, 0, NoLeader},
+		{statePreCandidate, statePreCandidate, true, 0, NoLeader},
+		{statePreCandidate, stateCandidate, true, 1, NoLeader},
+		{statePreCandidate, stateLeader, true, 0, 1},
+
+		{stateCandidate, stateFollower, true, 0, NoLeader},
+		{stateCandidate, statePreCandidate, true, 0, NoLeader},
+		{stateCandidate, stateCandidate, true, 1, NoLeader},
+		{stateCandidate, stateLeader, true, 0, 1},
+
+		{stateLeader, stateFollower, true, 1, NoLeader},
+		{stateLeader, statePreCandidate, false, 0, NoLeader},
+		{stateLeader, stateCandidate, false, 1, NoLeader},
+		{stateLeader, stateLeader, true, 0, 1},
+	}
+
+	for i, tt := range tests {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if tt.wallow {
+						t.Errorf("%d: allow = %v, want %v", i, false, true)
+					}
+				}
+			}()
+
+			sm := newTestRaftFsm(1, 10, newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1)))
+			sm.state = tt.from
+
+			switch tt.to {
+			case stateFollower:
+				sm.becomeFollower(tt.wterm, tt.wlead)
+			case statePreCandidate:
+				sm.becomePreCandidate()
+			case stateCandidate:
+				sm.becomeCandidate()
+			case stateLeader:
+				sm.becomeLeader()
+			}
+
+			if sm.term != tt.wterm {
+				t.Errorf("%d: term = %d, want %d", i, sm.term, tt.wterm)
+			}
+			if sm.leader != tt.wlead {
+				t.Errorf("%d: lead = %d, want %d", i, sm.leader, tt.wlead)
+			}
+		}()
+	}
+}
+
+func TestAllServerStepdown(t *testing.T) {
+	tests := []struct {
+		state fsmState
+
+		wstate fsmState
+		wterm  uint64
+		windex uint64
+	}{
+		{stateFollower, stateFollower, 3, 0},
+		{statePreCandidate, stateFollower, 3, 0},
+		{stateCandidate, stateFollower, 3, 0},
+		{stateLeader, stateFollower, 3, 1},
+	}
+
+	tmsgTypes := [...]proto.MsgType{proto.ReqMsgVote, proto.ReqMsgAppend}
+	tterm := uint64(3)
+
+	for i, tt := range tests {
+		sm := newTestRaftFsm(1, 10, newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1)))
+		switch tt.state {
+		case stateFollower:
+			sm.becomeFollower(1, NoLeader)
+		case statePreCandidate:
+			sm.becomePreCandidate()
+		case stateCandidate:
+			sm.becomeCandidate()
+		case stateLeader:
+			sm.becomeCandidate()
+			sm.becomeLeader()
+		}
+
+		for j, msgType := range tmsgTypes {
+			sm.Step(&proto.Message{From: 2, Type: msgType, Term: tterm, LogTerm: tterm})
+
+			if sm.state != tt.wstate {
+				t.Errorf("#%d.%d state = %v , want %v", i, j, sm.state, tt.wstate)
+			}
+			if sm.term != tt.wterm {
+				t.Errorf("#%d.%d term = %v , want %v", i, j, sm.term, tt.wterm)
+			}
+			if sm.raftLog.lastIndex() != tt.windex {
+				t.Errorf("#%d.%d index = %v , want %v", i, j, sm.raftLog.lastIndex(), tt.windex)
+			}
+			if uint64(len(sm.raftLog.allEntries())) != tt.windex {
+				t.Errorf("#%d.%d len(ents) = %v , want %v", i, j, len(sm.raftLog.allEntries()), tt.windex)
+			}
+			wlead := uint64(2)
+			if msgType == proto.ReqMsgVote {
+				wlead = NoLeader
+			}
+			if sm.leader != wlead {
+				t.Errorf("#%d, sm.leader = %d, want %d", i, sm.leader, NoLeader)
+			}
+		}
+	}
+}
+
+func TestCandidateResetTermMsgHeartbeat(t *testing.T) {
+	testCandidateResetTerm(t, proto.ReqMsgHeartBeat)
+}
+
+func TestCandidateResetTermMsgApp(t *testing.T) {
+	testCandidateResetTerm(t, proto.ReqMsgAppend)
+}
+
+// testCandidateResetTerm tests when a candidate receives a
+// MsgHeartbeat or proto.ReqMsgAppend from leader, "Step" resets the term
+// with leader's and reverts back to follower.
+func testCandidateResetTerm(t *testing.T, mt proto.MsgType) {
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	c := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	nt := newNetwork(a, b, c)
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	if a.state != stateLeader {
+		t.Errorf("state = %s, want %v", a.state, stateLeader)
+	}
+	if b.state != stateFollower {
+		t.Errorf("state = %s, want %v", b.state, stateFollower)
+	}
+	if c.state != stateFollower {
+		t.Errorf("state = %s, want %v", c.state, stateFollower)
+	}
+
+	// isolate 3 and increase term in rest
+	nt.isolate(3)
+
+	nt.send(proto.Message{From: 2, To: 2, Type: proto.LocalMsgHup})
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	if a.state != stateLeader {
+		t.Errorf("state = %s, want %v", a.state, stateLeader)
+	}
+	if b.state != stateFollower {
+		t.Errorf("state = %s, want %v", b.state, stateFollower)
+	}
+
+	// trigger campaign in isolated c
+	c.resetRandomizedElectionTimeout()
+	for i := 0; i < c.randElectionTick; i++ {
+		c.tick()
+	}
+
+	if c.state != stateCandidate {
+		t.Errorf("state = %s, want %v", c.state, stateCandidate)
+	}
+
+	nt.recover()
+
+	// leader sends to isolated candidate
+	// and expects candidate to revert to follower
+	nt.send(proto.Message{From: 1, To: 3, Term: a.term, Type: mt})
+
+	if c.state != stateFollower {
+		t.Errorf("state = %s, want %v", c.state, stateFollower)
+	}
+
+	// follower c term is reset with leader's
+	if a.term != c.term {
+		t.Errorf("follower term expected same term as leader's %d, got %d", a.term, c.term)
+	}
+}
+
+func TestLeaderStepdownWhenQuorumActive(t *testing.T) {
+	sm := newTestRaftFsm(5, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	sm.config.LeaseCheck = true
+
+	sm.becomeCandidate()
+	sm.becomeLeader()
+
+	for i := 0; i < sm.randElectionTick+1; i++ {
+		sm.Step(&proto.Message{From: 2, Type: proto.RespMsgHeartBeat, Term: sm.term})
+		sm.tick()
+	}
+
+	if sm.state != stateLeader {
+		t.Errorf("state = %v, want %v", sm.state, stateLeader)
+	}
+}
+
+func TestLeaderStepdownWhenQuorumLost(t *testing.T) {
+	sm := newTestRaftFsm(5, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	sm.config.LeaseCheck = true
+
+	sm.becomeCandidate()
+	sm.becomeLeader()
+
+	for i := 0; i < sm.randElectionTick+1; i++ {
+		sm.tick()
+	}
+
+	if sm.state != stateFollower {
+		t.Errorf("state = %v, want %v", sm.state, stateFollower)
+	}
+}
+
+func TestLeaderSupersedingWithCheckQuorum(t *testing.T) {
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	c := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	a.config.LeaseCheck = true
+	b.config.LeaseCheck = true
+	c.config.LeaseCheck = true
+
+	nt := newNetwork(a, b, c)
+	b.randElectionTick = b.randElectionTick + 1
+
+	for i := 0; i < b.randElectionTick; i++ {
+		b.tick()
+	}
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	if a.state != stateLeader {
+		t.Errorf("state = %s, want %v", a.state, stateLeader)
+	}
+
+	if c.state != stateFollower {
+		t.Errorf("state = %s, want %v", c.state, stateFollower)
+	}
+
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	// Peer b rejected c's vote since its electionElapsed had not reached to randElectionTick
+	if c.state != stateCandidate {
+		t.Errorf("state = %s, want %v", c.state, stateCandidate)
+	}
+
+	// Letting b's electionElapsed reach to randElectionTick
+	for i := 0; i < b.randElectionTick; i++ {
+		b.tick()
+	}
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if c.state != stateLeader {
+		t.Errorf("state = %s, want %v", c.state, stateLeader)
+	}
+}
+
+func TestLeaderElectionWithCheckQuorum(t *testing.T) {
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	c := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	a.config.LeaseCheck = true
+	b.config.LeaseCheck = true
+	c.config.LeaseCheck = true
+
+	nt := newNetwork(a, b, c)
+	a.randElectionTick += 1
+	b.randElectionTick += 2
+
+	// Immediately after creation, votes are cast regardless of the
+	// election timeout.
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	if a.state != stateLeader {
+		t.Errorf("state = %s, want %v", a.state, stateLeader)
+	}
+
+	if c.state != stateFollower {
+		t.Errorf("state = %s, want %v", c.state, stateFollower)
+	}
+
+	// need to reset randomizedElectionTimeout larger than randElectionTick again,
+	// because the value might be reset to randElectionTick since the last state changes
+	a.randElectionTick += 1
+	b.randElectionTick += 2
+	for i := 0; i < a.randElectionTick; i++ {
+		a.tick()
+	}
+	for i := 0; i < b.randElectionTick; i++ {
+		b.tick()
+	}
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if a.state != stateFollower {
+		t.Errorf("state = %s, want %v", a.state, stateFollower)
+	}
+
+	if c.state != stateLeader {
+		t.Errorf("state = %s, want %v", c.state, stateLeader)
+	}
+}
+
+// TestFreeStuckCandidateWithCheckQuorum ensures that a candidate with a higher term
+// can disrupt the leader even if the leader still "officially" holds the lease, The
+// leader is expected to step down and adopt the candidate's term
+func TestFreeStuckCandidateWithCheckQuorum(t *testing.T) {
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	c := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	a.config.LeaseCheck = true
+	b.config.LeaseCheck = true
+	c.config.LeaseCheck = true
+
+	nt := newNetwork(a, b, c)
+	b.randElectionTick += 1
+
+	for i := 0; i < b.randElectionTick; i++ {
+		b.tick()
+	}
+	// first a selected leader
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+	if a.state != stateLeader {
+		t.Errorf("state = %s, want %v", b.state, stateFollower)
+	}
+
+	nt.isolate(1)
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if b.state != stateFollower {
+		t.Errorf("state = %s, want %v", b.state, stateFollower)
+	}
+
+	if c.state != stateCandidate {
+		t.Errorf("state = %s, want %v", c.state, stateCandidate)
+	}
+
+	if c.term != b.term+1 {
+		t.Errorf("term = %d, want %d", c.term, b.term+1)
+	}
+
+	// Vote again for safety
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if b.state != stateFollower {
+		t.Errorf("state = %s, want %v", b.state, stateFollower)
+	}
+
+	if c.state != stateCandidate {
+		t.Errorf("state = %s, want %v", c.state, stateCandidate)
+	}
+
+	if c.term != b.term+2 {
+		t.Errorf("term = %d, want %d", c.term, b.term+2)
+	}
+
+	// c term is bigger than a, a should change to follower
+	nt.recover()
+	nt.send(proto.Message{From: 1, To: 3, Type: proto.ReqMsgHeartBeat, Term: a.term})
+
+	// Disrupt the leader so that the stuck peer is freed
+	if a.state != stateFollower {
+		t.Errorf("state = %s, want %v", a.state, stateFollower)
+	}
+
+	if c.term != a.term {
+		t.Errorf("term = %d, want %d", c.term, a.term)
+	}
+
+	// Vote again, should become leader this time
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	if c.state != stateLeader {
+		t.Errorf("peer 3 state: %s, want %v", c.state, stateLeader)
+	}
+}
+
+func TestNonPromotableVoterWithCheckQuorum(t *testing.T) {
+	a := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2)))
+	b := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1)))
+
+	a.config.LeaseCheck = true
+	b.config.LeaseCheck = true
+
+	nt := newNetwork(a, b)
+	b.randElectionTick += 1
+	// Need to remove 2 again to make it a non-promotable node since newNetwork overwritten some internal states
+	b.applyConfChange(&proto.ConfChange{Type: proto.ConfRemoveNode, Peer: proto.Peer{PeerID: 2}})
+
+	if b.promotable() {
+		t.Fatalf("promotable = %v, want false", b.promotable())
+	}
+
+	for i := 0; i < b.randElectionTick; i++ {
+		b.tick()
+	}
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	if a.state != stateLeader {
+		t.Errorf("state = %s, want %v", a.state, stateLeader)
+	}
+
+	if b.state != stateFollower {
+		t.Errorf("state = %s, want %v", b.state, stateFollower)
+	}
+
+	if b.leader != 1 {
+		t.Errorf("lead = %d, want 1", b.leader)
+	}
+}
+
+//TestDisruptiveFollower tests isolated follower,
+//with slow network incoming from leader, election times out
+//to become a candidate with an increased term. Then, the
+//candiate's response to late leader heartbeat forces the leader
+//to step down.
+func TestDisruptiveFollower(t *testing.T) {
+	n1 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n2 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n3 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	n1.config.LeaseCheck = true
+	n2.config.LeaseCheck = true
+	n3.config.LeaseCheck = true
+
+	n1.becomeFollower(1, NoLeader)
+	n2.becomeFollower(1, NoLeader)
+	n3.becomeFollower(1, NoLeader)
+
+	nt := newNetwork(n1, n2, n3)
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// check state
+	// n1.state == stateLeader
+	// n2.state == stateFollower
+	// n3.state == stateFollower
+	if n1.state != stateLeader {
+		t.Fatalf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Fatalf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != stateFollower {
+		t.Fatalf("node 3 state: %s, want %v", n3.state, stateFollower)
+	}
+
+	// etcd server "advanceTicksForElection" on restart;
+	// this is to expedite campaign trigger when given larger
+	// election timeouts (e.g. multi-datacenter deploy)
+	// Or leader messages are being delayed while ticks elapse
+	n3.randElectionTick += 2
+	for i := 0; i < n3.randElectionTick-1; i++ {
+		n3.tick()
+	}
+
+	// ideally, before last election tick elapses,
+	// the follower n3 receives "proto.MsgApp" or "proto.ReqMsgHeartBeat"
+	// from leader n1, and then resets its "electionElapsed"
+	// however, last tick may elapse before receiving any
+	// messages from leader, thus triggering campaign
+	n3.tick()
+
+	// n1 is still leader yet
+	// while its heartbeat to candidate n3 is being delayed
+
+	// check state
+	// n1.state == stateLeader
+	// n2.state == stateFollower
+	// n3.state == stateCandidate
+	if n1.state != stateLeader {
+		t.Fatalf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Fatalf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != stateCandidate {
+		t.Fatalf("node 3 state: %s, want %v", n3.state, stateCandidate)
+	}
+	// check term
+	// n1.term == 2
+	// n2.term == 2
+	// n3.term == 3
+	if n1.term != 2 {
+		t.Fatalf("node 1 term: %d, want %d", n1.term, 2)
+	}
+	if n2.term != 2 {
+		t.Fatalf("node 2 term: %d, want %d", n2.term, 2)
+	}
+	if n3.term != 3 {
+		t.Fatalf("node 3 term: %d, want %d", n3.term, 3)
+	}
+
+	// while outgoing vote requests are still queued in n3,
+	// leader heartbeat finally arrives at candidate n3
+	// however, due to delayed network from leader, leader
+	// heartbeat was sent with lower term than candidate's
+	nt.send(proto.Message{From: 1, To: 3, Term: n1.term, Type: proto.ReqMsgHeartBeat})
+
+	// then candidate n3 responds with "proto.RespMsgAppend" of higher term
+	// and leader steps down from a message with higher term
+	// this is to disrupt the current leader, so that candidate
+	// with higher term can be freed with following election
+
+	// check state
+	// n1.state == stateFollower
+	// n2.state == stateFollower
+	// n3.state == stateCandidate
+	if n1.state != stateFollower {
+		t.Fatalf("node 1 state: %s, want %v", n1.state, stateFollower)
+	}
+	if n2.state != stateFollower {
+		t.Fatalf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != stateCandidate {
+		t.Fatalf("node 3 state: %s, want %v", n3.state, stateCandidate)
+	}
+	// check term
+	// n1.term == 3
+	// n2.term == 2
+	// n3.term == 3
+	if n1.term != 3 {
+		t.Fatalf("node 1 term: %d, want %d", n1.term, 3)
+	}
+	if n2.term != 2 {
+		t.Fatalf("node 2 term: %d, want %d", n2.term, 2)
+	}
+	if n3.term != 3 {
+		t.Fatalf("node 3 term: %d, want %d", n3.term, 3)
+	}
+}
+
+// TestDisruptiveFollowerPreVote tests isolated follower,
+// with slow network incoming from leader, election times out
+// to become a pre-candidate with less log than current leader.
+// Then pre-vote phase prevents this isolated node from forcing
+// current leader to step down, thus less disruptions.
+func TestDisruptiveFollowerPreVote(t *testing.T) {
+	n1 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n2 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+	n3 := newTestRaftFsm(10, 1,
+		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+
+	n1.config.LeaseCheck = true
+	n2.config.LeaseCheck = true
+	n3.config.LeaseCheck = true
+
+	n1.becomeFollower(1, NoLeader)
+	n2.becomeFollower(1, NoLeader)
+	n3.becomeFollower(1, NoLeader)
+
+	nt := newNetwork(n1, n2, n3)
+
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+
+	// check state
+	// n1.state == stateLeader
+	// n2.state == stateFollower
+	// n3.state == stateFollower
+	if n1.state != stateLeader {
+		t.Fatalf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Fatalf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != stateFollower {
+		t.Fatalf("node 3 state: %s, want %v", n3.state, stateFollower)
+	}
+
+	nt.isolate(3)
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Data: []byte("somedata")}}})
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Data: []byte("somedata")}}})
+	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Data: []byte("somedata")}}})
+	n1.config.PreVote = true
+	n2.config.PreVote = true
+	n3.config.PreVote = true
+	nt.recover()
+	nt.send(proto.Message{From: 3, To: 3, Type: proto.LocalMsgHup})
+
+	// check state
+	// n1.state == stateLeader
+	// n2.state == stateFollower
+	// n3.state == statePreCandidate
+	if n1.state != stateLeader {
+		t.Fatalf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+	if n2.state != stateFollower {
+		t.Fatalf("node 2 state: %s, want %v", n2.state, stateFollower)
+	}
+	if n3.state != statePreCandidate {
+		t.Fatalf("node 3 state: %s, want %v", n3.state, statePreCandidate)
+	}
+	// check term
+	// n1.term == 2
+	// n2.term == 2
+	// n3.term == 2
+	if n1.term != 2 {
+		t.Fatalf("node 1 term: %d, want %d", n1.term, 2)
+	}
+	if n2.term != 2 {
+		t.Fatalf("node 2 term: %d, want %d", n2.term, 2)
+	}
+	if n3.term != 2 {
+		t.Fatalf("node 2 term: %d, want %d", n3.term, 2)
+	}
+
+	// delayed leader heartbeat does not force current leader to step down
+	nt.send(proto.Message{From: 1, To: 3, Term: n1.term, Type: proto.ReqMsgHeartBeat})
+	if n1.state != stateLeader {
+		t.Fatalf("node 1 state: %s, want %v", n1.state, stateLeader)
+	}
+}
+
+//func TestReadOnlyOptionSafe(t *testing.T) {
+//	a := newTestRaftFsm(10, 1,
+//		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//	b := newTestRaftFsm(10, 1,
+//		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//	c := newTestRaftFsm(10, 1,
+//		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//
+//	nt := newNetwork(a, b, c)
+//	b.randElectionTick+=1
+//	for i := 0; i < b.randElectionTick; i++ {
+//		b.tick()
+//	}
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//
+//	if a.state != stateLeader {
+//		t.Fatalf("state = %s, want %v", a.state, stateLeader)
+//	}
+//
+//	tests := []struct {
+//		sm        *raftFsm
+//		proposals int
+//		wri       uint64
+//		wctx      []byte
+//	}{
+//		{a, 10, 11, []byte("ctx1")},
+//		{b, 10, 21, []byte("ctx2")},
+//		{c, 10, 31, []byte("ctx3")},
+//		{a, 10, 41, []byte("ctx4")},
+//		{b, 10, 51, []byte("ctx5")},
+//		{c, 10, 61, []byte("ctx6")},
+//	}
+//
+//	for i, tt := range tests {
+//		for j := 0; j < tt.proposals; j++ {
+//			nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+//		}
+//
+//		nt.send(proto.Message{From: tt.sm.id, To: tt.sm.id, Type: proto.MsgReadIndex, Entries: []*proto.Entry{{Data: tt.wctx}}})
+//
+//		r := tt.sm
+//		if len(r.readStates) == 0 {
+//			t.Errorf("#%d: len(readStates) = 0, want non-zero", i)
+//		}
+//		rs := r.readStates[0]
+//		if rs.Index != tt.wri {
+//			t.Errorf("#%d: readIndex = %d, want %d", i, rs.Index, tt.wri)
+//		}
+//
+//		if !bytes.Equal(rs.RequestCtx, tt.wctx) {
+//			t.Errorf("#%d: requestCtx = %v, want %v", i, rs.RequestCtx, tt.wctx)
+//		}
+//		r.readStates = nil
+//	}
+//}
+//
+//func TestReadOnlyOptionLease(t *testing.T) {
+//	a := newTestRaftFsm(10, 1,
+//		newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//	b := newTestRaftFsm(10, 1,
+//		newTestRaftConfig(2, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//	c := newTestRaftFsm(10, 1,
+//		newTestRaftConfig(3, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//	a.readOnly.option = ReadOnlyLeaseBased
+//	b.readOnly.option = ReadOnlyLeaseBased
+//	c.readOnly.option = ReadOnlyLeaseBased
+//	a.config.LeaseCheck = true
+//	b.config.LeaseCheck = true
+//	c.config.LeaseCheck = true
+//
+//	nt := newNetwork(a, b, c)
+//	b.randElectionTick += 1
+//
+//	for i := 0; i < b.randElectionTick; i++ {
+//		b.tick()
+//	}
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//
+//	if a.state != stateLeader {
+//		t.Fatalf("state = %s, want %v", a.state, stateLeader)
+//	}
+//
+//	tests := []struct {
+//		sm        *raftFsm
+//		proposals int
+//		wri       uint64
+//		wctx      []byte
+//	}{
+//		{a, 10, 11, []byte("ctx1")},
+//		{b, 10, 21, []byte("ctx2")},
+//		{c, 10, 31, []byte("ctx3")},
+//		{a, 10, 41, []byte("ctx4")},
+//		{b, 10, 51, []byte("ctx5")},
+//		{c, 10, 61, []byte("ctx6")},
+//	}
+//
+//	for i, tt := range tests {
+//		for j := 0; j < tt.proposals; j++ {
+//			nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+//		}
+//
+//		nt.send(proto.Message{From: tt.sm.id, To: tt.sm.id, Type: proto.MsgReadIndex, Entries: []*proto.Entry{{Data: tt.wctx}}})
+//
+//		r := tt.sm
+//		rs := r.readStates[0]
+//		if rs.Index != tt.wri {
+//			t.Errorf("#%d: readIndex = %d, want %d", i, rs.Index, tt.wri)
+//		}
+//
+//		if !bytes.Equal(rs.RequestCtx, tt.wctx) {
+//			t.Errorf("#%d: requestCtx = %v, want %v", i, rs.RequestCtx, tt.wctx)
+//		}
+//		r.readStates = nil
+//	}
+//}
+//
+//// TestReadOnlyForNewLeader ensures that a leader only accepts MsgReadIndex message
+//// when it commits at least one log entry at it term.
+//func TestReadOnlyForNewLeader(t *testing.T) {
+//	nodeConfigs := []struct {
+//		id           uint64
+//		committed    uint64
+//		applied      uint64
+//		compactIndex uint64
+//	}{
+//		{1, 1, 1, 0},
+//		{2, 2, 2, 2},
+//		{3, 2, 2, 2},
+//	}
+//	peers := make([]stateMachine, 0)
+//	for _, c := range nodeConfigs {
+//		storage := newTestMemoryStorage(withPeers(1, 2, 3))
+//		storage.Append([]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1}})
+//		storage.SetHardState(proto.HardState{Term: 1, Commit: c.committed})
+//		if c.compactIndex != 0 {
+//			storage.Compact(c.compactIndex)
+//		}
+//		cfg := newTestConfig(c.id, 10, 1, storage)
+//		cfg.Applied = c.applied
+//		raft := newRaft(cfg)
+//		peers = append(peers, raft)
+//	}
+//	nt := newNetwork(peers...)
+//
+//	// Drop MsgApp to forbid peer a to commit any log entry at its term after it becomes leader.
+//	nt.ignore(proto.MsgApp)
+//	// Force peer a to become leader.
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//
+//	sm := nt.peers[1].(*raft)
+//	if sm.state != stateLeader {
+//		t.Fatalf("state = %s, want %v", sm.state, stateLeader)
+//	}
+//
+//	// Ensure peer a drops read only request.
+//	var windex uint64 = 4
+//	wctx := []byte("ctx")
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.MsgReadIndex, Entries: []*proto.Entry{{Data: wctx}}})
+//	if len(sm.readStates) != 0 {
+//		t.Fatalf("len(readStates) = %d, want zero", len(sm.readStates))
+//	}
+//
+//	nt.recover()
+//
+//	// Force peer a to commit a log entry at its term
+//	for i := 0; i < sm.heartbeatTimeout; i++ {
+//		sm.tick()
+//	}
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+//	if sm.raftLog.committed != 4 {
+//		t.Fatalf("committed = %d, want 4", sm.raftLog.committed)
+//	}
+//	lastLogTerm := sm.raftLog.zeroTermOnErrCompacted(sm.raftLog.term(sm.raftLog.committed))
+//	if lastLogTerm != sm.term {
+//		t.Fatalf("last log term = %d, want %d", lastLogTerm, sm.term)
+//	}
+//
+//	// Ensure peer a processed postponed read only request after it committed an entry at its term.
+//	if len(sm.readStates) != 1 {
+//		t.Fatalf("len(readStates) = %d, want 1", len(sm.readStates))
+//	}
+//	rs := sm.readStates[0]
+//	if rs.Index != windex {
+//		t.Fatalf("readIndex = %d, want %d", rs.Index, windex)
+//	}
+//	if !bytes.Equal(rs.RequestCtx, wctx) {
+//		t.Fatalf("requestCtx = %v, want %v", rs.RequestCtx, wctx)
+//	}
+//
+//	// Ensure peer a accepts read only request after it committed an entry at its term.
+//	nt.send(proto.Message{From: 1, To: 1, Type: proto.MsgReadIndex, Entries: []*proto.Entry{{Data: wctx}}})
+//	if len(sm.readStates) != 2 {
+//		t.Fatalf("len(readStates) = %d, want 2", len(sm.readStates))
+//	}
+//	rs = sm.readStates[1]
+//	if rs.Index != windex {
+//		t.Fatalf("readIndex = %d, want %d", rs.Index, windex)
+//	}
+//	if !bytes.Equal(rs.RequestCtx, wctx) {
+//		t.Fatalf("requestCtx = %v, want %v", rs.RequestCtx, wctx)
+//	}
+//}
+//
+//func TestLeaderAppResp(t *testing.T) {
+//	// initial progress: match = 0; next = 3
+//	tests := []struct {
+//		index  uint64
+//		reject bool
+//		// progress
+//		wmatch uint64
+//		wnext  uint64
+//		// message
+//		wmsgNum    int
+//		windex     uint64
+//		wcommitted uint64
+//	}{
+//		{3, true, 0, 3, 0, 0, 0},  // stale resp; no replies
+//		{2, true, 0, 2, 1, 1, 0},  // denied resp; leader does not commit; decrease next and send probing msg
+//		{2, false, 2, 4, 2, 2, 2}, // accept resp; leader commits; broadcast with commit index
+//		{0, false, 0, 3, 0, 0, 0}, // ignore heartbeat replies
+//	}
+//
+//	for i, tt := range tests {
+//		// sm term is 1 after it becomes the leader.
+//		// thus the last log term must be 1 to be committed.
+//		sm := newTestRaftFsm(10, 1,
+//			newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//		sm.raftLog = &raftLog{
+//			storage:  &MemoryStorage{ents: []*proto.Entry{{}, {Index: 1, Term: 0}, {Index: 2, Term: 1}}},
+//			unstable: unstable{offset: 3},
+//		}
+//		sm.becomeCandidate()
+//		sm.becomeLeader()
+//		sm.readMessages()
+//		sm.Step(proto.Message{From: 2, Type: proto.RespMsgAppend, Index: tt.index, Term: sm.term, Reject: tt.reject, RejectHint: tt.index})
+//
+//		p := sm.prs.Progress[2]
+//		if p.Match != tt.wmatch {
+//			t.Errorf("#%d match = %d, want %d", i, p.Match, tt.wmatch)
+//		}
+//		if p.Next != tt.wnext {
+//			t.Errorf("#%d next = %d, want %d", i, p.Next, tt.wnext)
+//		}
+//
+//		msgs := sm.readMessages()
+//
+//		if len(msgs) != tt.wmsgNum {
+//			t.Errorf("#%d msgNum = %d, want %d", i, len(msgs), tt.wmsgNum)
+//		}
+//		for j, msg := range msgs {
+//			if msg.Index != tt.windex {
+//				t.Errorf("#%d.%d index = %d, want %d", i, j, msg.Index, tt.windex)
+//			}
+//			if msg.Commit != tt.wcommitted {
+//				t.Errorf("#%d.%d commit = %d, want %d", i, j, msg.Commit, tt.wcommitted)
+//			}
+//		}
+//	}
+//}
+//
+//// TestBcastBeat is when the leader receives a heartbeat tick, it should
+//// send a MsgHeartbeat with m.Index = 0, m.LogTerm=0 and empty entries.
+//func TestBcastBeat(t *testing.T) {
+//	offset := uint64(1000)
+//	// make a state machine with log.offset = 1000
+//	s := proto.Snapshot{
+//		Metadata: proto.SnapshotMetadata{
+//			Index:     offset,
+//			Term:      1,
+//			ConfState: proto.ConfState{Voters: []uint64{1, 2, 3}},
+//		},
+//	}
+//	storage := NewMemoryStorage()
+//	storage.ApplySnapshot(s)
+//	sm := newTestRaft(1, 10, 1, storage)
+//	sm.term = 1
+//
+//	sm.becomeCandidate()
+//	sm.becomeLeader()
+//	for i := 0; i < 10; i++ {
+//		mustAppendEntry(sm, proto.Entry{Index: uint64(i) + 1})
+//	}
+//	// slow follower
+//	sm.prs.Progress[2].Match, sm.prs.Progress[2].Next = 5, 6
+//	// normal follower
+//	sm.prs.Progress[3].Match, sm.prs.Progress[3].Next = sm.raftLog.lastIndex(), sm.raftLog.lastIndex()+1
+//
+//	sm.Step(proto.Message{Type: proto.MsgBeat})
+//	msgs := sm.readMessages()
+//	if len(msgs) != 2 {
+//		t.Fatalf("len(msgs) = %v, want 2", len(msgs))
+//	}
+//	wantCommitMap := map[uint64]uint64{
+//		2: min(sm.raftLog.committed, sm.prs.Progress[2].Match),
+//		3: min(sm.raftLog.committed, sm.prs.Progress[3].Match),
+//	}
+//	for i, m := range msgs {
+//		if m.Type != proto.ReqMsgHeartBeat {
+//			t.Fatalf("#%d: type = %v, want = %v", i, m.Type, proto.ReqMsgHeartBeat)
+//		}
+//		if m.Index != 0 {
+//			t.Fatalf("#%d: prevIndex = %d, want %d", i, m.Index, 0)
+//		}
+//		if m.LogTerm != 0 {
+//			t.Fatalf("#%d: prevTerm = %d, want %d", i, m.LogTerm, 0)
+//		}
+//		if wantCommitMap[m.To] == 0 {
+//			t.Fatalf("#%d: unexpected to %d", i, m.To)
+//		} else {
+//			if m.Commit != wantCommitMap[m.To] {
+//				t.Fatalf("#%d: commit = %d, want %d", i, m.Commit, wantCommitMap[m.To])
+//			}
+//			delete(wantCommitMap, m.To)
+//		}
+//		if len(m.Entries) != 0 {
+//			t.Fatalf("#%d: len(entries) = %d, want 0", i, len(m.Entries))
+//		}
+//	}
+//}
+//
+//// TestRecvMsgBeat tests the output of the state machine when receiving MsgBeat
+//func TestRecvMsgBeat(t *testing.T) {
+//	tests := []struct {
+//		state fsmState
+//		wMsg  int
+//	}{
+//		{stateLeader, 2},
+//		// candidate and follower should ignore MsgBeat
+//		{stateCandidate, 0},
+//		{stateFollower, 0},
+//	}
+//
+//	for i, tt := range tests {
+//		sm := newTestRaftFsm(10, 1,
+//			newTestRaftConfig(1, withStorage(stor.DefaultMemoryStorage()), withPeers(1, 2, 3)))
+//		sm.raftLog = &raftLog{storage: &MemoryStorage{ents: []*proto.Entry{{}, {Index: 1, Term: 0}, {Index: 2, Term: 1}}}}
+//		sm.term = 1
+//		sm.state = tt.state
+//		switch tt.state {
+//		case stateFollower:
+//			sm.step = stepFollower
+//		case stateCandidate:
+//			sm.step = stepCandidate
+//		case stateLeader:
+//			sm.step = stepLeader
+//		}
+//		sm.Step(proto.Message{From: 1, To: 1, Type: proto.MsgBeat})
+//
+//		msgs := sm.readMessages()
+//		if len(msgs) != tt.wMsg {
+//			t.Errorf("%d: len(msgs) = %d, want %d", i, len(msgs), tt.wMsg)
+//		}
+//		for _, m := range msgs {
+//			if m.Type != proto.ReqMsgHeartBeat {
+//				t.Errorf("%d: msg.type = %v, want %v", i, m.Type, proto.ReqMsgHeartBeat)
+//			}
+//		}
+//	}
+//}
+//
+//func TestLeaderIncreaseNext(t *testing.T) {
+//	previousEnts := []*proto.Entry{{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3}}
+//	tests := []struct {
+//		// progress
+//		state tracker.fsmState
+//		next  uint64
+//
+//		wnext uint64
+//	}{
+//		// state replicate, optimistically increase next
+//		// previous entries + noop entry + propose + 1
+//		{tracker.StateReplicate, 2, uint64(len(previousEnts) + 1 + 1 + 1)},
+//		// state probe, not optimistically increase next
+//		{tracker.StateProbe, 2, 2},
+//	}
+//
+//	for i, tt := range tests {
+//		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
+//		sm.raftLog.append(previousEnts...)
+//		sm.becomeCandidate()
+//		sm.becomeLeader()
+//		sm.prs.Progress[2].State = tt.state
+//		sm.prs.Progress[2].Next = tt.next
+//		sm.Step(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Data: []byte("somedata")}}})
+//
+//		p := sm.prs.Progress[2]
+//		if p.Next != tt.wnext {
+//			t.Errorf("#%d next = %d, want %d", i, p.Next, tt.wnext)
+//		}
+//	}
+//}

--- a/depends/tiglabs/raft/raft_log_test.go
+++ b/depends/tiglabs/raft/raft_log_test.go
@@ -1,0 +1,760 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/storage"
+	"reflect"
+	"testing"
+)
+
+func TestFindConflict(t *testing.T) {
+	previousEnts := []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}
+	tests := []struct {
+		ents      []*proto.Entry
+		wconflict uint64
+	}{
+		// no conflict, empty ent
+		{[]*proto.Entry{}, 0},
+		// no conflict
+		{[]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}, 0},
+		{[]*proto.Entry{{Index: 2, Term: 2}, {Index: 3, Term: 3}}, 0},
+		{[]*proto.Entry{{Index: 3, Term: 3}}, 0},
+		// no conflict, but has new entries
+		{[]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 4}}, 4},
+		{[]*proto.Entry{{Index: 2, Term: 2}, {Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 4}}, 4},
+		{[]*proto.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 4}}, 4},
+		{[]*proto.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 4}}, 4},
+		// conflicts with existing entries
+		{[]*proto.Entry{{Index: 1, Term: 4}, {Index: 2, Term: 4}}, 1},
+		{[]*proto.Entry{{Index: 2, Term: 1}, {Index: 3, Term: 4}, {Index: 4, Term: 4}}, 2},
+		{[]*proto.Entry{{Index: 3, Term: 1}, {Index: 4, Term: 2}, {Index: 5, Term: 4}, {Index: 6, Term: 4}}, 3},
+	}
+
+	for i, tt := range tests {
+		raftLog, _ := newRaftLog(storage.DefaultMemoryStorage())
+		raftLog.append(previousEnts...)
+
+		gconflict := raftLog.findConflict(tt.ents)
+		if gconflict != tt.wconflict {
+			t.Errorf("#%d: conflict = %d, want %d", i, gconflict, tt.wconflict)
+		}
+	}
+}
+
+func TestIsUpToDate(t *testing.T) {
+	previousEnts := []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}
+	raftLog, _ := newRaftLog(storage.DefaultMemoryStorage())
+	raftLog.append(previousEnts...)
+	tests := []struct {
+		lastIndex uint64
+		term      uint64
+		wUpToDate bool
+	}{
+		// greater term, ignore lastIndex
+		{raftLog.lastIndex() - 1, 4, true},
+		{raftLog.lastIndex(), 4, true},
+		{raftLog.lastIndex() + 1, 4, true},
+		// smaller term, ignore lastIndex
+		{raftLog.lastIndex() - 1, 2, false},
+		{raftLog.lastIndex(), 2, false},
+		{raftLog.lastIndex() + 1, 2, false},
+		// equal term, equal or lager lastIndex wins
+		{raftLog.lastIndex() - 1, 3, false},
+		{raftLog.lastIndex(), 3, true},
+		{raftLog.lastIndex() + 1, 3, true},
+	}
+
+	for i, tt := range tests {
+		gUpToDate := raftLog.isUpToDate(tt.lastIndex, tt.term, 0, 0)
+		if gUpToDate != tt.wUpToDate {
+			t.Errorf("#%d: uptodate = %v, want %v", i, gUpToDate, tt.wUpToDate)
+		}
+	}
+}
+
+func TestAppend(t *testing.T) {
+	previousEnts := []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}
+	tests := []struct {
+		ents      []*proto.Entry
+		windex    uint64
+		wents     []*proto.Entry
+		wunstable uint64
+	}{
+		{
+			[]*proto.Entry{},
+			2,
+			[]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}},
+			3,
+		},
+		{
+			[]*proto.Entry{{Index: 3, Term: 2}},
+			3,
+			[]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 2}},
+			3,
+		},
+		// conflicts with index 1
+		{
+			[]*proto.Entry{{Index: 1, Term: 2}},
+			1,
+			[]*proto.Entry{{Index: 1, Term: 2}},
+			1,
+		},
+		// conflicts with index 2
+		{
+			[]*proto.Entry{{Index: 2, Term: 3}, {Index: 3, Term: 3}},
+			3,
+			[]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 3}, {Index: 3, Term: 3}},
+			2,
+		},
+	}
+
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.StoreEntries(previousEnts)
+		raftLog, _ := newRaftLog(s)
+
+		index := raftLog.append(tt.ents...)
+		if index != tt.windex {
+			t.Errorf("#%d: lastIndex = %d, want %d", i, index, tt.windex)
+		}
+		g, err := raftLog.entries(1, noLimit)
+		if err != nil {
+			t.Fatalf("#%d: unexpected error %v", i, err)
+		}
+		if !reflect.DeepEqual(g, tt.wents) {
+			t.Errorf("#%d: logEnts = %+v, want %+v", i, g, tt.wents)
+		}
+		if goff := raftLog.unstable.offset; goff != tt.wunstable {
+			t.Errorf("#%d: unstable = %d, want %d", i, goff, tt.wunstable)
+		}
+	}
+}
+
+// TestLogMaybeAppend ensures:
+// If the given (index, term) matches with the existing log:
+//  1. If an existing entry conflicts with a new one (same index
+//     but different terms), delete the existing entry and all that
+//     follow it
+//  2. Append any new entries not already in the log
+//
+// If the given (index, term) does not match with the existing log:
+//
+//	return false
+func TestLogMaybeAppend(t *testing.T) {
+	previousEnts := []*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}, {Index: 3, Term: 3}}
+	lastindex := uint64(3)
+	lastterm := uint64(3)
+	commit := uint64(1)
+
+	tests := []struct {
+		logTerm   uint64
+		index     uint64
+		committed uint64
+		ents      []*proto.Entry
+
+		wlasti  uint64
+		wappend bool
+		wcommit uint64
+		wpanic  bool
+	}{
+		// not match: term is different
+		{
+			lastterm - 1, lastindex, lastindex, []*proto.Entry{{Index: lastindex + 1, Term: 4}},
+			0, false, commit, false,
+		},
+		// not match: index out of bound
+		{
+			lastterm, lastindex + 1, lastindex, []*proto.Entry{{Index: lastindex + 2, Term: 4}},
+			0, false, commit, false,
+		},
+		// match with the last existing entry
+		{
+			lastterm, lastindex, lastindex, nil,
+			lastindex, true, lastindex, false,
+		},
+		{
+			lastterm, lastindex, lastindex + 1, nil,
+			lastindex, true, lastindex, false, // do not increase commit higher than lastnewi
+		},
+		{
+			lastterm, lastindex, lastindex - 1, nil,
+			lastindex, true, lastindex - 1, false, // commit up to the commit in the message
+		},
+		{
+			lastterm, lastindex, 0, nil,
+			lastindex, true, commit, false, // commit do not decrease
+		},
+		{
+			0, 0, lastindex, nil,
+			0, true, commit, false, // commit do not decrease
+		},
+		{
+			lastterm, lastindex, lastindex, []*proto.Entry{{Index: lastindex + 1, Term: 4}},
+			lastindex + 1, true, lastindex, false,
+		},
+		{
+			lastterm, lastindex, lastindex + 1, []*proto.Entry{{Index: lastindex + 1, Term: 4}},
+			lastindex + 1, true, lastindex + 1, false,
+		},
+		{
+			lastterm, lastindex, lastindex + 2, []*proto.Entry{{Index: lastindex + 1, Term: 4}},
+			lastindex + 1, true, lastindex + 1, false, // do not increase commit higher than lastnewi
+		},
+		{
+			lastterm, lastindex, lastindex + 2, []*proto.Entry{{Index: lastindex + 1, Term: 4}, {Index: lastindex + 2, Term: 4}},
+			lastindex + 2, true, lastindex + 2, false,
+		},
+		// match with the the entry in the middle
+		{
+			lastterm - 1, lastindex - 1, lastindex, []*proto.Entry{{Index: lastindex, Term: 4}},
+			lastindex, true, lastindex, false,
+		},
+		{
+			lastterm - 2, lastindex - 2, lastindex, []*proto.Entry{{Index: lastindex - 1, Term: 4}},
+			lastindex - 1, true, lastindex - 1, false,
+		},
+		{
+			lastterm - 3, lastindex - 3, lastindex, []*proto.Entry{{Index: lastindex - 2, Term: 4}},
+			lastindex - 2, true, lastindex - 2, true, // conflict with existing committed entry
+		},
+		{
+			lastterm - 2, lastindex - 2, lastindex, []*proto.Entry{{Index: lastindex - 1, Term: 4}, {Index: lastindex, Term: 4}},
+			lastindex, true, lastindex, false,
+		},
+	}
+
+	for i, tt := range tests {
+		raftLog, _ := newRaftLog(storage.DefaultMemoryStorage())
+		raftLog.append(previousEnts...)
+		raftLog.committed = commit
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wpanic {
+						t.Errorf("%d: panic = %v, want %v", i, true, tt.wpanic)
+					}
+				}
+			}()
+			glasti, gappend := raftLog.maybeAppend(tt.index, tt.logTerm, tt.committed, tt.ents...)
+			gcommit := raftLog.committed
+
+			if glasti != tt.wlasti {
+				t.Errorf("#%d: lastindex = %d, want %d", i, glasti, tt.wlasti)
+			}
+			if gappend != tt.wappend {
+				t.Errorf("#%d: append = %v, want %v", i, gappend, tt.wappend)
+			}
+			if gcommit != tt.wcommit {
+				t.Errorf("#%d: committed = %d, want %d", i, gcommit, tt.wcommit)
+			}
+			if gappend && len(tt.ents) != 0 {
+				gents, err := raftLog.slice(raftLog.lastIndex()-uint64(len(tt.ents))+1, raftLog.lastIndex()+1, noLimit)
+				if err != nil {
+					t.Fatalf("unexpected error %v", err)
+				}
+				if !reflect.DeepEqual(tt.ents, gents) {
+					t.Errorf("#%d: appended entries = %v, want %v", i, gents, tt.ents)
+				}
+			}
+		}()
+	}
+}
+
+// TestCompactionSideEffects ensures that all the log related functionality works correctly after
+// a compaction.
+func TestCompactionSideEffects(t *testing.T) {
+	var i uint64
+	// Populate the log with 1000 entries; 750 in stable storage and 250 in unstable.
+	lastIndex := uint64(1000)
+	unstableIndex := uint64(750)
+	lastTerm := lastIndex
+	s := storage.DefaultMemoryStorage()
+	for i = 1; i <= unstableIndex; i++ {
+		s.StoreEntries([]*proto.Entry{{Term: i, Index: i}})
+	}
+	raftLog, _ := newRaftLog(s)
+	for i = unstableIndex; i < lastIndex; i++ {
+		raftLog.append(&proto.Entry{Term: i + 1, Index: i + 1})
+	}
+
+	ok := raftLog.maybeCommit(lastIndex, lastTerm)
+	if !ok {
+		t.Fatalf("maybeCommit returned false")
+	}
+	raftLog.appliedTo(raftLog.committed)
+
+	offset := uint64(500)
+	s.Truncate(offset)
+
+	if raftLog.lastIndex() != lastIndex {
+		t.Errorf("lastIndex = %d, want %d", raftLog.lastIndex(), lastIndex)
+	}
+
+	for j := offset; j <= raftLog.lastIndex(); j++ {
+		if mustTerm(raftLog.term(j)) != j {
+			t.Errorf("term(%d) = %d, want %d", j, mustTerm(raftLog.term(j)), j)
+		}
+	}
+
+	for j := offset; j <= raftLog.lastIndex(); j++ {
+		if !raftLog.matchTerm(j, j) {
+			t.Errorf("matchTerm(%d) = false, want true", j)
+		}
+	}
+
+	unstableEnts := raftLog.unstableEntries()
+	if g := len(unstableEnts); g != 250 {
+		t.Errorf("len(unstableEntries) = %d, want = %d", g, 250)
+	}
+	if unstableEnts[0].Index != 751 {
+		t.Errorf("Index = %d, want = %d", unstableEnts[0].Index, 751)
+	}
+
+	prev := raftLog.lastIndex()
+	raftLog.append(&proto.Entry{Index: raftLog.lastIndex() + 1, Term: raftLog.lastIndex() + 1})
+	if raftLog.lastIndex() != prev+1 {
+		t.Errorf("lastIndex = %d, want = %d", raftLog.lastIndex(), prev+1)
+	}
+
+	ents, err := raftLog.entries(raftLog.lastIndex(), noLimit)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if len(ents) != 1 {
+		t.Errorf("len(entries) = %d, want = %d", len(ents), 1)
+	}
+}
+
+func TestNextEnts(t *testing.T) {
+	snap := proto.SnapshotMeta{
+		Term:  1,
+		Index: 3,
+	}
+	ents := []*proto.Entry{
+		{Term: 1, Index: 4},
+		{Term: 1, Index: 5},
+		{Term: 1, Index: 6},
+	}
+	tests := []struct {
+		applied uint64
+		wents   []*proto.Entry
+	}{
+		{0, ents[:2]},
+		{3, ents[:2]},
+		{4, ents[1:2]},
+		{5, nil},
+	}
+	for i, tt := range tests {
+		storage := storage.DefaultMemoryStorage()
+		storage.ApplySnapshot(snap)
+		raftLog, _ := newRaftLog(storage)
+		raftLog.append(ents...)
+		raftLog.maybeCommit(5, 1)
+		raftLog.appliedTo(tt.applied)
+
+		nents := raftLog.nextEnts(noLimit)
+		if !reflect.DeepEqual(nents, tt.wents) {
+			t.Errorf("#%d: nents = %+v, want %+v", i, nents, tt.wents)
+		}
+	}
+}
+
+// TestUnstableEnts ensures unstableEntries returns the unstable part of the
+// entries correctly.
+func TestUnstableEnts(t *testing.T) {
+	previousEnts := []*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}}
+	tests := []struct {
+		unstable uint64
+		wents    []*proto.Entry
+	}{
+		{3, nil},
+		{1, previousEnts},
+	}
+
+	for i, tt := range tests {
+		// append stable entries to storage
+		storage := storage.DefaultMemoryStorage()
+		storage.StoreEntries(previousEnts[:tt.unstable-1])
+
+		// append unstable entries to raftlog
+		raftLog, _ := newRaftLog(storage)
+		raftLog.append(previousEnts[tt.unstable-1:]...)
+
+		ents := raftLog.unstableEntries()
+		if !reflect.DeepEqual(ents, tt.wents) {
+			t.Errorf("#%d: unstableEnts = %+v, want %+v", i, ents, tt.wents)
+		}
+
+		if l := len(ents); l > 0 {
+			raftLog.stableTo(ents[l-1].Index, ents[l-1].Term)
+		}
+		w := previousEnts[len(previousEnts)-1].Index + 1
+		if g := raftLog.unstable.offset; g != w {
+			t.Errorf("#%d: unstable = %d, want %d", i, g, w)
+		}
+	}
+}
+
+func TestCommitTo(t *testing.T) {
+	previousEnts := []*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}, {Term: 3, Index: 3}}
+	commit := uint64(2)
+	tests := []struct {
+		commit  uint64
+		wcommit uint64
+		wpanic  bool
+	}{
+		{3, 3, false},
+		{1, 2, false}, // never decrease
+		{4, 0, true},  // commit out of range -> panic
+	}
+	for i, tt := range tests {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wpanic {
+						t.Errorf("%d: panic = %v, want %v", i, true, tt.wpanic)
+					}
+				}
+			}()
+			raftLog, _ := newRaftLog(storage.DefaultMemoryStorage())
+			raftLog.append(previousEnts...)
+			raftLog.committed = commit
+			raftLog.commitTo(tt.commit)
+			if raftLog.committed != tt.wcommit {
+				t.Errorf("#%d: committed = %d, want %d", i, raftLog.committed, tt.wcommit)
+			}
+		}()
+	}
+}
+
+func TestStableTo(t *testing.T) {
+	tests := []struct {
+		stablei   uint64
+		stablet   uint64
+		wunstable uint64
+	}{
+		{1, 1, 2},
+		{2, 2, 3},
+		{2, 1, 1}, // bad term
+		{3, 1, 1}, // bad index
+	}
+	for i, tt := range tests {
+		raftLog, _ := newRaftLog(storage.DefaultMemoryStorage())
+		raftLog.append([]*proto.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 2}}...)
+		raftLog.stableTo(tt.stablei, tt.stablet)
+		if raftLog.unstable.offset != tt.wunstable {
+			t.Errorf("#%d: unstable = %d, want %d", i, raftLog.unstable.offset, tt.wunstable)
+		}
+	}
+}
+
+func TestStableToWithSnap(t *testing.T) {
+	snapi, snapt := uint64(5), uint64(2)
+	tests := []struct {
+		stablei uint64
+		stablet uint64
+		newEnts []*proto.Entry
+
+		wunstable uint64
+	}{
+		{snapi + 1, snapt, nil, snapi + 1},
+		{snapi, snapt, nil, snapi + 1},
+		{snapi - 1, snapt, nil, snapi + 1},
+
+		{snapi + 1, snapt + 1, nil, snapi + 1},
+		{snapi, snapt + 1, nil, snapi + 1},
+		{snapi - 1, snapt + 1, nil, snapi + 1},
+
+		{snapi + 1, snapt, []*proto.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 2},
+		{snapi, snapt, []*proto.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 1},
+		{snapi - 1, snapt, []*proto.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 1},
+
+		{snapi + 1, snapt + 1, []*proto.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 1},
+		{snapi, snapt + 1, []*proto.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 1},
+		{snapi - 1, snapt + 1, []*proto.Entry{{Index: snapi + 1, Term: snapt}}, snapi + 1},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.ApplySnapshot(proto.SnapshotMeta{Index: snapi, Term: snapt})
+		raftLog, _ := newRaftLog(s)
+		raftLog.append(tt.newEnts...)
+		raftLog.stableTo(tt.stablei, tt.stablet)
+		if raftLog.unstable.offset != tt.wunstable {
+			t.Errorf("#%d: unstable = %d, want %d", i, raftLog.unstable.offset, tt.wunstable)
+		}
+	}
+}
+
+// TestCompaction ensures that the number of log entries is correct after compactions.
+func TestCompaction(t *testing.T) {
+	tests := []struct {
+		lastIndex uint64
+		compact   []uint64
+		wleft     []int
+		wallow    bool
+	}{
+		// out of upper bound
+		{1000, []uint64{1001}, []int{-1}, false},
+		{1000, []uint64{300, 500, 800, 900}, []int{700, 500, 200, 100}, true},
+		// out of lower bound
+		{1000, []uint64{300, 299}, []int{700, -1}, false},
+	}
+
+	for i, tt := range tests {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if tt.wallow {
+						t.Errorf("%d: allow = %v, want %v: %v", i, false, true, r)
+					}
+				}
+			}()
+
+			s := storage.DefaultMemoryStorage()
+			for i := uint64(1); i <= tt.lastIndex; i++ {
+				s.StoreEntries([]*proto.Entry{{Index: i}})
+			}
+			raftLog, _ := newRaftLog(s)
+			raftLog.maybeCommit(tt.lastIndex, 0)
+			raftLog.appliedTo(raftLog.committed)
+
+			for j := 0; j < len(tt.compact); j++ {
+				err := s.Truncate(tt.compact[j])
+				if err != nil {
+					if tt.wallow {
+						t.Errorf("#%d.%d allow = %t, want %t", i, j, false, tt.wallow)
+					}
+					continue
+				}
+				if len(raftLog.allEntries()) != tt.wleft[j] {
+					t.Errorf("#%d.%d len = %d, want %d", i, j, len(raftLog.allEntries()), tt.wleft[j])
+				}
+			}
+		}()
+	}
+}
+
+func TestLogRestore(t *testing.T) {
+	index := uint64(1000)
+	term := uint64(1000)
+	snap := proto.SnapshotMeta{Index: index, Term: term}
+	s := storage.DefaultMemoryStorage()
+	s.ApplySnapshot(snap)
+	raftLog, _ := newRaftLog(s)
+
+	if len(raftLog.allEntries()) != 0 {
+		t.Errorf("len = %d, want 0", len(raftLog.allEntries()))
+	}
+	if raftLog.firstIndex() != index+1 {
+		t.Errorf("firstIndex = %d, want %d", raftLog.firstIndex(), index+1)
+	}
+	if raftLog.committed != index {
+		t.Errorf("committed = %d, want %d", raftLog.committed, index)
+	}
+	if raftLog.unstable.offset != index+1 {
+		t.Errorf("unstable = %d, want %d", raftLog.unstable.offset, index+1)
+	}
+	if mustTerm(raftLog.term(index)) != term {
+		t.Errorf("term = %d, want %d", mustTerm(raftLog.term(index)), term)
+	}
+}
+
+func TestIsOutOfBounds(t *testing.T) {
+	offset := uint64(100)
+	num := uint64(100)
+	s := storage.DefaultMemoryStorage()
+	s.ApplySnapshot(proto.SnapshotMeta{Index: offset})
+	l, _ := newRaftLog(s)
+	for i := uint64(1); i <= num; i++ {
+		l.append(&proto.Entry{Index: i + offset})
+	}
+
+	first := offset + 1
+	tests := []struct {
+		lo, hi        uint64
+		wpanic        bool
+		wErrCompacted bool
+	}{
+		{
+			first - 2, first + 1,
+			false,
+			true,
+		},
+		{
+			first - 1, first + 1,
+			false,
+			true,
+		},
+		{
+			first, first,
+			false,
+			false,
+		},
+		{
+			first + num/2, first + num/2,
+			false,
+			false,
+		},
+		{
+			first + num - 1, first + num - 1,
+			false,
+			false,
+		},
+		{
+			first + num, first + num,
+			false,
+			false,
+		},
+		{
+			first + num, first + num + 1,
+			true,
+			false,
+		},
+		{
+			first + num + 1, first + num + 1,
+			true,
+			false,
+		},
+	}
+
+	for i, tt := range tests {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wpanic {
+						t.Errorf("%d: panic = %v, want %v: %v", i, true, false, r)
+					}
+				}
+			}()
+			err := l.mustCheckOutOfBounds(tt.lo, tt.hi)
+			if tt.wpanic {
+				t.Errorf("#%d: panic = %v, want %v", i, false, true)
+			}
+			if tt.wErrCompacted && err != ErrCompacted {
+				t.Errorf("#%d: err = %v, want %v", i, err, ErrCompacted)
+			}
+			if !tt.wErrCompacted && err != nil {
+				t.Errorf("#%d: unexpected err %v", i, err)
+			}
+		}()
+	}
+}
+
+func TestTerm(t *testing.T) {
+	var i uint64
+	offset := uint64(100)
+	num := uint64(100)
+
+	s := storage.DefaultMemoryStorage()
+	s.ApplySnapshot(proto.SnapshotMeta{Index: offset, Term: 1})
+	l, _ := newRaftLog(s)
+	for i = 1; i < num; i++ {
+		l.append(&proto.Entry{Index: offset + i, Term: i})
+	}
+
+	tests := []struct {
+		index uint64
+		w     uint64
+	}{
+		{offset - 1, 0},
+		{offset, 1},
+		{offset + num/2, num / 2},
+		{offset + num - 1, num - 1},
+		{offset + num, 0},
+	}
+
+	for j, tt := range tests {
+		term := mustTerm(l.term(tt.index))
+		if term != tt.w {
+			t.Errorf("#%d: at = %d, want %d", j, term, tt.w)
+		}
+	}
+}
+
+func TestSlice(t *testing.T) {
+	var i uint64
+	offset := uint64(100)
+	num := uint64(100)
+	last := offset + num
+	half := offset + num/2
+	halfe := proto.Entry{Index: half, Term: half}
+
+	s := storage.DefaultMemoryStorage()
+	s.ApplySnapshot(proto.SnapshotMeta{Index: offset})
+	for i = 1; i < num/2; i++ {
+		s.StoreEntries([]*proto.Entry{{Index: offset + i, Term: offset + i}})
+	}
+	l, _ := newRaftLog(s)
+	for i = num / 2; i < num; i++ {
+		l.append(&proto.Entry{Index: offset + i, Term: offset + i})
+	}
+
+	tests := []struct {
+		from  uint64
+		to    uint64
+		limit uint64
+
+		w      []*proto.Entry
+		wpanic bool
+	}{
+		// test no limit
+		{offset - 1, offset + 1, noLimit, nil, false},
+		{offset, offset + 1, noLimit, nil, false},
+		{half - 1, half + 1, noLimit, []*proto.Entry{{Index: half - 1, Term: half - 1}, {Index: half, Term: half}}, false},
+		{half, half + 1, noLimit, []*proto.Entry{{Index: half, Term: half}}, false},
+		{last - 1, last, noLimit, []*proto.Entry{{Index: last - 1, Term: last - 1}}, false},
+		{last, last + 1, noLimit, nil, true},
+
+		// test limit
+		{half - 1, half + 1, 0, []*proto.Entry{{Index: half - 1, Term: half - 1}}, false},
+		{half - 1, half + 1, uint64(halfe.Size() + 1), []*proto.Entry{{Index: half - 1, Term: half - 1}}, false},
+		{half - 2, half + 1, uint64(halfe.Size() + 1), []*proto.Entry{{Index: half - 2, Term: half - 2}}, false},
+		{half - 1, half + 1, uint64(halfe.Size() * 2), []*proto.Entry{{Index: half - 1, Term: half - 1}, {Index: half, Term: half}}, false},
+		{half - 1, half + 2, uint64(halfe.Size() * 3), []*proto.Entry{{Index: half - 1, Term: half - 1}, {Index: half, Term: half}, {Index: half + 1, Term: half + 1}}, false},
+		{half, half + 2, uint64(halfe.Size()), []*proto.Entry{{Index: half, Term: half}}, false},
+		{half, half + 2, uint64(halfe.Size() * 2), []*proto.Entry{{Index: half, Term: half}, {Index: half + 1, Term: half + 1}}, false},
+	}
+
+	for j, tt := range tests {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wpanic {
+						t.Errorf("%d: panic = %v, want %v: %v", j, true, false, r)
+					}
+				}
+			}()
+			g, err := l.slice(tt.from, tt.to, tt.limit)
+			if tt.from <= offset && err != ErrCompacted {
+				t.Fatalf("#%d: err = %v, want %v", j, err, ErrCompacted)
+			}
+			if tt.from > offset && err != nil {
+				t.Fatalf("#%d: unexpected error %v", j, err)
+			}
+			if !reflect.DeepEqual(g, tt.w) {
+				t.Errorf("#%d: from %d to %d = %v, want %v", j, tt.from, tt.to, g, tt.w)
+			}
+		}()
+	}
+}
+
+func mustTerm(term uint64, err error) uint64 {
+	if err != nil {
+		panic(err)
+	}
+	return term
+}

--- a/depends/tiglabs/raft/raft_log_unstable_test.go
+++ b/depends/tiglabs/raft/raft_log_unstable_test.go
@@ -1,0 +1,252 @@
+// Copyright 2015 The etcd Authors
+// Modified work copyright 2018 The tiglabs Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	"reflect"
+	"testing"
+)
+
+func TestMaybeLastIndex(t *testing.T) {
+	tests := []struct {
+		entries []*proto.Entry
+		offset  uint64
+		snap    *proto.SnapshotMeta
+
+		wok    bool
+		windex uint64
+	}{
+		// last in entries
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			true, 5,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			true, 5,
+		},
+		// empty unstable
+		{
+			[]*proto.Entry{}, 0, nil,
+			false, 0,
+		},
+	}
+
+	for i, tt := range tests {
+		u := unstable{
+			entries: tt.entries,
+			offset:  tt.offset,
+		}
+		index, ok := u.maybeLastIndex()
+		if ok != tt.wok {
+			t.Errorf("#%d: ok = %t, want %t", i, ok, tt.wok)
+		}
+		if index != tt.windex {
+			t.Errorf("#%d: index = %d, want %d", i, index, tt.windex)
+		}
+	}
+}
+
+func TestUnstableMaybeTerm(t *testing.T) {
+	tests := []struct {
+		entries []*proto.Entry
+		offset  uint64
+		index   uint64
+
+		wok   bool
+		wterm uint64
+	}{
+		// term from entries
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5,
+			5,
+			true, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5,
+			6,
+			false, 0,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5,
+			4,
+			false, 0,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5,
+			5,
+			true, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5,
+			6,
+			false, 0,
+		},
+	}
+
+	for i, tt := range tests {
+		u := unstable{
+			entries: tt.entries,
+			offset:  tt.offset,
+		}
+		term, ok := u.maybeTerm(tt.index)
+		if ok != tt.wok {
+			t.Errorf("#%d: ok = %t, want %t", i, ok, tt.wok)
+		}
+		if term != tt.wterm {
+			t.Errorf("#%d: term = %d, want %d", i, term, tt.wterm)
+		}
+	}
+}
+
+func TestUnstableStableTo(t *testing.T) {
+	tests := []struct {
+		entries     []*proto.Entry
+		offset      uint64
+		snap        *proto.SnapshotMeta
+		index, term uint64
+
+		woffset uint64
+		wlen    int
+	}{
+		{
+			[]*proto.Entry{}, 0, nil,
+			5, 1,
+			0, 0,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			5, 1, // stable to the first entry
+			6, 0,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 1}}, 5, nil,
+			5, 1, // stable to the first entry
+			6, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 6, Term: 2}}, 6, nil,
+			6, 1, // stable to the first entry and term mismatch
+			6, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			4, 1, // stable to old entry
+			5, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			4, 2, // stable to old entry
+			5, 1,
+		},
+		// with snapshot
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, &proto.SnapshotMeta{Index: 4, Term: 1},
+			5, 1, // stable to the first entry
+			6, 0,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 1}}, 5, &proto.SnapshotMeta{Index: 4, Term: 1},
+			5, 1, // stable to the first entry
+			6, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 6, Term: 2}}, 6, &proto.SnapshotMeta{Index: 5, Term: 1},
+			6, 1, // stable to the first entry and term mismatch
+			6, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, &proto.SnapshotMeta{Index: 4, Term: 1},
+			4, 1, // stable to snapshot
+			5, 1,
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 2}}, 5, &proto.SnapshotMeta{Index: 4, Term: 2},
+			4, 1, // stable to old entry
+			5, 1,
+		},
+	}
+
+	for i, tt := range tests {
+		u := unstable{
+			entries: tt.entries,
+			offset:  tt.offset,
+		}
+		u.stableTo(tt.index, tt.term)
+		if u.offset != tt.woffset {
+			t.Errorf("#%d: offset = %d, want %d", i, u.offset, tt.woffset)
+		}
+		if len(u.entries) != tt.wlen {
+			t.Errorf("#%d: len = %d, want %d", i, len(u.entries), tt.wlen)
+		}
+	}
+}
+
+func TestUnstableTruncateAndAppend(t *testing.T) {
+	tests := []struct {
+		entries  []*proto.Entry
+		offset   uint64
+		snap     *proto.Snapshot
+		toappend []*proto.Entry
+
+		woffset  uint64
+		wentries []*proto.Entry
+	}{
+		// append to the end
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			[]*proto.Entry{{Index: 6, Term: 1}, {Index: 7, Term: 1}},
+			5, []*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 1}, {Index: 7, Term: 1}},
+		},
+		// replace the unstable entries
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			[]*proto.Entry{{Index: 5, Term: 2}, {Index: 6, Term: 2}},
+			5, []*proto.Entry{{Index: 5, Term: 2}, {Index: 6, Term: 2}},
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}}, 5, nil,
+			[]*proto.Entry{{Index: 4, Term: 2}, {Index: 5, Term: 2}, {Index: 6, Term: 2}},
+			4, []*proto.Entry{{Index: 4, Term: 2}, {Index: 5, Term: 2}, {Index: 6, Term: 2}},
+		},
+		// truncate the existing entries and append
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 1}, {Index: 7, Term: 1}}, 5, nil,
+			[]*proto.Entry{{Index: 6, Term: 2}},
+			5, []*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 2}},
+		},
+		{
+			[]*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 1}, {Index: 7, Term: 1}}, 5, nil,
+			[]*proto.Entry{{Index: 7, Term: 2}, {Index: 8, Term: 2}},
+			5, []*proto.Entry{{Index: 5, Term: 1}, {Index: 6, Term: 1}, {Index: 7, Term: 2}, {Index: 8, Term: 2}},
+		},
+	}
+
+	for i, tt := range tests {
+		u := unstable{
+			entries: tt.entries,
+			offset:  tt.offset,
+		}
+		u.truncateAndAppend(tt.toappend)
+		if u.offset != tt.woffset {
+			t.Errorf("#%d: offset = %d, want %d", i, u.offset, tt.woffset)
+		}
+		if !reflect.DeepEqual(u.entries, tt.wentries) {
+			t.Errorf("#%d: entries = %v, want %v", i, u.entries, tt.wentries)
+		}
+	}
+}

--- a/depends/tiglabs/raft/raft_paper_test.go
+++ b/depends/tiglabs/raft/raft_paper_test.go
@@ -953,7 +953,6 @@ func newTestRaftConfig(nodeId uint64, opts ...testRaftConfigOptions) *RaftConfig
 	return rc
 }
 
-// todo should raft_test.go
 func (r *raftFsm) readMessages() []proto.Message {
 	msgs := make([]proto.Message, 0)
 	for _, m := range r.msgs {

--- a/depends/tiglabs/raft/raft_paper_test.go
+++ b/depends/tiglabs/raft/raft_paper_test.go
@@ -1,0 +1,1012 @@
+// Copyright 2015 The etcd Authors
+// Modified work copyright 2018 The tiglabs Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"fmt"
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/storage"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestFollowerUpdateTermFromMessage(t *testing.T) {
+	testUpdateTermFromMessage(t, stateFollower)
+}
+func TestCandidateUpdateTermFromMessage(t *testing.T) {
+	testUpdateTermFromMessage(t, stateCandidate)
+}
+func TestLeaderUpdateTermFromMessage(t *testing.T) {
+	testUpdateTermFromMessage(t, stateLeader)
+}
+
+// testUpdateTermFromMessage tests that if one server’s current term is
+// smaller than the other’s, then it updates its current term to the larger
+// value. If a candidate or leader discovers that its term is out of date,
+// it immediately reverts to follower state.
+// Reference: section 5.1
+func testUpdateTermFromMessage(t *testing.T, state fsmState) {
+	r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+
+	switch state {
+	case stateFollower:
+		r.becomeFollower(1, 2)
+	case stateCandidate:
+		r.becomeCandidate()
+	case stateLeader:
+		r.becomeCandidate()
+		r.becomeLeader()
+	}
+
+	r.Step(&proto.Message{Type: proto.ReqMsgAppend, Term: 2})
+
+	if r.term != 2 {
+		t.Errorf("term = %d, want %d", r.term, 2)
+	}
+	if r.state != stateFollower {
+		t.Errorf("state = %v, want %v", r.state, stateFollower)
+	}
+
+}
+
+// TestRejectStaleTermMessage tests that if a server receives a request with
+// a stale term number, it rejects the request.
+// Our implementation ignores the request instead.
+// Reference: section 5.1
+func TestRejectStaleTermMessage(t *testing.T) {
+	called := false
+	fakeStep := func(r *raftFsm, m *proto.Message) {
+		called = true
+	}
+	r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+	r.step = fakeStep
+	r.loadState(proto.HardState{Term: 2})
+
+	r.Step(&proto.Message{Type: proto.ReqMsgAppend, Term: r.term - 1})
+
+	if called {
+		t.Errorf("stepFunc called = %v, want %v", called, false)
+	}
+}
+
+// TestStartAsFollower tests that when servers start up, they begin as followers.
+// Reference: section 5.2
+func TestStartAsFollower(t *testing.T) {
+	r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+	if r.state != stateFollower {
+		t.Errorf("state = %s, want %s", r.state, stateFollower)
+	}
+}
+
+//	TestLeaderBcastBeat tests that if the leader receives a heartbeat tick,
+//	it will send a MsgHeartbeat with m.Index = 0, m.LogTerm=0 and empty entries
+//	as heartbeat to all followers.
+//	Reference: section 5.2
+//	tiglab/raft use ReqCheckQuorum while not ReqMsgHeartBeat, and if readIndex queue not nil direct return
+func TestLeaderBcastBeat(t *testing.T) {
+	// heartbeat interval
+	hi := 1
+	r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+	r.becomeCandidate()
+	r.becomeLeader()
+	for i := 0; i < 10; i++ {
+		r.appendEntry(&proto.Entry{Index: uint64(i) + 1})
+	}
+
+	for i := 0; i < hi; i++ {
+		r.tick()
+	}
+
+	msgs := r.readMessages()
+	sort.Sort(messageSlice(msgs))
+	wmsgs := []proto.Message{
+		{ID: r.id, From: 1, To: 2, Term: 1, Type: proto.ReqCheckQuorum},
+		{ID: r.id, From: 1, To: 3, Term: 1, Type: proto.ReqCheckQuorum},
+	}
+	for i := range msgs {
+		msgs[i].Entries = nil
+		require.Equal(t, msgs[i], wmsgs[i])
+	}
+}
+
+func TestFollowerStartElection(t *testing.T) {
+	testNonleaderStartElection(t, stateFollower)
+}
+func TestCandidateStartNewElection(t *testing.T) {
+	testNonleaderStartElection(t, stateCandidate)
+}
+
+// testNonleaderStartElection tests that if a follower receives no communication
+// over election timeout, it begins an election to choose a new leader. It
+// increments its current term and transitions to candidate state. It then
+// votes for itself and issues RequestVote RPCs in parallel to each of the
+// other servers in the cluster.
+// Reference: section 5.2
+// Also if a candidate fails to obtain a majority, it will time out and
+// start a new election by incrementing its term and initiating another
+// round of RequestVote RPCs.
+// Reference: section 5.2
+func testNonleaderStartElection(t *testing.T, state fsmState) {
+	// election timeout
+	et := 10
+	r := newTestRaftFsm(et, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+	switch state {
+	case stateFollower:
+		r.becomeFollower(1, 2)
+	case stateCandidate:
+		r.becomeCandidate()
+	}
+
+	for i := 1; i <= 2*et; i++ {
+		r.tick()
+	}
+
+	if r.term != 2 {
+		t.Errorf("term = %d, want 2", r.term)
+	}
+	if r.state != stateCandidate {
+		t.Errorf("state = %s, want %d", r.state, stateCandidate)
+	}
+	if !r.votes[r.id] {
+		t.Errorf("vote for self = false, want true")
+	}
+	msgs := r.readMessages()
+	sort.Sort(messageSlice(msgs))
+	wmsgs := []*proto.Message{
+		{ID: r.id, From: 1, To: 2, Term: 2, Type: proto.ReqMsgVote},
+		{ID: r.id, From: 1, To: 3, Term: 2, Type: proto.ReqMsgVote},
+	}
+	for i := range wmsgs {
+		require.Equal(t, msgs[i].Type, wmsgs[i].Type)
+		require.Equal(t, msgs[i].Term, wmsgs[i].Term)
+		require.Equal(t, msgs[i].To, wmsgs[i].To)
+		require.Equal(t, msgs[i].From, wmsgs[i].From)
+	}
+
+}
+
+// TestLeaderElectionInOneRoundRPC tests all cases that may happen in
+// leader election during one round of RequestVote RPC:
+// a) it wins the election
+// b) it loses the election
+// c) it is unclear about the result
+// Reference: section 5.2
+func TestLeaderElectionInOneRoundRPC(t *testing.T) {
+	tests := []struct {
+		size  int
+		votes map[uint64]bool
+		state fsmState
+	}{
+		// win the election when receiving votes from a majority of the servers
+		{1, map[uint64]bool{}, stateLeader},
+		{3, map[uint64]bool{2: true, 3: true}, stateLeader},
+		{3, map[uint64]bool{2: true}, stateLeader},
+		{5, map[uint64]bool{2: true, 3: true, 4: true, 5: true}, stateLeader},
+		{5, map[uint64]bool{2: true, 3: true, 4: true}, stateLeader},
+		{5, map[uint64]bool{2: true, 3: true}, stateLeader},
+
+		// return to follower state if it receives vote denial from a majority
+		{3, map[uint64]bool{2: false, 3: false}, stateFollower},
+		{5, map[uint64]bool{2: false, 3: false, 4: false, 5: false}, stateFollower},
+		{5, map[uint64]bool{2: true, 3: false, 4: false, 5: false}, stateFollower},
+
+		// stay in candidate if it does not obtain the majority
+		{3, map[uint64]bool{}, stateCandidate},
+		{5, map[uint64]bool{2: true}, stateCandidate},
+		{5, map[uint64]bool{2: false, 3: false}, stateCandidate},
+		{5, map[uint64]bool{}, stateCandidate},
+	}
+	for i, tt := range tests {
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(idsBySize(tt.size)...)))
+		r.Step(&proto.Message{ID: r.id, From: 1, To: 1, Type: proto.LocalMsgHup})
+		for id, vote := range tt.votes {
+			r.Step(&proto.Message{From: id, To: 1, Term: r.term, Type: proto.RespMsgVote, Reject: !vote})
+		}
+
+		if r.state != tt.state {
+			t.Errorf("#%d: state = %s, want %d", i, r.state, tt.state)
+		}
+		if g := r.term; g != 1 {
+			t.Errorf("#%d: term = %d, want %d", i, g, 1)
+		}
+	}
+}
+
+// TestFollowerVote tests that each follower will vote for at most one
+// candidate in a given term, on a first-come-first-served basis.
+// Reference: section 5.2
+func TestFollowerVote(t *testing.T) {
+	tests := []struct {
+		vote    uint64
+		nvote   uint64
+		wreject bool
+	}{
+		{NoLeader, 2, false},
+		{NoLeader, 3, false},
+		{2, 2, false},
+		{3, 3, false},
+		{2, 3, true},
+		{3, 2, true},
+	}
+	for _, tt := range tests {
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+		r.loadState(proto.HardState{Term: 1, Vote: tt.vote})
+
+		r.Step(&proto.Message{From: tt.nvote, To: 1, Term: 1, Type: proto.ReqMsgVote})
+
+		msgs := r.readMessages()
+		wmsgs := []proto.Message{
+			{ID: r.id, From: 1, To: tt.nvote, Term: 1, Type: proto.RespMsgVote, Reject: tt.wreject},
+		}
+
+		//todo
+		msgs[0].Entries = nil
+		require.Equal(t, msgs, wmsgs)
+	}
+}
+
+// TestCandidateFallback tests that while waiting for votes,
+// if a candidate receives an AppendEntries RPC from another server claiming
+// to be leader whose term is at least as large as the candidate's current term,
+// it recognizes the leader as legitimate and returns to follower state.
+// Reference: section 5.2
+func TestCandidateFallback(t *testing.T) {
+	tests := []*proto.Message{
+		{From: 2, To: 1, Term: 1, Type: proto.ReqMsgAppend},
+		{From: 2, To: 1, Term: 2, Type: proto.ReqMsgAppend},
+	}
+	for i, tt := range tests {
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+		r.Step(&proto.Message{ID: r.id, From: 1, To: 1, Type: proto.LocalMsgHup})
+		if r.state != stateCandidate {
+			t.Fatalf("unexpected state = %s, want %d", r.state, stateCandidate)
+		}
+
+		r.Step(tt)
+
+		if g := r.state; g != stateFollower {
+			t.Errorf("#%d: state = %s, want %d", i, g, stateFollower)
+		}
+		if g := r.term; g != tt.Term {
+			t.Errorf("#%d: term = %d, want %d", i, g, tt.Term)
+		}
+	}
+}
+
+func TestFollowerElectionTimeoutRandomized(t *testing.T) {
+	testNonleaderElectionTimeoutRandomized(t, stateFollower)
+}
+func TestCandidateElectionTimeoutRandomized(t *testing.T) {
+	testNonleaderElectionTimeoutRandomized(t, stateCandidate)
+}
+
+// testNonleaderElectionTimeoutRandomized tests that election timeout for
+// follower or candidate is randomized.
+// Reference: section 5.2
+func testNonleaderElectionTimeoutRandomized(t *testing.T, state fsmState) {
+	et := 10
+	r := newTestRaftFsm(et, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+	timeouts := make(map[int]bool)
+	for round := 0; round < 50*et; round++ {
+		switch state {
+		case stateFollower:
+			r.becomeFollower(r.term+1, 2)
+		case stateCandidate:
+			r.becomeCandidate()
+		}
+
+		time := 0
+		for len(r.readMessages()) == 0 {
+			r.tick()
+			time++
+		}
+		timeouts[time] = true
+	}
+
+	for d := et; d < 2*et; d++ {
+		if !timeouts[d] {
+			t.Errorf("timeout in %d ticks should happen", d)
+		}
+	}
+}
+
+func TestFollowersElectionTimeoutNonconflict(t *testing.T) {
+	testNonleadersElectionTimeoutNonconflict(t, stateFollower)
+}
+func TestCandidatesElectionTimeoutNonconflict(t *testing.T) {
+	testNonleadersElectionTimeoutNonconflict(t, stateCandidate)
+}
+
+// testNonleadersElectionTimeoutNonconflict tests that in most cases only a
+// single server(follower or candidate) will time out, which reduces the
+// likelihood of split vote in the new election.
+// Reference: section 5.2
+func testNonleadersElectionTimeoutNonconflict(t *testing.T, state fsmState) {
+	et := 10
+	size := 5
+	rs := make([]*raftFsm, size)
+	ids := idsBySize(size)
+	for k := range rs {
+		rs[k] = newTestRaftFsm(et, 1, newTestRaftConfig(ids[k], withPeers(ids...)))
+	}
+	conflicts := 0
+	for round := 0; round < 1000; round++ {
+		for _, r := range rs {
+			switch state {
+			case stateFollower:
+				r.becomeFollower(r.term+1, NoLeader)
+			case stateCandidate:
+				r.becomeCandidate()
+			}
+		}
+
+		timeoutNum := 0
+		for timeoutNum == 0 {
+			for _, r := range rs {
+				r.tick()
+				if len(r.readMessages()) > 0 {
+					timeoutNum++
+				}
+			}
+		}
+		// several rafts time out at the same tick
+		if timeoutNum > 1 {
+			conflicts++
+		}
+	}
+
+	if g := float64(conflicts) / 1000; g > 0.3 {
+		t.Errorf("probability of conflicts = %v, want <= 0.3", g)
+	}
+}
+
+// TestLeaderStartReplication tests that when receiving client proposals,
+// the leader appends the proposal to its log as a new entry, then issues
+// AppendEntries RPCs in parallel to each of the other servers to replicate
+// the entry. Also, when sending an AppendEntries RPC, the leader includes
+// the index and term of the entry in its log that immediately precedes
+// the new entries.
+// Also, it writes the new entry into stable storage.
+// Reference: section 5.3
+func TestLeaderStartReplication(t *testing.T) {
+	s := storage.DefaultMemoryStorage()
+	r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3)))
+	r.becomeCandidate()
+	r.becomeLeader()
+	commitNoopEntry(r, s)
+	li := r.raftLog.lastIndex()
+
+	ents := []*proto.Entry{{Index: li + 1, Term: r.term, Data: []byte("some data")}}
+	r.Step(&proto.Message{ID: r.id, From: 1, To: 1, Type: proto.LocalMsgProp, Entries: ents})
+
+	if g := r.raftLog.lastIndex(); g != li+1 {
+		t.Errorf("lastIndex = %d, want %d", g, li+1)
+	}
+	if g := r.raftLog.committed; g != li {
+		t.Errorf("committed = %d, want %d", g, li)
+	}
+	msgs := r.readMessages()
+	sort.Sort(messageSlice(msgs))
+	wents := []*proto.Entry{{Index: li + 1, Term: 1, Data: []byte("some data")}}
+	wmsgs := []proto.Message{
+		{ID: r.id, From: 1, To: 2, Term: 1, Type: proto.ReqMsgAppend, Index: li, LogTerm: 1, Entries: wents, Commit: li},
+		{ID: r.id, From: 1, To: 3, Term: 1, Type: proto.ReqMsgAppend, Index: li, LogTerm: 1, Entries: wents, Commit: li},
+	}
+	require.Equal(t, msgs, wmsgs)
+	g := r.raftLog.unstableEntries()
+	require.Equal(t, g, wents)
+
+}
+
+// TestLeaderCommitEntry tests that when the entry has been safely replicated,
+// the leader gives out the applied entries, which can be applied to its state
+// machine.
+// Also, the leader keeps track of the highest index it knows to be committed,
+// and it includes that index in future AppendEntries RPCs so that the other
+// servers eventually find out.
+// Reference: section 5.3
+func TestLeaderCommitEntry(t *testing.T) {
+	s := storage.DefaultMemoryStorage()
+	r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3)))
+	r.becomeCandidate()
+	r.becomeLeader()
+	commitNoopEntry(r, s)
+	li := r.raftLog.lastIndex()
+	r.Step(&proto.Message{ID: r.id, From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: li + 1, Term: r.term, Data: []byte("some data")}}})
+
+	for _, m := range r.readMessages() {
+		r.Step(acceptAndReply(m))
+	}
+
+	if g := r.raftLog.committed; g != li+1 {
+		t.Errorf("committed = %d, want %d", g, li+1)
+	}
+	wents := []*proto.Entry{{Index: li + 1, Term: 1, Data: []byte("some data")}}
+	if g := r.raftLog.nextEnts(noLimit); !reflect.DeepEqual(g, wents) {
+		t.Errorf("nextEnts = %+v, want %+v", g, wents)
+	}
+	msgs := r.readMessages()
+	sort.Sort(messageSlice(msgs))
+	for i, m := range msgs {
+		if w := uint64(i + 2); m.To != w {
+			t.Errorf("to = %x, want %x", m.To, w)
+		}
+		if m.Type != proto.ReqMsgAppend {
+			t.Errorf("type = %v, want %v", m.Type, proto.ReqMsgAppend)
+		}
+		if m.Commit != li+1 {
+			t.Errorf("commit = %d, want %d", m.Commit, li+1)
+		}
+	}
+}
+
+// TestLeaderAcknowledgeCommit tests that a log entry is committed once the
+// leader that created the entry has replicated it on a majority of the servers.
+// Reference: section 5.3
+func TestLeaderAcknowledgeCommit(t *testing.T) {
+	tests := []struct {
+		size               int
+		nonLeaderAcceptors map[uint64]bool
+		wack               bool
+	}{
+		{1, nil, true},
+		{3, nil, false},
+		{3, map[uint64]bool{2: true}, true},
+		{3, map[uint64]bool{2: true, 3: true}, true},
+		{5, nil, false},
+		{5, map[uint64]bool{2: true}, false},
+		{5, map[uint64]bool{2: true, 3: true}, true},
+		{5, map[uint64]bool{2: true, 3: true, 4: true}, true},
+		{5, map[uint64]bool{2: true, 3: true, 4: true, 5: true}, true},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(idsBySize(tt.size)...)))
+		r.becomeCandidate()
+		r.becomeLeader()
+		commitNoopEntry(r, s)
+		li := r.raftLog.lastIndex()
+		r.Step(&proto.Message{ID: r.id, From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: li + 1, Term: r.term, Data: []byte("some data")}}})
+		for _, m := range r.msgs {
+			if tt.nonLeaderAcceptors[m.To] {
+				r.Step(acceptAndReply(*m))
+			}
+		}
+
+		if g := r.raftLog.committed > li; g != tt.wack {
+			t.Errorf("#%d: ack commit = %v, want %v", i, g, tt.wack)
+		}
+	}
+}
+
+// TestLeaderCommitPrecedingEntries tests that when leader commits a log entry,
+// it also commits all preceding entries in the leader’s log, including
+// entries created by previous leaders.
+// Also, it applies the entry to its local state machine (in log order).
+// Reference: section 5.3
+func TestLeaderCommitPrecedingEntries(t *testing.T) {
+	tests := [][]*proto.Entry{
+		{},
+		{{Term: 2, Index: 1}},
+		{{Term: 1, Index: 1}, {Term: 2, Index: 2}},
+		{{Term: 1, Index: 1}},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.StoreEntries(tt)
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3)))
+		r.loadState(proto.HardState{Term: 2})
+		r.becomeCandidate()
+		r.becomeLeader()
+		r.Step(&proto.Message{ID: r.id, From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: r.raftLog.lastIndex() + 1, Term: r.term, Data: []byte("some data")}}})
+
+		for _, m := range r.readMessages() {
+			r.Step(acceptAndReply(m))
+		}
+
+		li := uint64(len(tt))
+		wents := append(tt, &proto.Entry{Term: 3, Index: li + 1}, &proto.Entry{Term: 3, Index: li + 2, Data: []byte("some data")})
+		if g := r.raftLog.nextEnts(noLimit); !reflect.DeepEqual(g, wents) {
+			t.Errorf("#%d: ents = %+v, want %+v", i, g, wents)
+		}
+	}
+}
+
+// TestFollowerCommitEntry tests that once a follower learns that a log entry
+// is committed, it applies the entry to its local state machine (in log order).
+// Reference: section 5.3
+func TestFollowerCommitEntry(t *testing.T) {
+	tests := []struct {
+		ents   []*proto.Entry
+		commit uint64
+	}{
+		{
+			[]*proto.Entry{
+				{Term: 1, Index: 1, Data: []byte("some data")},
+			},
+			1,
+		},
+		{
+			[]*proto.Entry{
+				{Term: 1, Index: 1, Data: []byte("some data")},
+				{Term: 1, Index: 2, Data: []byte("some data2")},
+			},
+			2,
+		},
+		{
+			[]*proto.Entry{
+				{Term: 1, Index: 1, Data: []byte("some data2")},
+				{Term: 1, Index: 2, Data: []byte("some data")},
+			},
+			2,
+		},
+		{
+			[]*proto.Entry{
+				{Term: 1, Index: 1, Data: []byte("some data")},
+				{Term: 1, Index: 2, Data: []byte("some data2")},
+			},
+			1,
+		},
+	}
+	for i, tt := range tests {
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+		r.becomeFollower(1, 2)
+
+		r.Step(&proto.Message{From: 2, To: 1, Type: proto.ReqMsgAppend, Term: 1, Entries: tt.ents, Commit: tt.commit})
+
+		if g := r.raftLog.committed; g != tt.commit {
+			t.Errorf("#%d: committed = %d, want %d", i, g, tt.commit)
+		}
+		wents := tt.ents[:int(tt.commit)]
+		//if g := r.raftLog.nextCommittedEnts(true); !reflect.DeepEqual(g, wents) {
+		if g := r.raftLog.nextEnts(noLimit); !reflect.DeepEqual(g, wents) {
+			t.Errorf("#%d: nextCommittedEnts = %v, want %v", i, g, wents)
+		}
+	}
+}
+
+// TestFollowerCheckMsgApp tests that if the follower does not find an
+// entry in its log with the same index and term as the one in AppendEntries RPC,
+// then it refuses the new entries. Otherwise it replies that it accepts the
+// append entries.
+// Reference: section 5.3
+// todo tiglab raft msg append rejiect not same with raft
+func TestFollowerCheckMsgApp(t *testing.T) {
+	ents := []*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}}
+	tests := []struct {
+		term        uint64
+		index       uint64
+		windex      uint64
+		wreject     bool
+		wrejectHint uint64
+		wlogterm    uint64
+	}{
+		// match with committed entries
+		{0, 0, 1, false, 0, 0},
+		{ents[0].Term, ents[0].Index, 1, false, 0, 0},
+		// match with uncommitted entries
+		{ents[1].Term, ents[1].Index, 2, false, 0, 0},
+
+		// unmatch with existing entry
+		{ents[0].Term, ents[1].Index, ents[1].Index, true, 2, 1},
+		// unexisting entry
+		{ents[1].Term + 1, ents[1].Index + 1, ents[1].Index + 1, true, 2, 2},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.StoreEntries(ents)
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3)))
+		r.loadState(proto.HardState{Commit: 1})
+		r.becomeFollower(2, 2)
+
+		r.Step(&proto.Message{From: 2, To: 1, Type: proto.ReqMsgAppend, Term: 2, LogTerm: tt.term, Index: tt.index})
+
+		msgs := r.readMessages()
+		// todo  this is diff from etcd raft, because tiglab raft has commited in (replica) which not in etcd raft (Progress)
+		// so this test case in tiglab raft, not use findConflictByTerm func, which wrejectHint should 1 and logTerm=0
+		wmsgs := []proto.Message{
+			{ID: r.id, From: 1, To: 2, Type: proto.RespMsgAppend, Term: 2, Index: tt.windex, Reject: tt.wreject, RejectIndex: tt.wrejectHint, LogTerm: 0, Commit: 1},
+		}
+		msgs[0].Entries = nil
+		if !reflect.DeepEqual(msgs, wmsgs) {
+			t.Errorf("#%d: msgs = %+v, want %+v", i, msgs, wmsgs)
+		}
+
+		// in test case the entries is empty, not need to check and manual set nil
+
+		fmt.Println("i=", i)
+		require.Equal(t, msgs, wmsgs)
+	}
+}
+
+// TestFollowerAppendEntries tests that when AppendEntries RPC is valid,
+// the follower will delete the existing conflict entry and all that follow it,
+// and append any new entries not already in the log.
+// Also, it writes the new entry into stable storage.
+// Reference: section 5.3
+func TestFollowerAppendEntries(t *testing.T) {
+	tests := []struct {
+		index, term uint64
+		ents        []*proto.Entry
+		wents       []*proto.Entry
+		wunstable   []*proto.Entry
+	}{
+		{
+			2, 2,
+			[]*proto.Entry{{Term: 3, Index: 3}},
+			[]*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}, {Term: 3, Index: 3}},
+			[]*proto.Entry{{Term: 3, Index: 3}},
+		},
+		{
+			1, 1,
+			[]*proto.Entry{{Term: 3, Index: 2}, {Term: 4, Index: 3}},
+			[]*proto.Entry{{Term: 1, Index: 1}, {Term: 3, Index: 2}, {Term: 4, Index: 3}},
+			[]*proto.Entry{{Term: 3, Index: 2}, {Term: 4, Index: 3}},
+		},
+		{
+			0, 0,
+			[]*proto.Entry{{Term: 1, Index: 1}},
+			[]*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}},
+			nil,
+		},
+		{
+			0, 0,
+			[]*proto.Entry{{Term: 3, Index: 1}},
+			[]*proto.Entry{{Term: 3, Index: 1}},
+			[]*proto.Entry{{Term: 3, Index: 1}},
+		},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.StoreEntries([]*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}})
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2, 3)))
+		r.becomeFollower(2, 2)
+
+		r.Step(&proto.Message{From: 2, To: 1, Type: proto.ReqMsgAppend, Term: 2, LogTerm: tt.term, Index: tt.index, Entries: tt.ents})
+
+		if g := r.raftLog.allEntries(); !reflect.DeepEqual(g, tt.wents) {
+			t.Errorf("#%d: ents = %+v, want %+v", i, g, tt.wents)
+		}
+		if g := r.raftLog.unstableEntries(); !reflect.DeepEqual(g, tt.wunstable) {
+			t.Errorf("#%d: unstableEnts = %+v, want %+v", i, g, tt.wunstable)
+		}
+	}
+}
+
+// TestLeaderSyncFollowerLog tests that the leader could bring a follower's log
+// into consistency with its own.
+// Reference: section 5.3, figure 7
+// todo remove
+//func TestLeaderSyncFollowerLog(t *testing.T) {
+//	ents := []*proto.Entry{
+//		{},
+//		{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//		{Term: 4, Index: 4}, {Term: 4, Index: 5},
+//		{Term: 5, Index: 6}, {Term: 5, Index: 7},
+//		{Term: 6, Index: 8}, {Term: 6, Index: 9}, {Term: 6, Index: 10},
+//	}
+//	term := uint64(8)
+//	tests := [][]*proto.Entry{
+//		{
+//			{},
+//			{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//			{Term: 4, Index: 4}, {Term: 4, Index: 5},
+//			{Term: 5, Index: 6}, {Term: 5, Index: 7},
+//			{Term: 6, Index: 8}, {Term: 6, Index: 9},
+//		},
+//		{
+//			{},
+//			{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//			{Term: 4, Index: 4},
+//		},
+//		{
+//			{},
+//			{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//			{Term: 4, Index: 4}, {Term: 4, Index: 5},
+//			{Term: 5, Index: 6}, {Term: 5, Index: 7},
+//			{Term: 6, Index: 8}, {Term: 6, Index: 9}, {Term: 6, Index: 10}, {Term: 6, Index: 11},
+//		},
+//		{
+//			{},
+//			{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//			{Term: 4, Index: 4}, {Term: 4, Index: 5},
+//			{Term: 5, Index: 6}, {Term: 5, Index: 7},
+//			{Term: 6, Index: 8}, {Term: 6, Index: 9}, {Term: 6, Index: 10},
+//			{Term: 7, Index: 11}, {Term: 7, Index: 12},
+//		},
+//		{
+//			{},
+//			{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//			{Term: 4, Index: 4}, {Term: 4, Index: 5}, {Term: 4, Index: 6}, {Term: 4, Index: 7},
+//		},
+//		{
+//			{},
+//			{Term: 1, Index: 1}, {Term: 1, Index: 2}, {Term: 1, Index: 3},
+//			{Term: 2, Index: 4}, {Term: 2, Index: 5}, {Term: 2, Index: 6},
+//			{Term: 3, Index: 7}, {Term: 3, Index: 8}, {Term: 3, Index: 9}, {Term: 3, Index: 10}, {Term: 3, Index: 11},
+//		},
+//	}
+//	for i, tt := range tests {
+//
+//		leadStorage := storage.DefaultMemoryStorage()
+//		leadStorage.StoreEntries(ents)
+//		lead := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(leadStorage), withPeers(1, 2, 3)))
+//
+//		lead.loadState(proto.HardState{Commit: lead.raftLog.lastIndex(), Term: term})
+//		followerStorage := storage.DefaultMemoryStorage()
+//		followerStorage.StoreEntries(tt)
+//		follower := newTestRaftFsm(10, 1, newTestRaftConfig(2, withStorage(followerStorage), withPeers(1, 2, 3)))
+//
+//		follower.loadState(proto.HardState{Term: term - 1})
+//		// It is necessary to have a three-node cluster.
+//		// The second may have more up-to-date log than the first one, so the
+//		// first node needs the vote from the third node to become the leader.
+//		n := newNetwork(lead, follower, nopStepper)
+//		n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgHup})
+//		// The election occurs in the term after the one we loaded with
+//		// lead.loadState above.
+//		n.send(proto.Message{From: 3, To: 1, Type: proto.RespMsgVote, Term: term + 1})
+//
+//		n.send(proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{}}})
+//
+//		if g := diffu(ltoa(lead.raftLog), ltoa(follower.raftLog)); g != "" {
+//			t.Errorf("#%d: log diff:\n%s", i, g)
+//		}
+//	}
+//}
+
+// TestVoteRequest tests that the vote request includes information about the candidate’s log
+// and are sent to all of the other nodes.
+// Reference: section 5.4.1
+func TestVoteRequest(t *testing.T) {
+	tests := []struct {
+		ents  []*proto.Entry
+		wterm uint64
+	}{
+		{[]*proto.Entry{{Term: 1, Index: 1}}, 2},
+		{[]*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}}, 3},
+	}
+	for j, tt := range tests {
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withPeers(1, 2, 3)))
+		r.Step(&proto.Message{
+			From: 2, To: 1, Type: proto.ReqMsgAppend, Term: tt.wterm - 1, LogTerm: 0, Index: 0, Entries: tt.ents,
+		})
+		r.readMessages()
+
+		for i := 1; i < r.config.ElectionTick*2; i++ {
+			r.tickElection()
+		}
+
+		msgs := r.readMessages()
+		sort.Sort(messageSlice(msgs))
+		if len(msgs) != 2 {
+			t.Fatalf("#%d: len(msg) = %d, want %d", j, len(msgs), 2)
+		}
+		for i, m := range msgs {
+			if m.Type != proto.ReqMsgVote {
+				t.Errorf("#%d: msgType = %d, want %d", i, m.Type, proto.ReqMsgVote)
+			}
+			if m.To != uint64(i+2) {
+				t.Errorf("#%d: to = %d, want %d", i, m.To, i+2)
+			}
+			if m.Term != tt.wterm {
+				t.Errorf("#%d: term = %d, want %d", i, m.Term, tt.wterm)
+			}
+			windex, wlogterm := tt.ents[len(tt.ents)-1].Index, tt.ents[len(tt.ents)-1].Term
+			if m.Index != windex {
+				t.Errorf("#%d: index = %d, want %d", i, m.Index, windex)
+			}
+			if m.LogTerm != wlogterm {
+				t.Errorf("#%d: logterm = %d, want %d", i, m.LogTerm, wlogterm)
+			}
+		}
+	}
+}
+
+// TestVoter tests the voter denies its vote if its own log is more up-to-date
+// than that of the candidate.
+// Reference: section 5.4.1
+func TestVoter(t *testing.T) {
+	tests := []struct {
+		ents    []*proto.Entry
+		logterm uint64
+		index   uint64
+
+		wreject bool
+	}{
+		// same logterm
+		{[]*proto.Entry{{Term: 1, Index: 1}}, 1, 1, false},
+		{[]*proto.Entry{{Term: 1, Index: 1}}, 1, 2, false},
+		{[]*proto.Entry{{Term: 1, Index: 1}, {Term: 1, Index: 2}}, 1, 1, true},
+		// candidate higher logterm
+		{[]*proto.Entry{{Term: 1, Index: 1}}, 2, 1, false},
+		{[]*proto.Entry{{Term: 1, Index: 1}}, 2, 2, false},
+		{[]*proto.Entry{{Term: 1, Index: 1}, {Term: 1, Index: 2}}, 2, 1, false},
+		// voter higher logterm
+		{[]*proto.Entry{{Term: 2, Index: 1}}, 1, 1, true},
+		{[]*proto.Entry{{Term: 2, Index: 1}}, 1, 2, true},
+		{[]*proto.Entry{{Term: 2, Index: 1}, {Term: 1, Index: 2}}, 1, 1, true},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.StoreEntries(tt.ents)
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2)))
+
+		r.Step(&proto.Message{From: 2, To: 1, Type: proto.ReqMsgVote, Term: 3, LogTerm: tt.logterm, Index: tt.index})
+
+		msgs := r.readMessages()
+		if len(msgs) != 1 {
+			t.Fatalf("#%d: len(msg) = %d, want %d", i, len(msgs), 1)
+		}
+		m := msgs[0]
+		if m.Type != proto.RespMsgVote {
+			t.Errorf("#%d: msgType = %d, want %d", i, m.Type, proto.RespMsgVote)
+		}
+		if m.Reject != tt.wreject {
+			t.Errorf("#%d: reject = %t, want %t", i, m.Reject, tt.wreject)
+		}
+	}
+}
+
+// TestLeaderOnlyCommitsLogFromCurrentTerm tests that only log entries from the leader’s
+// current term are committed by counting replicas.
+// Reference: section 5.4.2
+func TestLeaderOnlyCommitsLogFromCurrentTerm(t *testing.T) {
+	ents := []*proto.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}}
+	tests := []struct {
+		index   uint64
+		wcommit uint64
+	}{
+		// do not commit log entries in previous terms
+		{1, 0},
+		{2, 0},
+		// commit log in current term
+		{3, 3},
+	}
+	for i, tt := range tests {
+		s := storage.DefaultMemoryStorage()
+		s.StoreEntries(ents)
+		r := newTestRaftFsm(10, 1, newTestRaftConfig(1, withStorage(s), withPeers(1, 2)))
+
+		r.loadState(proto.HardState{Term: 2})
+		// become leader at term 3
+		r.becomeCandidate()
+		r.becomeLeader()
+		r.readMessages()
+		// propose a entry to current term
+		r.Step(&proto.Message{From: 1, To: 1, Type: proto.LocalMsgProp, Entries: []*proto.Entry{{Index: r.raftLog.lastIndex() + 1, Term: r.term}}})
+
+		r.Step(&proto.Message{From: 2, To: 1, Type: proto.RespMsgAppend, Term: r.term, Index: tt.index})
+		if r.raftLog.committed != tt.wcommit {
+			t.Errorf("#%d: commit = %d, want %d", i, r.raftLog.committed, tt.wcommit)
+		}
+	}
+}
+
+// nodeId is nodeID which must equal to one of peers ID
+func newTestRaftFsm(election, heartbeat int, rc *RaftConfig) *raftFsm {
+	conf := DefaultConfig()
+	conf.HeartbeatTick = heartbeat
+	conf.ElectionTick = election
+	conf.NodeID = rc.ID
+
+	r, _ := newRaftFsm(conf, rc)
+	return r
+}
+
+// lease check is true while use stateAck
+func newTestRaftFsmWithLeaseCheck(election, heartbeat int, rc *RaftConfig) *raftFsm {
+	conf := DefaultConfig()
+	conf.HeartbeatTick = heartbeat
+	conf.ElectionTick = election
+	conf.NodeID = rc.ID
+	conf.LeaseCheck = true
+
+	r, _ := newRaftFsm(conf, rc)
+	return r
+}
+
+type testRaftConfigOptions func(*RaftConfig)
+
+func withPeers(peersID ...uint64) testRaftConfigOptions {
+	peers := make([]proto.Peer, 0)
+	for _, p := range peersID {
+		peers = append(peers, proto.Peer{Type: 0, Priority: 0, ID: p, PeerID: p})
+	}
+	return func(config *RaftConfig) {
+		config.Peers = peers
+	}
+}
+
+func withStorage(s storage.Storage) testRaftConfigOptions {
+	return func(config *RaftConfig) {
+		config.Storage = s
+	}
+}
+
+func newTestRaftConfig(nodeId uint64, opts ...testRaftConfigOptions) *RaftConfig {
+	rc := &RaftConfig{
+		ID: nodeId,
+	}
+	for _, o := range opts {
+		o(rc)
+	}
+
+	if rc.Storage == nil {
+		rc.Storage = storage.DefaultMemoryStorage()
+	}
+	return rc
+}
+
+// todo should raft_test.go
+func (r *raftFsm) readMessages() []proto.Message {
+	msgs := make([]proto.Message, 0)
+	for _, m := range r.msgs {
+		msgs = append(msgs, *m)
+	}
+	r.msgs = make([]*proto.Message, 0)
+	return msgs
+}
+
+type messageSlice []proto.Message
+
+func (s messageSlice) Len() int           { return len(s) }
+func (s messageSlice) Less(i, j int) bool { return fmt.Sprint(s[i]) < fmt.Sprint(s[j]) }
+func (s messageSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+func idsBySize(size int) []uint64 {
+	ids := make([]uint64, size)
+	for i := 0; i < size; i++ {
+		ids[i] = 1 + uint64(i)
+	}
+	return ids
+}
+
+func commitNoopEntry(r *raftFsm, s *storage.MemoryStorage) {
+	if r.state != stateLeader {
+		panic("it should only be used when it is the leader")
+	}
+	r.bcastAppend()
+	// simulate the response of MsgApp
+	msgs := r.readMessages()
+	for _, m := range msgs {
+		//if m.Type != proto.RespMsgAppend || len(m.Entries) != 1 || m.Entries[0].Data != nil {
+		if m.Type != proto.ReqMsgAppend || len(m.Entries) != 1 || m.Entries[0].Data != nil {
+			panic("not a message to append noop entry")
+		}
+		r.Step(acceptAndReply(m))
+	}
+	// ignore further messages to refresh followers' commit index
+	r.readMessages()
+	s.StoreEntries(r.raftLog.unstableEntries())
+	r.raftLog.appliedTo(r.raftLog.committed)
+	r.raftLog.stableTo(r.raftLog.lastIndex(), r.raftLog.lastTerm())
+}
+
+func acceptAndReply(m proto.Message) *proto.Message {
+	if m.Type != proto.ReqMsgAppend {
+		panic("type should be MsgApp")
+	}
+	return &proto.Message{
+		From:  m.To,
+		To:    m.From,
+		Term:  m.Term,
+		Type:  proto.RespMsgAppend,
+		Index: m.Index + uint64(len(m.Entries)),
+	}
+}

--- a/depends/tiglabs/raft/server_test.go
+++ b/depends/tiglabs/raft/server_test.go
@@ -17,7 +17,7 @@ package raft
 
 import (
 	"encoding/binary"
-	"github.com/cubefs/cubefs/blobstore/cli/common/fmt"
+	"fmt"
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/storage/wal"
 	"github.com/cubefs/cubefs/util/log"

--- a/depends/tiglabs/raft/server_test.go
+++ b/depends/tiglabs/raft/server_test.go
@@ -270,7 +270,7 @@ func TestRaftServer(t *testing.T) {
 
 	// campaign and change leader
 	for _, raft := range servers[0].rafts {
-		raft.raftFsm.campaign(true)
+		raft.raftFsm.campaign(true, campaignPreElection)
 	}
 
 	for i := range servers {
@@ -316,7 +316,7 @@ func TestRaftServer(t *testing.T) {
 
 		t.Logf("----------------test -------------------")
 		// node1's raftId1 campaign
-		servers[1].rafts[raftId1].raftFsm.campaign(true)
+		servers[1].rafts[raftId1].raftFsm.campaign(true, campaignElection)
 
 		//for i := 0; i < len(servers); i++ {
 		//	if i == 0 {

--- a/depends/tiglabs/raft/server_test.go
+++ b/depends/tiglabs/raft/server_test.go
@@ -1,0 +1,360 @@
+// Copyright 2015 The etcd Authors
+// Modified work copyright 2018 The tiglabs Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"encoding/binary"
+	"github.com/cubefs/cubefs/blobstore/cli/common/fmt"
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
+	"github.com/cubefs/cubefs/depends/tiglabs/raft/storage/wal"
+	"github.com/cubefs/cubefs/util/log"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type serverStorage struct {
+	kv      sync.Map
+	applied uint64
+}
+
+func (s *serverStorage) Put(key, val []byte) error {
+	s.kv.Store(string(key), val)
+	return nil
+}
+
+func (s *serverStorage) Get(key string) ([]byte, error) {
+	val, hit := s.kv.Load(key)
+	if hit {
+		return val.([]byte), nil
+	}
+	return nil, nil
+}
+
+type testStateMachine struct {
+	store         *serverStorage
+	id            uint64
+	leader        uint64
+	changeLeaderC chan struct{}
+	applySnapC    chan struct{}
+	applyC        chan struct{}
+}
+
+func newTestStateMachine(id uint64, store *serverStorage) *testStateMachine {
+	return &testStateMachine{
+		id:            id,
+		store:         store,
+		changeLeaderC: make(chan struct{}, 1),
+		applySnapC:    make(chan struct{}, 1),
+		applyC:        make(chan struct{}, 1),
+	}
+}
+
+func (sm *testStateMachine) Apply(command []byte, index uint64) (interface{}, error) {
+
+	key, val := decode(command)
+	if err := sm.store.Put(key, val); err != nil {
+		return nil, err
+	}
+
+	sm.store.applied = index
+	sm.applyC <- struct{}{}
+
+	return nil, nil
+}
+
+func (sm *testStateMachine) ApplyMemberChange(cc *proto.ConfChange, index uint64) (interface{}, error) {
+	log.LogInfof("[node=%d] ApplyMemberChange [context: %s Type: %s]", sm.id, string(cc.Context), cc.Type.String())
+
+	sm.store.applied = index
+	return nil, nil
+}
+
+func (sm *testStateMachine) Snapshot() (proto.Snapshot, error) {
+	return nil, nil
+}
+
+func (sm *testStateMachine) ApplySnapshot(peers []proto.Peer, iter proto.SnapIterator) error {
+
+	return nil
+}
+
+func (sm *testStateMachine) HandleLeaderChange(leader uint64) {
+	sm.leader = leader
+	fmt.Println("xiangcai handler change")
+	if leader != 0 {
+		select {
+		case sm.changeLeaderC <- struct{}{}:
+
+		default:
+		}
+	}
+}
+
+func (sm *testStateMachine) HandleFatalEvent(err *FatalError) {
+
+}
+
+type testResolver struct {
+	nodeMap sync.Map
+}
+
+type testNodeAddress struct {
+	Heartbeat string
+	Replicate string
+}
+
+func newTestResolver() *testResolver {
+	return &testResolver{}
+}
+
+func (r *testResolver) NodeAddress(nodeID uint64, stype SocketType) (addr string, err error) {
+	val, ok := r.nodeMap.Load(nodeID)
+	if !ok {
+		return
+	}
+	address, ok := val.(*testNodeAddress)
+	if !ok {
+		return
+	}
+	switch stype {
+	case HeartBeat:
+		addr = address.Heartbeat
+	case Replicate:
+		addr = address.Replicate
+	default:
+
+	}
+	return
+}
+
+func (r *testResolver) AddNodeWithPort(nodeID uint64, addr string, heartbeat int, replicate int) {
+	if heartbeat == 0 {
+		heartbeat = 5901
+	}
+	if replicate == 0 {
+		replicate = 5902
+	}
+	if len(strings.TrimSpace(addr)) != 0 {
+		r.nodeMap.Store(nodeID, &testNodeAddress{
+			Heartbeat: fmt.Sprintf("%s:%d", addr, heartbeat),
+			Replicate: fmt.Sprintf("%s:%d", addr, replicate),
+		})
+	}
+}
+
+const (
+	raftId1 = iota + 11
+	raftId2
+	raftId3
+)
+
+var cleanWG sync.WaitGroup
+
+var peers = [3][]proto.Peer{
+	{{ID: 1, PeerID: raftId1}, {ID: 2, PeerID: raftId1}, {ID: 3, PeerID: raftId1}},
+	{{ID: 1, PeerID: raftId2}, {ID: 2, PeerID: raftId2}, {ID: 3, PeerID: raftId2}},
+	{{ID: 1, PeerID: raftId3}, {ID: 2, PeerID: raftId3}, {ID: 3, PeerID: raftId3}},
+}
+
+var walPaths = map[string]struct{}{}
+
+var rCfgs = [3][3]*RaftConfig{
+	{
+		{ID: raftId1, Term: 0, Applied: 0, Peers: peers[0]},
+		{ID: raftId2, Term: 0, Applied: 0, Peers: peers[1]},
+		{ID: raftId3, Term: 0, Applied: 0, Peers: peers[2]},
+	},
+	{
+		{ID: raftId1, Term: 0, Applied: 0, Peers: peers[0]},
+		{ID: raftId2, Term: 0, Applied: 0, Peers: peers[1]},
+		{ID: raftId3, Term: 0, Applied: 0, Peers: peers[2]},
+	},
+	{
+		{ID: raftId1, Term: 0, Applied: 0, Peers: peers[0]},
+		{ID: raftId2, Term: 0, Applied: 0, Peers: peers[1]},
+		{ID: raftId3, Term: 0, Applied: 0, Peers: peers[2]},
+	},
+}
+
+var cfgs = [3]*Config{
+	{NodeID: 1, TransportConfig: TransportConfig{HeartbeatAddr: ":9026", ReplicateAddr: ":9995"}},
+	{NodeID: 2, TransportConfig: TransportConfig{HeartbeatAddr: ":9027", ReplicateAddr: ":9996"}},
+	{NodeID: 3, TransportConfig: TransportConfig{HeartbeatAddr: ":9028", ReplicateAddr: ":9997"}},
+}
+
+func randID() string {
+	return fmt.Sprintf("%010d", rand.Intn(100000000))
+}
+
+func cleanTestServer(servers [3]*RaftServer) {
+	for i := range servers {
+		servers[i].Stop()
+	}
+	for p := range walPaths {
+		os.RemoveAll(p)
+	}
+
+}
+
+func initConfig() {
+	wc := &wal.Config{}
+	for j := range rCfgs {
+		nodePath := "/tmp/raft-" + fmt.Sprintf("%d/", j+1)
+		walPaths[nodePath] = struct{}{}
+		for _, rcf := range rCfgs[j] {
+			path := nodePath + fmt.Sprintf("%d-", rcf.ID) + randID()
+			rcf.Storage, _ = wal.NewStorage(path, wc)
+		}
+	}
+
+	resolver := newTestResolver()
+	for i := 0; i < len(cfgs); i++ {
+		cfgs[i].Resolver = resolver
+		hPorts := strings.Split(cfgs[i].HeartbeatAddr, ":")
+		h, _ := strconv.Atoi(hPorts[1])
+		rPorts := strings.Split(cfgs[i].ReplicateAddr, ":")
+		r, _ := strconv.Atoi(rPorts[1])
+		resolver.AddNodeWithPort(cfgs[i].NodeID, "127.0.0.1", h, r)
+	}
+}
+
+func newTestRaftServer() ([3]*RaftServer, func()) {
+	initConfig()
+
+	var (
+		servers [3]*RaftServer
+		sms     [3][3]*testStateMachine
+	)
+
+	// new raft server
+	for i := 0; i < len(rCfgs); i++ {
+		servers[i], _ = NewRaftServer(cfgs[i])
+		for j := 0; j < len(rCfgs); j++ {
+			sms[i][j] = newTestStateMachine(rCfgs[i][j].ID, &serverStorage{})
+			rCfgs[i][j].StateMachine = sms[i][j]
+			servers[i].CreateRaft(rCfgs[i][j])
+		}
+	}
+	cleanWG.Add(1)
+
+	return servers, func() {
+		go func() {
+			cleanTestServer(servers)
+			cleanWG.Done()
+		}()
+		cleanWG.Wait()
+	}
+}
+
+func TestRaftServer(t *testing.T) {
+	servers, clean := newTestRaftServer()
+	defer clean()
+
+	// campaign and change leader
+	for _, raft := range servers[0].rafts {
+		raft.raftFsm.campaign(true)
+	}
+
+	for i := range servers {
+		for _, raft := range servers[i].rafts {
+			// wait leader change finished
+			sm := raft.raftConfig.StateMachine.(*testStateMachine)
+			<-sm.changeLeaderC
+		}
+	}
+
+	// is leader
+	for i, _ := range servers[0].rafts {
+		isLeader := servers[0].IsLeader(i)
+		require.True(t, isLeader)
+	}
+
+	//submit some data
+	k1 := "key1"
+	v1 := "some data"
+	servers[0].Submit(raftId1, encode([]byte(k1), []byte(v1)))
+	sm1 := servers[0].rafts[raftId1].raftConfig.StateMachine.(*testStateMachine)
+	<-sm1.applyC
+	val, _ := sm1.store.Get(k1)
+	require.Equal(t, val, []byte(v1))
+
+	// get committed and applied
+	committed := servers[0].CommittedIndex(raftId1)
+	require.Equal(t, committed, uint64(2))
+	applied := servers[0].AppliedIndex(raftId1)
+	require.Equal(t, applied, uint64(2))
+
+	// remove raft
+	{
+		err := servers[0].RemoveRaft(raftId1)
+		require.NoError(t, err)
+
+		// remove raft will not exist
+		k2 := "key2"
+		v2 := "value data2"
+		future := servers[0].Submit(raftId1, encode([]byte(k2), []byte(v2)))
+		_, err = future.Response()
+		require.Equal(t, err, ErrRaftNotExists)
+
+		t.Logf("----------------test -------------------")
+		// node1's raftId1 campaign
+		servers[1].rafts[raftId1].raftFsm.campaign(true)
+
+		//for i := 0; i < len(servers); i++ {
+		//	if i == 0 {
+		//		continue
+		//	}
+		//	raft := servers[i].rafts[raftId1]
+		//	// wait leader change finished
+		//	sm := raft.raftConfig.StateMachine.(*testStateMachine)
+		//	<-sm.changeLeaderC
+		//}
+		//
+		//require.True(t, servers[1].IsLeader(raftId1))
+		//future = servers[1].Submit(raftId1, encode([]byte(k2), []byte(v2)))
+		//_, err = future.Response()
+		//require.NoError(t, err)
+
+	}
+
+}
+
+func TestSnapshot(t *testing.T) {
+	//servers, clean := newTestRaftServer()
+	//defer clean()
+
+}
+
+func encode(key []byte, value []byte) []byte {
+	data := make([]byte, 8+len(key)+len(value))
+	binary.BigEndian.PutUint32(data, uint32(len(key)))
+	binary.BigEndian.PutUint32(data[4:], uint32(len(value)))
+	copy(data[8:], key)
+	copy(data[8+len(key):], value)
+	return data
+}
+
+func decode(data []byte) ([]byte, []byte) {
+	keyLen := binary.BigEndian.Uint32(data)
+	valLen := binary.BigEndian.Uint32(data[4:])
+
+	return data[8 : 8+keyLen], data[8+keyLen : 8+keyLen+valLen]
+}

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -132,7 +132,9 @@ func (m *MetaNode) getPartitionByIDHandler(w http.ResponseWriter, r *http.Reques
 	}
 	msg := make(map[string]interface{})
 	leader, _ := mp.IsLeader()
+	_, leaderTerm := mp.LeaderTerm()
 	msg["leaderAddr"] = leader
+	msg["leader_term"] = leaderTerm
 	conf := mp.GetBaseConfig()
 	msg["partition_id"] = conf.PartitionId
 	msg["partition_type"] = conf.PartitionType

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -236,6 +236,7 @@ type OpPartition interface {
 	GetVolName() (volName string)
 	GetVerSeq() uint64
 	IsLeader() (leaderAddr string, isLeader bool)
+	LeaderTerm() (leaderID, term uint64)
 	IsFollowerRead() bool
 	SetFollowerRead(bool)
 	GetCursor() uint64
@@ -900,6 +901,13 @@ func (mp *metaPartition) IsLeader() (leaderAddr string, ok bool) {
 		}
 	}
 	return
+}
+
+func (mp *metaPartition) LeaderTerm() (leaderID, term uint64) {
+	if mp.raftPartition == nil {
+		return
+	}
+	return mp.raftPartition.LeaderTerm()
 }
 
 func (mp *metaPartition) GetPeers() (peers []string) {

--- a/raftstore/raftstore.go
+++ b/raftstore/raftstore.go
@@ -105,6 +105,7 @@ func NewRaftStore(cfg *Config, extendCfg *utilConfig.Config) (mr RaftStore, err 
 	rc := raft.DefaultConfig()
 	rc.NodeID = cfg.NodeID
 	rc.LeaseCheck = true
+	rc.PreVote = true
 	if cfg.HeartbeatPort <= 0 {
 		cfg.HeartbeatPort = DefaultHeartbeatPort
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CubeFS's MetaNode, DataNode, and Master components all use Raft. However, in exceptional situations such as network partitioning, the communication between nodes may be hindered, resulting in unnecessary leader election processes .

To address this issue, we use pre-Vote which involves conducting a preliminary round of voting before the formal election. Only when the candidate receives the support of the majority of nodes in the pre-vote can it participate in the formal election. This can reduce unnecessary leader election processes, improve system efficiency, and reliability.

add pre

fixes：#2383

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
When upgrading versions, it is important to ensure that the Raft service runs smoothly in a cluster composed of both old and new versions.