### PR TITLE
feat(master/datanode/client):Add mediaType(SSD or HDD) property for datanode

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -721,6 +721,7 @@ func formatDataNodeDetail(dn *proto.DataNodeInfo, rowTable bool) string {
 	sb.WriteString(fmt.Sprintf("  Available           : %v\n", formatSize(dn.AvailableSpace)))
 	sb.WriteString(fmt.Sprintf("  Total               : %v\n", formatSize(dn.Total)))
 	sb.WriteString(fmt.Sprintf("  Zone                : %v\n", dn.ZoneName))
+	sb.WriteString(fmt.Sprintf("  MediaType           : %v\n", proto.MediaTypeString(dn.MediaType)))
 	sb.WriteString(fmt.Sprintf("  IsActive            : %v\n", formatNodeStatus(dn.IsActive)))
 	sb.WriteString(fmt.Sprintf("  Report time         : %v\n", formatTimeToString(dn.ReportTime)))
 	sb.WriteString(fmt.Sprintf("  Partition count     : %v\n", dn.DataPartitionCount))

--- a/docker/conf/datanode.json
+++ b/docker/conf/datanode.json
@@ -24,5 +24,7 @@
     "192.168.0.12:17010",
     "192.168.0.13:17010"
   ],
-  "enableSmuxConnPool": true
+  "enableSmuxConnPool": true,
+
+  "mediaType": 1
 }

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -151,7 +151,7 @@ func parseRequestForUpdateMetaNode(r *http.Request) (nodeAddr string, id uint64,
 	return
 }
 
