### PR TITLE
[Feature]: client support change the explicit name of the filesystem

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -644,10 +644,10 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 		fuse.MaxReadahead(MaxReadAhead),
 		fuse.AsyncRead(),
 		fuse.AutoInvalData(opt.AutoInvalData),
-		fuse.FSName("cubefs-" + opt.Volname),
+		fuse.FSName(opt.FileSystemName),
 		fuse.Subtype("cubefs"),
 		fuse.LocalVolume(),
-		fuse.VolumeName("cubefs-" + opt.Volname),
+		fuse.VolumeName(opt.FileSystemName),
 		fuse.RequestTimeout(opt.RequestTimeout)}
 
 	if opt.Rdonly {
@@ -755,6 +755,7 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	opt.EnableAudit = GlobalMountOptions[proto.EnableAudit].GetBool()
 	opt.RequestTimeout = GlobalMountOptions[proto.RequestTimeout].GetInt64()
 	opt.MinWriteAbleDataPartitionCnt = int(GlobalMountOptions[proto.MinWriteAbleDataPartitionCnt].GetInt64())
+	opt.FileSystemName = GlobalMountOptions[proto.FileSystemName].GetString()
 
 	if opt.MountPoint == "" || opt.Volname == "" || opt.Owner == "" || opt.Master == "" {
 		return nil, errors.New(fmt.Sprintf("invalid config file: lack of mandatory fields, mountPoint(%v), volName(%v), owner(%v), masterAddr(%v)", opt.MountPoint, opt.Volname, opt.Owner, opt.Master))
@@ -763,6 +764,11 @@ func parseMountOption(cfg *config.Config) (*proto.MountOptions, error) {
 	if opt.BuffersTotalLimit < 0 {
 		return nil, errors.New(fmt.Sprintf("invalid fields, BuffersTotalLimit(%v) must larger or equal than 0", opt.BuffersTotalLimit))
 	}
+
+	if opt.FileSystemName == "" {
+		opt.FileSystemName = "cubefs-" + opt.Volname
+	}
+
 	return opt, nil
 }
 

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -70,6 +70,7 @@ const (
 	EnableAudit
 	LocallyProf
 	MinWriteAbleDataPartitionCnt
+	FileSystemName
 	MaxMountOption
 )
 
@@ -158,6 +159,7 @@ func InitMountOptions(opts []MountOption) {
 	opts[MinWriteAbleDataPartitionCnt] = MountOption{"minWriteAbleDataPartitionCnt",
 		"Min writeable data partition count retained int dpSelector when update DataPartitionsView from master",
 		"", int64(10)}
+	opts[FileSystemName] = MountOption{"fileSystemName", "The explicit name of the filesystem", "", ""}
 
 	for i := 0; i < MaxMountOption; i++ {
 		flag.StringVar(&opts[i].cmdlineValue, opts[i].keyword, "", opts[i].description)
@@ -315,4 +317,5 @@ type MountOptions struct {
 	EnableAudit                  bool
 	RequestTimeout               int64
 	MinWriteAbleDataPartitionCnt int
+	FileSystemName               string
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Client support change the explicit name of the filesystem.

The default is still `"cubefs-" + [volume name]`

## example: 

**configuration file:**
``` json
{
  "masterAddr": "172.16.1.101:17010,172.16.1.102:17010,172.16.1.103:17010",
  "mountPoint": "/home/data/client/mnt",
  "volName": "vol_cross5",
  "owner": "cfs",
  "logDir": "/home/data/client/log",
  "logLevel": "debug",
  "fileSystemName": "testfs"
}
```

**mount the volume:**
```bash
cfs-client -c client.json
```

**result:**
```bash
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
testfs         1000G     0 1000G   0% /home/data/client/mnt
```
```bash
$ mount
testfs on /home/data/client/mnt type fuse.cubefs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other)
```