### PR TITLE
fix(meta): deleteMarkedInodes() will panic when print log if inode.mu…

### DIFF
--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -87,6 +87,14 @@ type Inode struct {
 	multiSnap *InodeMultiSnap
 }
 
+func (i *Inode) GetMultiVerString() string {
+	if i.multiSnap == nil {
+		return "nil"
+	}
+
+	return fmt.Sprintf("%v", i.multiSnap.multiVersions)
+}
+
 func (i *Inode) RangeMultiVer(visitor func(idx int, info *Inode) bool) {
 	if i.multiSnap == nil {
 		return
@@ -175,9 +183,9 @@ func (i *Inode) getTailVerInList() (verSeq uint64, found bool) {
 
 // freelist clean inode get all exist extents info, deal special case for split key
 func (inode *Inode) GetAllExtsOfflineInode(mpID uint64) (extInfo map[uint64][]*proto.ExtentKey) {
+	log.LogDebugf("deleteMarkedInodes. GetAllExtsOfflineInode.mp %v inode [%v] inode.Extents: %v, ino verList: %v",
+		mpID, inode.Inode, inode.Extents, inode.GetMultiVerString())
 
-	log.LogDebugf("deleteMarkedInodes. GetAllExtsOfflineInode.mp %v inode [%v] inode.Extents %v, ino verlist %v",
-		mpID, inode.Inode, inode.Extents, inode.multiSnap.multiVersions)
 	extInfo = make(map[uint64][]*proto.ExtentKey)
 
 	if inode.getLayerLen() > 0 {

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -227,7 +228,9 @@ func (mp *metaPartition) batchDeleteExtentsByPartition(partitionDeleteExtents ma
 func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 	defer func() {
 		if r := recover(); r != nil {
-			log.LogErrorf(fmt.Sprintf("metaPartition(%v) deleteMarkedInodes panic (%v)", mp.config.PartitionId, r))
+			stack := string(debug.Stack())
+			log.LogErrorf(fmt.Sprintf("metaPartition(%v) deleteMarkedInodes panic (%v)\nstack:%v",
+				mp.config.PartitionId, r, stack))
 		}
 	}()
 
@@ -247,7 +250,9 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 			continue
 		}
 
-		log.LogDebugf("deleteMarkedInodes. mp %v inode [%v] inode.Extents %v, ino verlist %v", mp.config.PartitionId, ino, inode.Extents, inode.multiSnap.multiVersions)
+		log.LogDebugf("deleteMarkedInodes. mp %v inode [%v] inode.Extents: %v, ino verList: %v",
+			mp.config.PartitionId, ino, inode.Extents, inode.GetMultiVerString())
+
 		if inode.getLayerLen() > 1 {
 			log.LogErrorf("deleteMarkedInodes. mp %v inode [%v] verlist len %v should not drop",
 				mp.config.PartitionId, ino, inode.getLayerLen())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix the problem that deleteMarkedInodes() will panic when print log if inode.multiSnap is nil