-func parseRequestForAddNode(r *http.Request) (nodeAddr, zoneName string, err error) {
+func parseRequestForAddNode(r *http.Request) (nodeAddr, zoneName string, mediaType uint32, err error) {
 	if err = r.ParseForm(); err != nil {
 		return
 	}
@@ -160,6 +160,9 @@ func parseRequestForAddNode(r *http.Request) (nodeAddr, zoneName string, err err
 	}
 	if zoneName = r.FormValue(zoneNameKey); zoneName == "" {
 		zoneName = DefaultZoneName
+	}
+	if mediaType, err = extractMediaType(r); err != nil {
+		return
 	}
 	return
 }
@@ -1650,4 +1653,16 @@ func extractInodeId(r *http.Request) (inode uint64, err error) {
 		return
 	}
 	return strconv.ParseUint(value, 10, 64)
+}
+
+func extractMediaType(r *http.Request) (mediaType uint32, err error) {
+	var value string
+	if value = r.FormValue(mediaTypeKey); value == "" {
+		mediaType = proto.MediaType_Unspecified
+		return
+	}
+
+	parsedMediaType, err := strconv.ParseUint(value, 10, 32)
+	mediaType = uint32(parsedMediaType)
+	return
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2275,6 +2275,7 @@ func (m *Server) addDataNode(w http.ResponseWriter, r *http.Request) {
 	var (
 		nodeAddr  string
 		zoneName  string
+		mediaType uint32
 		id        uint64
 		err       error
 		nodesetId uint64
@@ -2284,7 +2285,7 @@ func (m *Server) addDataNode(w http.ResponseWriter, r *http.Request) {
 		doStatAndMetric(proto.AddDataNode, metric, err, nil)
 	}()
 
-	if nodeAddr, zoneName, err = parseRequestForAddNode(r); err != nil {
+	if nodeAddr, zoneName, mediaType, err = parseRequestForAddNode(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
@@ -2301,7 +2302,7 @@ func (m *Server) addDataNode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if id, err = m.cluster.addDataNode(nodeAddr, zoneName, nodesetId); err != nil {
+	if id, err = m.cluster.addDataNode(nodeAddr, zoneName, nodesetId, mediaType); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}
@@ -2355,6 +2356,7 @@ func (m *Server) getDataNode(w http.ResponseWriter, r *http.Request) {
 		MaxDpCntLimit:             dataNode.GetDpCntLimit(),
 		CpuUtil:                   dataNode.CpuUtil.Load(),
 		IoUtils:                   dataNode.GetIoUtils(),
+		MediaType:                 dataNode.MediaType,
 	}
 
 	sendOkReply(w, r, newSuccessHTTPReply(dataNodeInfo))
@@ -3574,7 +3576,7 @@ func (m *Server) addMetaNode(w http.ResponseWriter, r *http.Request) {
 		doStatAndMetric(proto.AddMetaNode, metric, err, nil)
 	}()
 
-	if nodeAddr, zoneName, err = parseRequestForAddNode(r); err != nil {
+	if nodeAddr, zoneName, _, err = parseRequestForAddNode(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -955,7 +955,7 @@ errHandler:
 	return
 }
 
-func (c *Cluster) addDataNode(nodeAddr, zoneName string, nodesetId uint64) (id uint64, err error) {
+func (c *Cluster) addDataNode(nodeAddr, zoneName string, nodesetId uint64, mediaType uint32) (id uint64, err error) {
 	c.dnMutex.Lock()
 	defer c.dnMutex.Unlock()
 	var dataNode *DataNode
@@ -967,7 +967,7 @@ func (c *Cluster) addDataNode(nodeAddr, zoneName string, nodesetId uint64) (id u
 		return dataNode.ID, nil
 	}
 
-	dataNode = newDataNode(nodeAddr, zoneName, c.Name)
+	dataNode = newDataNode(nodeAddr, zoneName, c.Name, mediaType)
 	dataNode.DpCntLimit = newDpCountLimiter(&c.cfg.MaxDpCntLimit)
 	zone, err := c.t.getZone(zoneName)
 	if err != nil {
@@ -992,7 +992,8 @@ func (c *Cluster) addDataNode(nodeAddr, zoneName string, nodesetId uint64) (id u
 	}
 	dataNode.ID = id
 	dataNode.NodeSetID = ns.ID
-	log.LogInfof("action[addDataNode] datanode id[%v] zonename [%v] add node to nodesetid[%v]", id, zoneName, ns.ID)
+	log.LogInfof("action[addDataNode] datanode id[%v] zonename[%v] MediaType[%v] add node to nodesetid[%v]",
+		id, zoneName, dataNode.MediaType, ns.ID)
 	if err = c.syncAddDataNode(dataNode); err != nil {
 		goto errHandler
 	}

--- a/master/const.go
+++ b/master/const.go
@@ -58,8 +58,8 @@ const (
 	authenticateKey            = "authenticate"
 	akKey                      = "ak"
 	keywordsKey                = "keywords"
-	zoneNameKey                = "zoneName"
 	nodesetIdKey               = "nodesetId"
+	zoneNameKey                = "zoneName"
 	crossZoneKey               = "crossZone"
 	normalZonesFirstKey        = "normalZonesFirst"
 	userKey                    = "user"
@@ -119,6 +119,7 @@ const (
 	ignoreDiscardKey           = "ignoreDiscard"
 	verSeqKey                  = "verSeq"
 	Periodic                   = "periodic"
+	mediaTypeKey               = "mediaType"
 )
 
 const (

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -71,9 +71,10 @@ type DataNode struct {
 	DpCntLimit                DpCountLimiter     `json:"-"` // max count of data partition in a data node
 	CpuUtil                   atomicutil.Float64 `json:"-"`
 	ioUtils                   atomic.Value       `json:"-"`
+	MediaType                 uint32
 }
 
-func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
+func newDataNode(addr, zoneName, clusterID string, mediaType uint32) (dataNode *DataNode) {
 	dataNode = new(DataNode)
 	dataNode.Carry = rand.Float64()
 	dataNode.Total = 1
@@ -87,6 +88,7 @@ func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
 	dataNode.DpCntLimit = newDpCountLimiter(nil)
 	dataNode.CpuUtil.Store(0)
 	dataNode.SetIoUtils(make(map[string]float64))
+	dataNode.MediaType = mediaType
 	return
 }
 

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -354,6 +354,7 @@ type dataNodeValue struct {
 	DecommissionTerm         uint64
 	DecommissionCompleteTime int64
 	ToBeOffline              bool
+	MediaType                uint32
 }
 
 func newDataNodeValue(dataNode *DataNode) *dataNodeValue {
@@ -373,6 +374,7 @@ func newDataNodeValue(dataNode *DataNode) *dataNodeValue {
 		DecommissionTerm:         dataNode.DecommissionTerm,
 		DecommissionCompleteTime: dataNode.DecommissionCompleteTime,
 		ToBeOffline:              dataNode.ToBeOffline,
+		MediaType:                dataNode.MediaType,
 	}
 }
 
@@ -1216,7 +1218,7 @@ func (c *Cluster) loadDataNodes() (err error) {
 		if dnv.ZoneName == "" {
 			dnv.ZoneName = DefaultZoneName
 		}
-		dataNode := newDataNode(dnv.Addr, dnv.ZoneName, c.Name)
+		dataNode := newDataNode(dnv.Addr, dnv.ZoneName, c.Name, dnv.MediaType)
 		dataNode.ID = dnv.ID
 		dataNode.NodeSetID = dnv.NodeSetID
 		dataNode.RdOnly = dnv.RdOnly
@@ -1239,7 +1241,8 @@ func (c *Cluster) loadDataNodes() (err error) {
 			}
 		}
 		c.dataNodes.Store(dataNode.Addr, dataNode)
-		log.LogInfof("action[loadDataNodes],dataNode[%v],dataNodeID[%v],zone[%v],ns[%v]", dataNode.Addr, dataNode.ID, dnv.ZoneName, dnv.NodeSetID)
+		log.LogInfof("action[loadDataNodes],dataNode[%v],dataNodeID[%v],zone[%v],ns[%v],MediaType[%v]",
+			dataNode.Addr, dataNode.ID, dnv.ZoneName, dnv.NodeSetID, dataNode.MediaType)
 	}
 	return
 }

--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -68,7 +68,7 @@ func (mds *MockDataServer) register() {
 	var nodeID uint64
 	var retry int
 	for retry < 3 {
-		nodeID, err = mds.mc.NodeAPI().AddDataNode(mds.TcpAddr, mds.zoneName)
+		nodeID, err = mds.mc.NodeAPI().AddDataNode(mds.TcpAddr, mds.zoneName, proto.MediaType_HDD)
 		if err == nil {
 			break
 		}

--- a/master/topology_test.go
+++ b/master/topology_test.go
@@ -2,6 +2,7 @@ package master
 
 import (
 	"fmt"
+	"github.com/cubefs/cubefs/proto"
 	"testing"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 )
 
 func createDataNodeForTopo(addr, zoneName string, ns *nodeSet) (dn *DataNode) {
-	dn = newDataNode(addr, zoneName, "test")
+	dn = newDataNode(addr, zoneName, "test", proto.MediaType_HDD)
 	dn.ZoneName = zoneName
 	dn.Total = 1024 * util.GB
 	dn.Used = 10 * util.GB

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1065,3 +1065,24 @@ const (
 const (
 	LFClient = 1 // low frequency client
 )
+
+//data node hardware media type
+const (
+	MediaType_Unspecified uint32 = 0
+	MediaType_SSD         uint32 = 1
+	MediaType_HDD         uint32 = 2
+)
+
+var mediaTypeStringMap = map[uint32]string{
+	MediaType_Unspecified: "Unspecified",
+	MediaType_SSD:         "SSD",
+	MediaType_HDD:         "HDD",
+}
+
+func MediaTypeString(mediaType uint32) (value string) {
+	value, ok := mediaTypeStringMap[mediaType]
+	if !ok {
+		value = "InvalidValue"
+	}
+	return
+}

--- a/proto/model.go
+++ b/proto/model.go
@@ -70,6 +70,7 @@ type DataNodeInfo struct {
 	MaxDpCntLimit             uint32             `json:"maxDpCntLimit"`
 	CpuUtil                   float64            `json:"cpuUtil"`
 	IoUtils                   map[string]float64 `json:"ioUtil"`
+	MediaType                 uint32
 }
 
 // MetaPartition defines the structure of a meta partition

--- a/sdk/master/api_node.go
+++ b/sdk/master/api_node.go
@@ -26,10 +26,11 @@ type NodeAPI struct {
 	mc *MasterClient
 }
 
-func (api *NodeAPI) AddDataNode(serverAddr, zoneName string) (id uint64, err error) {
+func (api *NodeAPI) AddDataNode(serverAddr, zoneName string, mediaType uint32) (id uint64, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AddDataNode)
 	request.addParam("addr", serverAddr)
 	request.addParam("zoneName", zoneName)
+	request.addParam("mediaType", strconv.Itoa(int(mediaType)))
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add mediaType(SSD or HDD) property for datanode:
(1) add "mediaType" item in the config file of datanode, and it carries mediaType when it registers to master
(2) add "mediaType" field in master's datanode struct.
(3) the cmd 'cfs-cli datanode info' shows datanode's mediaType 
