### PR TITLE
fix(meta)：check if err occur when query master, in function checkLocalPartitionMatchWithMaster() 

### DIFF
--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -101,6 +101,11 @@ func (m *MetaNode) checkLocalPartitionMatchWithMaster() (err error) {
 		break
 	}
 
+	if err != nil {
+		log.LogErrorf("checkLocalPartitionMatchWithMaster: after retry, get MetaNode info fail: err(%v)", err)
+		return
+	}
+
 	if len(metaNodeInfo.PersistenceMetaPartitions) == 0 {
 		return
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
in checkLocalPartitionMatchWithMaster()，if failed to query master may trigger panic for not checking if err occur.
not add checking if err occur before reading the response var.
