### PR TITLE
feat(docker): remove double quotes in docker env

### DIFF
--- a/docker/run_docker.env
+++ b/docker/run_docker.env
@@ -1,2 +1,2 @@
-IMAGE="cubefs/cbfs-base:1.0-golang-1.17.13"
-CFSROOT="/go/src/github.com/cubefs/cubefs"
+IMAGE=cubefs/cbfs-base:1.0-golang-1.17.13
+CFSROOT=/go/src/github.com/cubefs/cubefs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In old docker-compose version (before 1.26.0), docker compose will treats double quotes differently when parsing .env file. See issue https://github.com/docker/compose/issues/3702. This issue was fixed in docker-compose version [1.26.0](https://github.com/docker/compose/releases/tag/1.26.0). However, docker-compose in many places has not been upgraded to this version, which will cause compilation errors.

```bash
$ docker-compose -v
docker-compose version 1.25.0, build unknown
```

```bash
$ docker/run_docker.sh -r -d /data/disk
ERROR: no such image: "cubefs/cbfs-base:1.0-golang-1.17.13": invalid reference format
```

```bash
$ docker/run_docker.sh -r -d /data/disk
ERROR: Cannot create container for service prepare: invalid volume specification: '/root/cubefs:"/go/src/github.com/cubefs/cubefs":rw': invalid mount config for type "bind": invalid mount path: '"/go/src/github.com/cubefs/cubefs"' mount path must be absolute
```
### fix

Here, since the .env file has no spaces or special characters, we only need to remove the double quotes.