### PR TITLE
fix(log): fix bug that log configuration of logLeftSpaceLimit parsing…

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -159,7 +160,12 @@ func main() {
 	profPort := cfg.GetString(ConfigKeyProfPort)
 	umpDatadir := cfg.GetString(ConfigKeyWarnLogDir)
 	buffersTotalLimit := cfg.GetInt64(ConfigKeyBuffersTotalLimit)
-	logLeftSpaceLimit := cfg.GetInt(ConfigKeyLogLeftSpaceLimit)
+	logLeftSpaceLimitStr := cfg.GetString(ConfigKeyLogLeftSpaceLimit)
+	logLeftSpaceLimit, err := strconv.ParseInt(logLeftSpaceLimitStr, 10, 64)
+	if err != nil || logLeftSpaceLimit == 0 {
+		log.LogErrorf("logLeftSpaceLimit is not a legal int value: %v", err.Error())
+		logLeftSpaceLimit = log.DefaultLogLeftSpaceLimit
+	}
 
 	// Init server instance with specified role configuration.
 	var (
@@ -209,10 +215,6 @@ func main() {
 		level = log.CriticalLevel
 	default:
 		level = log.ErrorLevel
-	}
-
-	if logLeftSpaceLimit == 0 {
-		logLeftSpaceLimit = log.DefaultLogLeftSpaceLimit
 	}
 
 	_, err = log.InitLog(logDir, module, level, nil, logLeftSpaceLimit)

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -282,7 +282,7 @@ var gLog *Log = nil
 var LogDir string
 
 // InitLog initializes the log.
-func InitLog(dir, module string, level Level, rotate *LogRotate, logLeftSpaceLimit int) (*Log, error) {
+func InitLog(dir, module string, level Level, rotate *LogRotate, logLeftSpaceLimit int64) (*Log, error) {
 	l := new(Log)
 	dir = path.Join(dir, module)
 	l.dir = dir
@@ -745,10 +745,14 @@ func (l *Log) checkLogRotation(logDir, module string) {
 		fs := syscall.Statfs_t{}
 		if err := syscall.Statfs(logDir, &fs); err != nil {
 			LogErrorf("check disk space: %s", err.Error())
+			time.Sleep(DefaultRollingInterval)
 			continue
 		}
 		diskSpaceLeft := int64(fs.Bavail * uint64(fs.Bsize))
 		diskSpaceLeft -= l.rotate.headRoom * 1024 * 1024
+		if diskSpaceLeft <= 0 {
+			LogDebugf("logLeftSpaceLimit has been reached, need to clear %v Mb of Space", (-diskSpaceLeft)/1024/1024)
+		}
 		err := l.removeLogFile(logDir, diskSpaceLeft, module)
 		if err != nil {
 			time.Sleep(DefaultRollingInterval)
@@ -791,6 +795,7 @@ func (l *Log) removeLogFile(logDir string, diskSpaceLeft int64, module string) (
 	var needDelFiles RolledFile
 	for _, info := range fInfos {
 		if DeleteFileFilter(info, diskSpaceLeft, module) {
+			LogDebugf("%v will be put into needDelFiles", info.Name())
 			needDelFiles = append(needDelFiles, info)
 		}
 	}

--- a/util/log/log_test.go
+++ b/util/log/log_test.go
@@ -106,8 +106,14 @@ func TestLogLeftSpaceLimit01(t *testing.T) {
 	diskSpaceLeft, logFilePath, err := prepareTestLeftSpaceLimit(dir, logFileName)
 	if err != nil {
 		t.Errorf("create file[%v] err[%v]", logFilePath, err)
+		return
 	}
-	InitLog("/tmp/cfs", "cfs", DebugLevel, nil, diskSpaceLeft/1024/1024-1)
+	log, err := InitLog("/tmp/cfs", "cfs", DebugLevel, nil, DefaultLogLeftSpaceLimit)
+	if err != nil {
+		t.Errorf("init log err[%v]", err)
+		return
+	}
+	log.rotate.SetHeadRoomMb(int64(diskSpaceLeft/1024/1024 - 1))
 
 	time.Sleep(200 * time.Millisecond)
 
@@ -124,9 +130,15 @@ func TestLogLeftSpaceLimit02(t *testing.T) {
 	diskSpaceLeft, logFilePath, err := prepareTestLeftSpaceLimit(dir, logFileName)
 	if err != nil {
 		t.Errorf("create file[%v] err[%v]", logFilePath, err)
+		return
 	}
 
-	InitLog("/tmp/cfs", "cfs", DebugLevel, nil, diskSpaceLeft/1024/1024+1)
+	log, err := InitLog("/tmp/cfs", "cfs", DebugLevel, nil, DefaultLogLeftSpaceLimit)
+	if err != nil {
+		t.Errorf("init log err[%v]", err)
+		return
+	}
+	log.rotate.SetHeadRoomMb(int64(diskSpaceLeft/1024/1024 + 1))
 
 	time.Sleep(200 * time.Millisecond)
 	_, err = os.Stat(logFilePath)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix bug that log configuration of logLeftSpaceLimit parsing failed, and debug log when log deletion is triggered.Because the getInt() method in the current log configuration file parsing can not correctly parse the configuration value, so it will lead to the configuration item can not take effect properly, so modified the parsing method of these configuration items, in addition, the lack of debug logs in the log deletion process, it is impossible to know whether the deletion process is triggered or not.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes: #2399 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
