### PR TITLE
fix(doc): the value of "profPort" in client's configuration file example should be port instead of IP

### DIFF
--- a/docs-zh/source/user-guide/file.md
+++ b/docs-zh/source/user-guide/file.md
@@ -32,7 +32,7 @@ cfs-client -c client.json
     "rdonly":"false",
     "logDir":"/home/service/var/logs/cfs/log",
     "logLevel":"warn",
-    "profPort":"192.168.1.1"
+    "profPort":"17410"
 }
 ```
 

--- a/docs/source/user-guide/file.md
+++ b/docs/source/user-guide/file.md
@@ -32,7 +32,7 @@ The example configuration file is as follows:
     "rdonly":"false",
     "logDir":"/home/service/var/logs/cfs/log",
     "logLevel":"warn",
-    "profPort":"192.168.1.1"
+    "profPort":"17410"
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(doc): the value of "profPort" in client's configuration file example should be port instead of IP
