### PR TITLE
feat(Inode Lock Time): Changing the default value of optDeleteLockTim…

### DIFF
--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -396,10 +396,14 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 			}
 			confirmString.WriteString(fmt.Sprintf("  EnableQuota : %v\n", formatEnabledDisabled(vv.EnableQuota)))
 
-			if optDeleteLockTime >= 0 && optDeleteLockTime != vv.DeleteLockTime {
-				isChange = true
-				confirmString.WriteString(fmt.Sprintf("  DeleteLockTime            : %v h -> %v h\n", vv.DeleteLockTime, optDeleteLockTime))
-				vv.DeleteLockTime = optDeleteLockTime
+			if optDeleteLockTime >= 0 {
+				if optDeleteLockTime != vv.DeleteLockTime {
+					isChange = true
+					confirmString.WriteString(fmt.Sprintf("  DeleteLockTime            : %v h -> %v h\n", vv.DeleteLockTime, optDeleteLockTime))
+					vv.DeleteLockTime = optDeleteLockTime
+				} else {
+					confirmString.WriteString(fmt.Sprintf("  DeleteLockTime            : %v h\n", vv.DeleteLockTime))
+				}
 			} else {
 				confirmString.WriteString(fmt.Sprintf("  DeleteLockTime            : %v h\n", vv.DeleteLockTime))
 			}
@@ -627,7 +631,7 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().IntVar(&optTxOpLimitVal, CliTxOpLimit, 0, "Specify limitation[Unit: second] for transaction(default 0 unlimited)")
 	cmd.Flags().StringVar(&optReplicaNum, CliFlagReplicaNum, "", "Specify data partition replicas number(default 3 for normal volume,1 for low volume)")
 	cmd.Flags().StringVar(&optEnableQuota, CliFlagEnableQuota, "", "Enable quota")
-	cmd.Flags().Int64Var(&optDeleteLockTime, CliFlagDeleteLockTime, 0, "Specify delete lock time[Unit: hour] for volume")
+	cmd.Flags().Int64Var(&optDeleteLockTime, CliFlagDeleteLockTime, -1, "Specify delete lock time[Unit: hour] for volume")
 
 	return cmd
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, if you don't set the delete lock time when updating a volume, the delete lock function will be turned off when updating other information because its default value is 0. So this commit changes the default value of optDeleteLockTime and the judgment criteria
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes: #2341 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
