### PR TITLE
fix retry unlink dir inode failed bug.

### DIFF
--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -99,6 +99,10 @@ func (m *MetaNode) checkLocalPartitionMatchWithMaster() (err error) {
 		break
 	}
 
+	if err != nil {
+		return
+	}
+
 	if len(metaNodeInfo.PersistenceMetaPartitions) == 0 {
 		return
 	}

--- a/metanode/partition_fsmop_transaction.go
+++ b/metanode/partition_fsmop_transaction.go
@@ -161,14 +161,14 @@ func (mp *metaPartition) dentryInTx(parIno uint64, name string) uint8 {
 	return proto.OpOk
 }
 
-func (mp *metaPartition) txInodeInRb(inode uint64, newTxId string) bool {
+func (mp *metaPartition) txInodeInRb(inode uint64, newTxId string) (rbInode *TxRollbackInode) {
 
 	rbIno := mp.txProcessor.txResource.getTxRbInode(inode)
 	if rbIno != nil && rbIno.txInodeInfo.TxID == newTxId {
-		return true
+		return rbIno
 	}
 
-	return false
+	return nil
 }
 
 func (mp *metaPartition) txDentryInRb(parIno uint64, name, newTxId string) bool {

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -213,15 +213,17 @@ func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packe
 	ino := NewInode(req.Inode, 0)
 	inoResp := mp.getInode(ino)
 	if inoResp.Status != proto.OpOk {
-		if rbIno := mp.txInodeInRb(req.Inode, req.TxInfo.TxID); rbIno {
+		if rbIno := mp.txInodeInRb(req.Inode, req.TxInfo.TxID); rbIno != nil {
+			respIno = rbIno.inode
 			status = proto.OpOk
+
 			item := mp.inodeTree.Get(NewInode(req.Inode, 0))
 			if item != nil {
 				respIno = item.(*Inode)
 			}
 
 			p.ResultCode = status
-			log.LogWarnf("TxUnlinkInode: inode is already unlink before, req %v, rbIno %v", req, respIno)
+			log.LogWarnf("TxUnlinkInode: inode is already unlink before, req %v, rbIno %v, item %v", req, respIno, item)
 			return nil
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
check error fisrt to avoid panic when metanode request master. fixes #2421
when unlink dir ino, return ino info in rbInode. fixes #2422 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
