### PR TITLE
feat(cli): support unit test for cli

### DIFF
--- a/cli/cmd/acl.go
+++ b/cli/cmd/acl.go
@@ -1,10 +1,25 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
 	"github.com/cubefs/cubefs/util"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -44,11 +59,8 @@ func newAclAddCmd(client *master.MasterClient) *cobra.Command {
 		Use:     CliAclAdd,
 		Short:   cmdAclAddShort,
 		Aliases: []string{"add"},
+		Args:    cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) <= 1 {
-				stdout("example:cfs-cli acl aclAdd volName 192.168.0.1\n")
-				return
-			}
 			var err error
 			defer func() {
 				if err != nil {
@@ -72,11 +84,8 @@ func newAclListCmd(client *master.MasterClient) *cobra.Command {
 		Use:     cliAclListShort,
 		Short:   cmdAclListShort,
 		Aliases: []string{"list"},
+		Args:    cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				stdout("need volume name\n")
-				return
-			}
 			var volumeName = args[0]
 			var err error
 			defer func() {
@@ -105,12 +114,8 @@ func newAclDelCmd(client *master.MasterClient) *cobra.Command {
 		Use:     CliAclDel,
 		Short:   cmdAclDelShort,
 		Aliases: []string{"del"},
+		Args:    cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) <= 1 {
-				stdout("USAGE:./cfs-cli acl aclDel volName ipAddr\n")
-				return
-			}
-
 			var err error
 			defer func() {
 				if err != nil {
@@ -134,12 +139,8 @@ func newAclCheckCmd(client *master.MasterClient) *cobra.Command {
 		Use:     CliAclCheck,
 		Short:   cmdAclCheckShort,
 		Aliases: []string{"check"},
+		Args:    cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) <= 1 {
-				stdout("USAGE:./cfs-cli acl aclCheck volName ipAddr\n")
-				return
-			}
-
 			var err error
 			defer func() {
 				if err != nil {

--- a/cli/cmd/acl_test.go
+++ b/cli/cmd/acl_test.go
@@ -1,0 +1,185 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestAclCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("acl", "help")
+	assert.NoError(t, err)
+}
+
+func TestAclAddCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"testVol", "192.168.0.1"},
+			expectErr: false,
+		},
+		{
+			name:      "missing arguments",
+			args:      []string{"testVol"},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.AclRsp{
+		OK: true,
+		List: []*proto.AclIpInfo{
+			{
+				Ip:    "192.168.0.1",
+				CTime: 1689091200,
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/aclOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("acl", "add")
+	r.runTestCases(t, testCases)
+}
+
+func TestAclListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"testVol"},
+			expectErr: false,
+		},
+	}
+
+	successV1 := &proto.AclRsp{
+		OK: true,
+		List: []*proto.AclIpInfo{
+			{
+				Ip:    "192.168.0.1",
+				CTime: 1689091200,
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/aclOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	runner := newCliTestRunner().setHttpClient(fakeClient).setCommand("acl", "list")
+	runner.runTestCases(t, testCases)
+}
+
+func TestAclDelCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"testVol", "192.168.0.1"},
+			expectErr: false,
+		},
+		{
+			name:      "missing arguments",
+			args:      []string{"testVol"},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.AclRsp{
+		OK: true,
+		List: []*proto.AclIpInfo{
+			{
+				Ip:    "192.168.0.1",
+				CTime: 1689091200,
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/aclOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	runner := newCliTestRunner().setHttpClient(fakeClient).setCommand("acl", "del")
+	runner.runTestCases(t, testCases)
+}
+
+func TestAclCheckCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"testVol", "192.168.0.1"},
+			expectErr: false,
+		},
+		{
+			name:      "missing arguments",
+			args:      []string{"testVol"},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.AclRsp{
+		OK: true,
+		List: []*proto.AclIpInfo{
+			{
+				Ip:    "192.168.0.1",
+				CTime: 1689091200,
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/aclOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+	runner := newCliTestRunner().setHttpClient(fakeClient).setCommand("acl", "check")
+	runner.runTestCases(t, testCases)
+}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -68,19 +69,24 @@ func newClusterInfoCmd(client *master.MasterClient) *cobra.Command {
 			var cn *proto.ClusterNodeInfo
 			var cp *proto.ClusterIP
 			var clusterPara map[string]string
+			defer func() {
+				if err != nil {
+					errout("Error: %v\n", err)
+				}
+			}()
 			if cv, err = client.AdminAPI().GetCluster(); err != nil {
-				errout("Error: %v\n", err)
+				return
 			}
 			if cn, err = client.AdminAPI().GetClusterNodeInfo(); err != nil {
-				errout("Error: %v\n", err)
+				return
 			}
 			if cp, err = client.AdminAPI().GetClusterIP(); err != nil {
-				errout("Error: %v\n", err)
+				return
 			}
 			stdout("[Cluster]\n")
 			stdout(formatClusterView(cv, cn, cp))
 			if clusterPara, err = client.AdminAPI().GetClusterParas(); err != nil {
-				errout("Error: %v\n", err)
+				return
 			}
 
 			stdout(fmt.Sprintf("  BatchCount         : %v\n", clusterPara[nodeDeleteBatchCountKey]))

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1,0 +1,335 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestClusterCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("cluster", "help")
+	assert.NoError(t, err)
+}
+
+func TestClusterInfoCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	clusterV1 := &proto.ClusterView{
+		Name:               "cfs_dev",
+		CreateTime:         "2023-04-29 16:59:54",
+		LeaderAddr:         "172.16.1.101:17010",
+		DisableAutoAlloc:   false,
+		MetaNodeThreshold:  0.75,
+		Applied:            123,
+		MaxDataPartitionID: 20,
+		MaxMetaNodeID:      20,
+		MaxMetaPartitionID: 3,
+		DataNodeStatInfo: &proto.NodeStatInfo{
+			TotalGB:     215,
+			UsedGB:      177,
+			IncreasedGB: 0,
+			UsedRatio:   "0.826",
+		},
+		MetaNodeStatInfo: &proto.NodeStatInfo{
+			TotalGB:     9,
+			UsedGB:      0,
+			IncreasedGB: 0,
+			UsedRatio:   "0.037",
+		},
+		VolStatInfo: []*proto.VolStatInfo{
+			{
+				Name:                  "vol1",
+				TotalSize:             107374182400,
+				UsedSize:              0,
+				UsedRatio:             "0.000",
+				CacheTotalSize:        0,
+				CacheUsedSize:         0,
+				CacheUsedRatio:        "0.00",
+				EnableToken:           false,
+				InodeCount:            1,
+				DpReadOnlyWhenVolFull: false,
+			},
+		},
+		BadPartitionIDs:     []proto.BadPartitionView{},
+		BadMetaPartitionIDs: []proto.BadPartitionView{},
+		MasterNodes: []proto.NodeView{
+			{
+				Addr:       "172.16.1.101:17010",
+				Status:     true,
+				DomainAddr: "",
+				ID:         1,
+				IsWritable: false,
+			},
+			{
+				Addr:       "172.16.1.102:17010",
+				Status:     true,
+				DomainAddr: "",
+				ID:         2,
+				IsWritable: false,
+			},
+			{
+				Addr:       "172.16.1.103:17010",
+				Status:     true,
+				DomainAddr: "",
+				ID:         3,
+				IsWritable: false,
+			},
+		},
+		MetaNodes: []proto.NodeView{
+			{
+				Addr:       "172.16.1.101:17210",
+				Status:     false,
+				DomainAddr: "",
+				ID:         2,
+				IsWritable: true,
+			},
+			{
+				Addr:       "172.16.1.102:17210",
+				Status:     false,
+				DomainAddr: "",
+				ID:         3,
+				IsWritable: true,
+			},
+			{
+				Addr:       "172.16.1.103:17210",
+				Status:     false,
+				DomainAddr: "",
+				ID:         4,
+				IsWritable: true,
+			},
+		},
+		DataNodes: []proto.NodeView{
+			{
+				Addr:       "172.16.1.101:17310",
+				Status:     false,
+				DomainAddr: "",
+				ID:         2,
+				IsWritable: false,
+			},
+			{
+				Addr:       "172.16.1.102:17310",
+				Status:     false,
+				DomainAddr: "",
+				ID:         3,
+				IsWritable: false,
+			},
+			{
+				Addr:       "172.16.1.103:17310",
+				Status:     false,
+				DomainAddr: "",
+				ID:         4,
+				IsWritable: false,
+			},
+		},
+	}
+
+	nodeV1 := &proto.ClusterNodeInfo{}
+
+	ipV1 := &proto.ClusterIP{}
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getCluster":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(clusterV1)}, nil
+
+		case m == http.MethodGet && p == "/admin/getNodeInfo":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nodeV1)}, nil
+
+		case m == http.MethodGet && p == "/admin/getIp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(ipV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("cluster", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestClusterStatCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := &proto.ClusterStatInfo{
+		DataNodeStatInfo: &proto.NodeStatInfo{},
+		MetaNodeStatInfo: &proto.NodeStatInfo{},
+		ZoneStatInfo:     map[string]*proto.ZoneStat{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/cluster/stat":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("cluster", "stat")
+	r.runTestCases(t, testCases)
+}
+
+func TestClusterFreezeCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments enable",
+			args:      []string{"true"},
+			expectErr: false,
+		},
+		{
+			name:      "Valid arguments disable",
+			args:      []string{"false"},
+			expectErr: false,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"invalid"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/cluster/freeze":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("cluster", "freeze")
+	r.runTestCases(t, testCases)
+}
+
+func TestClusterSetThresholdCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"0.5"},
+			expectErr: false,
+		},
+		{
+			name:      "missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"invalid"},
+			expectErr: true,
+		},
+		{
+			name:      "too big threshold",
+			args:      []string{"1.1"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/threshold/set":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("cluster", "threshold")
+	r.runTestCases(t, testCases)
+}
+
+func TestClusterSetParasCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/setNodeInfo":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("cluster", "set")
+	r.runTestCases(t, testCases)
+}
+
+func TestClusterDisableMpDecommissionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"true"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{"forbid-mp-decommission"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/cluster/forbidMetaPartitionDecommission":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("cluster", "forbid-mp-decommission")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -87,12 +87,12 @@ func newConfigSetCmd() *cobra.Command {
 			}
 			timeOut := uint16(tmp)
 			if optMasterHosts == "" {
-				stdout(fmt.Sprintf("Please set addr. Input 'cfs-cli config set -h' for help.\n"))
+				err = fmt.Errorf("please set addr. Input 'cfs-cli config set -h' for help")
 				return
 			}
 
 			if timeOut == 0 {
-				stdout(fmt.Sprintf("timeOut %v is invalid.\n", timeOut))
+				err = fmt.Errorf("timeOut %v is invalid", timeOut)
 				return
 			}
 
@@ -116,8 +116,7 @@ func newConfigInfoCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			config, err := LoadConfig()
 			if err != nil {
-				_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				OsExitWithLogFlush()
+				errout("Error: %v\n", err)
 			}
 			printConfigInfo(config)
 		},

--- a/cli/cmd/config_test.go
+++ b/cli/cmd/config_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestConfigCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("config", "help")
+	assert.NoError(t, err)
+}
+
+func TestConfigSetCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"--addr", "172.16.1.101:17010"},
+			expectErr: false,
+		},
+		{
+			name:      "missing addr",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "zero timeout",
+			args:      []string{"--addr", "172.16.1.101:17010", "--timeout", "0"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/aclOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("config", "set")
+	r.runTestCases(t, testCases)
+}
+
+func TestConfigInfoCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("config", "info")
+	assert.NoError(t, err)
+}

--- a/cli/cmd/datanode.go
+++ b/cli/cmd/datanode.go
@@ -15,12 +15,14 @@
 package cmd
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -138,7 +140,7 @@ func newDataNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 			}()
 			nodeAddr = args[0]
 			if optCount < 0 {
-				stdout("Migrate dp count should >= 0\n")
+				err = fmt.Errorf("Migrate dp count should >= 0\n")
 				return
 			}
 			if err = client.NodeAPI().DataNodeDecommission(nodeAddr, optCount); err != nil {
@@ -175,7 +177,7 @@ func newDataNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 			src = args[0]
 			dst = args[1]
 			if optCount > dpMigrateMax || optCount <= 0 {
-				stdout("Migrate dp count should between [1-50]\n")
+				err = fmt.Errorf("Migrate dp count should between [1-50]\n")
 				return
 			}
 

--- a/cli/cmd/datanode_test.go
+++ b/cli/cmd/datanode_test.go
@@ -1,0 +1,200 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestDataNodeCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("datanode", "help")
+	assert.NoError(t, err)
+}
+
+func TestDataNodeListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"datanode", "list"},
+			expectErr: false,
+		},
+	}
+
+	successV1 := &proto.ClusterView{
+		DataNodes: []proto.NodeView{
+			{
+				Addr:       "172.16.1.101:17310",
+				Status:     false,
+				DomainAddr: "",
+				ID:         2,
+				IsWritable: false,
+			},
+			{
+				Addr:       "172.16.1.102:17310",
+				Status:     false,
+				DomainAddr: "",
+				ID:         3,
+				IsWritable: false,
+			},
+			{
+				Addr:       "172.16.1.103:17310",
+				Status:     false,
+				DomainAddr: "",
+				ID:         4,
+				IsWritable: false,
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getCluster":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient)
+	r.runTestCases(t, testCases)
+}
+
+func TestDataNodeInfoCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.110:17310"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.DataNodeInfo{
+		ReportTime:                time.Time{},
+		DataPartitionReports:      []*proto.PartitionReport{},
+		PersistenceDataPartitions: []uint64{},
+		BadDisks:                  []string{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataNode/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datanode", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestDataNodeDecommissionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.110:17310", "--count", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing node address",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid migrate dp count",
+			args:      []string{"172.16.1.110:17310", "--count", "-1"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataNode/decommission":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datanode", "decommission")
+	r.runTestCases(t, testCases)
+}
+
+func TestDataNodeMigrateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.110:17310", "172.16.1.110:17310"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 node address",
+			args:      []string{"172.16.1.110:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 node address",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "invalid migrate dp count",
+			args:      []string{"172.16.1.101:17310", "172.16.1.102:17310", "--count", "-1"},
+			expectErr: true,
+		},
+		{
+			name:      "too much migrate dp count",
+			args:      []string{"172.16.1.101:17310", "172.16.1.102:17310", "--count", "500"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataNode/migrate":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datanode", "migrate")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/datapartition_test.go
+++ b/cli/cmd/datapartition_test.go
@@ -1,0 +1,304 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestDataPartitionCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("datapartition", "help")
+	assert.NoError(t, err)
+}
+
+func TestDataPartitionGetCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"t"},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.DataPartitionInfo{
+		Replicas:                []*proto.DataReplica{},
+		Hosts:                   []string{},
+		Peers:                   []proto.Peer{},
+		Zones:                   []string{},
+		MissingNodes:            map[string]int64{},
+		FileInCoreMap:           map[string]*proto.FileInCore{},
+		FilesWithMissingReplica: map[string]int64{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataPartition/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datapartition", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestListCorruptDataPartitionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	diagnosisV1 := &proto.DataPartitionDiagnosis{
+		InactiveDataNodes:           []string{"172.16.1.101:17310", "172.16.1.102:17310"},
+		CorruptDataPartitionIDs:     []uint64{1, 2},
+		LackReplicaDataPartitionIDs: []uint64{1, 2},
+		BadDataPartitionIDs: []proto.BadPartitionView{
+			{
+				Path:         "/test1",
+				PartitionIDs: []uint64{1, 2},
+			},
+			{
+				Path:         "/test2",
+				PartitionIDs: []uint64{3, 4},
+			},
+		},
+		BadReplicaDataPartitionIDs: []uint64{1, 2},
+		RepFileCountDifferDpIDs:    []uint64{1, 2},
+		RepUsedSizeDifferDpIDs:     []uint64{1, 2},
+		ExcessReplicaDpIDs:         []uint64{1, 2},
+	}
+
+	dataNodeV1 := &proto.DataNodeInfo{
+		ReportTime:                time.Time{},
+		DataPartitionReports:      []*proto.PartitionReport{},
+		PersistenceDataPartitions: []uint64{},
+		BadDisks:                  []string{},
+	}
+
+	dataPartitionV1 := &proto.DataPartitionInfo{
+		Replicas:                []*proto.DataReplica{},
+		Hosts:                   []string{},
+		Peers:                   []proto.Peer{},
+		Zones:                   []string{},
+		MissingNodes:            map[string]int64{},
+		FileInCoreMap:           map[string]*proto.FileInCore{},
+		FilesWithMissingReplica: map[string]int64{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataPartition/diagnose":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(diagnosisV1)}, nil
+
+		case m == http.MethodGet && p == "/dataNode/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(dataNodeV1)}, nil
+
+		case m == http.MethodGet && p == "/dataPartition/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(dataPartitionV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datapartition", "check")
+	r.runTestCases(t, testCases)
+}
+
+func TestDataPartitionDecommissionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17310", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"172.16.1.101:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"172.16.1.101:17310", "t"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataPartition/decommission":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datapartition", "decommission")
+	r.runTestCases(t, testCases)
+}
+
+func TestDataPartitionReplicateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17310", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"172.16.1.101:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"172.16.1.101:17310", "t"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataReplica/add":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datapartition", "add-replica")
+	r.runTestCases(t, testCases)
+}
+
+func TestDataPartitionDeleteReplicaCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17310", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"172.16.1.101:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"172.16.1.101:17310", "t"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/dataReplica/delete":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datapartition", "del-replica")
+	r.runTestCases(t, testCases)
+}
+
+func TestDataPartitionGetDiscardCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := &proto.DiscardDataPartitionInfos{
+		DiscardDps: []proto.DataPartitionInfo{
+			{
+				PartitionID:             1,
+				Replicas:                []*proto.DataReplica{},
+				Hosts:                   []string{},
+				Peers:                   []proto.Peer{},
+				Zones:                   []string{},
+				MissingNodes:            map[string]int64{},
+				FileInCoreMap:           map[string]*proto.FileInCore{},
+				FilesWithMissingReplica: map[string]int64{},
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getDiscardDp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("datapartition", "get-discard")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/disk.go
+++ b/cli/cmd/disk.go
@@ -1,10 +1,26 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package cmd
 
 import (
+	"sort"
+
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
-	"github.com/spf13/cobra"
-	"sort"
 )
 
 const (

--- a/cli/cmd/disk_test.go
+++ b/cli/cmd/disk_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestDiskCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("disk", "help")
+	assert.NoError(t, err)
+}
+
+func TestListBadDiskCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := &proto.BadDiskInfos{
+		BadDisks: []proto.BadDiskInfo{
+			{
+				Address: "172.16.1.101:17310",
+				Path:    "/test1",
+			},
+			{
+				Address: "172.16.1.102:17310",
+				Path:    "/test2",
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/disk/queryBadDisks":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("disk", "check")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/http_service.go
+++ b/cli/cmd/http_service.go
@@ -1,8 +1,23 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package cmd
 
 import (
 	"errors"
 	"fmt"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
 	"github.com/cubefs/cubefs/util"

--- a/cli/cmd/metanode.go
+++ b/cli/cmd/metanode.go
@@ -15,12 +15,14 @@
 package cmd
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -138,7 +140,7 @@ func newMetaNodeDecommissionCmd(client *master.MasterClient) *cobra.Command {
 			}()
 			nodeAddr = args[0]
 			if optCount < 0 {
-				stdout("Migrate mp count should >= 0\n")
+				err = fmt.Errorf("Migrate mp count should >= 0\n")
 				return
 			}
 			if err = client.NodeAPI().MetaNodeDecommission(nodeAddr, optCount); err != nil {
@@ -174,7 +176,7 @@ func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 			src = args[0]
 			dst = args[1]
 			if optCount > mpMigrateMax || optCount <= 0 {
-				stdout("Migrate mp count should between [1-15]\n")
+				err = fmt.Errorf("Migrate mp count should between [1-15]\n")
 				return
 			}
 			if err = client.NodeAPI().MetaNodeMigrate(src, dst, optCount); err != nil {

--- a/cli/cmd/metanode_test.go
+++ b/cli/cmd/metanode_test.go
@@ -1,0 +1,197 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestMetaNodeCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("metanode", "help")
+	assert.NoError(t, err)
+}
+
+func TestMetaNodeListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"metanode", "list"},
+			expectErr: false,
+		},
+	}
+
+	successV1 := &proto.ClusterView{
+		MetaNodes: []proto.NodeView{
+			{
+				Addr:       "172.16.1.101:17210",
+				Status:     false,
+				DomainAddr: "",
+				ID:         2,
+				IsWritable: true,
+			},
+			{
+				Addr:       "172.16.1.102:17210",
+				Status:     false,
+				DomainAddr: "",
+				ID:         3,
+				IsWritable: true,
+			},
+			{
+				Addr:       "172.16.1.103:17210",
+				Status:     false,
+				DomainAddr: "",
+				ID:         4,
+				IsWritable: true,
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getCluster":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient)
+	r.runTestCases(t, testCases)
+}
+
+func TestMetaNodeInfoCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.110:17320"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.MetaNodeInfo{
+		ReportTime: time.Time{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaNode/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metanode", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestMetaNodeDecommissionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.110:17320", "--count", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing node address",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid migrate dp count",
+			args:      []string{"172.16.1.110:17320", "--count", "-1"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaNode/decommission":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metanode", "decommission")
+	r.runTestCases(t, testCases)
+}
+
+func TestMetaNodeMigrateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17210", "172.16.1.101:17210"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 node address",
+			args:      []string{"172.16.1.101:17320"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 node address",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "invalid migrate dp count",
+			args:      []string{"172.16.1.101:17210", "172.16.1.101:17210", "--count", "-1"},
+			expectErr: true,
+		},
+		{
+			name:      "too much migrate dp count",
+			args:      []string{"172.16.1.101:17210", "172.16.1.101:17210", "--count", "500"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaNode/migrate":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metanode", "migrate")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/metapartition.go
+++ b/cli/cmd/metapartition.go
@@ -16,11 +16,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cubefs/cubefs/proto"
-	"github.com/cubefs/cubefs/sdk/master"
-	"github.com/spf13/cobra"
 	"sort"
 	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/sdk/master"
 )
 
 const (
@@ -273,6 +275,9 @@ func newMetaPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 			}()
 			address := args[0]
 			partitionID, err = strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				return
+			}
 			if err = client.AdminAPI().DecommissionMetaPartition(partitionID, address); err != nil {
 				return
 			}
@@ -305,6 +310,9 @@ func newMetaPartitionReplicateCmd(client *master.MasterClient) *cobra.Command {
 			}()
 			address := args[0]
 			partitionID, err = strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				return
+			}
 			if err = client.AdminAPI().AddMetaReplica(partitionID, address); err != nil {
 				return
 			}

--- a/cli/cmd/metapartition_test.go
+++ b/cli/cmd/metapartition_test.go
@@ -1,0 +1,331 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestMetaPartitionCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("metapartition", "help")
+	assert.NoError(t, err)
+}
+
+func TestMetaPartitionGetCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"t"},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.MetaPartitionInfo{
+		Replicas: []*proto.MetaReplicaInfo{
+			{
+				Addr:       "172.16.1.101:17210",
+				DomainAddr: "172.16.1.101:17210",
+				IsLeader:   false,
+			},
+			{
+				Addr:       "172.16.1.102:17210",
+				DomainAddr: "172.16.1.102:17210",
+				IsLeader:   true,
+			},
+			{
+				Addr:       "172.16.1.103:17210",
+				DomainAddr: "172.16.1.103:17210",
+				IsLeader:   false,
+			},
+		},
+		ReplicaNum: 0,
+		Status:     0,
+		IsRecover:  false,
+		Hosts:      []string{"172.16.1.101:17210", "172.16.1.102:17210", "172.16.1.103:17210"},
+		Peers: []proto.Peer{
+			{
+				ID:   1,
+				Addr: "172.16.1.101:17210",
+			},
+			{
+				ID:   2,
+				Addr: "172.16.1.102:17210",
+			},
+			{
+				ID:   3,
+				Addr: "172.16.1.103:17210",
+			},
+		},
+		Zones:         []string{"default", "default", "default"},
+		OfflinePeerID: 0,
+		MissNodes: map[string]int64{
+			"172.16.1.103:17210": 1690280680,
+		},
+		LoadResponse: []*proto.MetaPartitionLoadResponse{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaPartition/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metapartition", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestListCorruptMetaPartitionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	diagnoseV1 := &proto.MetaPartitionDiagnosis{
+		InactiveMetaNodes:           []string{"172.16.1.101:17310", "172.16.1.102:17310"},
+		CorruptMetaPartitionIDs:     []uint64{1, 2},
+		LackReplicaMetaPartitionIDs: []uint64{1, 2},
+		BadMetaPartitionIDs: []proto.BadPartitionView{
+			{
+				Path:         "/test1",
+				PartitionIDs: []uint64{1, 2},
+			},
+			{
+				Path:         "/test2",
+				PartitionIDs: []uint64{3, 4},
+			},
+		},
+		BadReplicaMetaPartitionIDs:                 []uint64{1, 2},
+		ExcessReplicaMetaPartitionIDs:              []uint64{1, 2},
+		InodeCountNotEqualReplicaMetaPartitionIDs:  []uint64{1, 2},
+		MaxInodeNotEqualReplicaMetaPartitionIDs:    []uint64{1, 2},
+		DentryCountNotEqualReplicaMetaPartitionIDs: []uint64{1, 2},
+	}
+
+	metanodeV1 := &proto.MetaNodeInfo{
+		ReportTime: time.Time{},
+	}
+
+	metaPartitionV1 := &proto.MetaPartitionInfo{
+		Replicas: []*proto.MetaReplicaInfo{
+			{
+				Addr:       "172.16.1.101:17210",
+				DomainAddr: "172.16.1.101:17210",
+				IsLeader:   false,
+			},
+			{
+				Addr:       "172.16.1.102:17210",
+				DomainAddr: "172.16.1.102:17210",
+				IsLeader:   true,
+			},
+			{
+				Addr:       "172.16.1.103:17210",
+				DomainAddr: "172.16.1.103:17210",
+				IsLeader:   false,
+			},
+		},
+		ReplicaNum: 0,
+		Status:     0,
+		IsRecover:  false,
+		Hosts:      []string{"172.16.1.101:17210", "172.16.1.102:17210", "172.16.1.103:17210"},
+		Peers: []proto.Peer{
+			{
+				ID:   1,
+				Addr: "172.16.1.101:17210",
+			},
+			{
+				ID:   2,
+				Addr: "172.16.1.102:17210",
+			},
+			{
+				ID:   3,
+				Addr: "172.16.1.103:17210",
+			},
+		},
+		Zones:         []string{"default", "default", "default"},
+		OfflinePeerID: 0,
+		MissNodes: map[string]int64{
+			"172.16.1.103:17210": 1690280680,
+		},
+		LoadResponse: []*proto.MetaPartitionLoadResponse{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaPartition/diagnose":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(diagnoseV1)}, nil
+
+		case m == http.MethodGet && p == "/metaNode/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(metanodeV1)}, nil
+
+		case m == http.MethodGet && p == "/metaPartition/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(metaPartitionV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metapartition", "check")
+	r.runTestCases(t, testCases)
+}
+
+func TestMetaPartitionDecommissionCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17310", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"172.16.1.101:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"172.16.1.101:17310", "t"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaPartition/decommission":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metapartition", "decommission")
+	r.runTestCases(t, testCases)
+}
+
+func TestMetaPartitionReplicateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17310", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"172.16.1.101:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"172.16.1.101:17310", "t"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaReplica/add":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metapartition", "add-replica")
+	r.runTestCases(t, testCases)
+}
+
+func TestMetaPartitionDeleteReplicaCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"172.16.1.101:17310", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"172.16.1.101:17310"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid arguments",
+			args:      []string{"172.16.1.101:17310", "t"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/metaReplica/delete":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("metapartition", "del-replica")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/quota_test.go
+++ b/cli/cmd/quota_test.go
@@ -1,0 +1,220 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestQuotaCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("quota", "help")
+	assert.NoError(t, err)
+}
+
+func TestQuotaListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := []*proto.QuotaInfo{
+		{
+			VolName: "vol1",
+			QuotaId: 1,
+			CTime:   0,
+			PathInfos: []proto.QuotaPathInfo{
+				{
+					FullPath:    "/path1",
+					RootInode:   0,
+					PartitionId: 0,
+				},
+			},
+			LimitedInfo: proto.QuotaLimitedInfo{},
+			UsedInfo:    proto.QuotaUsedInfo{},
+			MaxFiles:    18446744073709551615,
+			MaxBytes:    18446744073709551615,
+			Rsv:         "",
+		},
+		{
+			VolName: "vol1",
+			QuotaId: 2,
+			CTime:   0,
+			PathInfos: []proto.QuotaPathInfo{
+				{
+					FullPath:    "/path2",
+					RootInode:   0,
+					PartitionId: 0,
+				},
+			},
+			LimitedInfo: proto.QuotaLimitedInfo{},
+			UsedInfo:    proto.QuotaUsedInfo{},
+			MaxFiles:    18446744073709551615,
+			MaxBytes:    18446744073709551615,
+			Rsv:         "",
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/quota/list":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("quota", "list")
+	r.runTestCases(t, testCases)
+}
+
+func TestQuotaListAllCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := []*proto.VolInfo{
+		{
+			Name:                  "vol1",
+			Owner:                 "cfs",
+			CreateTime:            0,
+			Status:                0,
+			TotalSize:             0,
+			UsedSize:              0,
+			DpReadOnlyWhenVolFull: false,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/quota/listAll":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("quota", "listAll")
+	r.runTestCases(t, testCases)
+}
+
+func TestQuotaUpdateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.QuotaInfo{
+		VolName:     "vol1",
+		QuotaId:     1,
+		CTime:       0,
+		PathInfos:   nil,
+		LimitedInfo: proto.QuotaLimitedInfo{},
+		UsedInfo:    proto.QuotaUsedInfo{},
+		MaxFiles:    18446744073709551615,
+		MaxBytes:    18446744073709551615,
+		Rsv:         "",
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/quota/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		case m == http.MethodGet && p == "/quota/update":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("quota", "update")
+	r.runTestCases(t, testCases)
+}
+
+func TestQuotaDeleteCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/aclOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("quota", "delete")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -19,10 +19,11 @@ import (
 	"os"
 	"path"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
 	"github.com/cubefs/cubefs/util/log"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -86,13 +86,15 @@ func stdout(format string, a ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stdout, format, a...)
 }
 
+var erroutHandler = OsExitWithLogFlush
+
 func errout(format string, a ...interface{}) {
 	log.LogErrorf(format, a...)
 	_, _ = fmt.Fprintf(os.Stderr, format, a...)
-	OsExitWithLogFlush()
+	erroutHandler(format, a)
 }
 
-func OsExitWithLogFlush() {
+func OsExitWithLogFlush(_ string, _ ...interface{}) {
 	log.LogFlush()
 	os.Exit(1)
 }

--- a/cli/cmd/uid.go
+++ b/cli/cmd/uid.go
@@ -1,10 +1,25 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
 	"github.com/cubefs/cubefs/util"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -47,11 +62,8 @@ func newUidAddCmd(client *master.MasterClient) *cobra.Command {
 		Use:     CliUidAdd,
 		Short:   cmdUidAddShort,
 		Aliases: []string{"add"},
+		Args:    cobra.MinimumNArgs(3),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) < 3 {
-				stdout("example:cfs-cli uid add volName uid size\n")
-				return
-			}
 			var err error
 			defer func() {
 				if err != nil {
@@ -78,11 +90,8 @@ func newUidListCmd(client *master.MasterClient) *cobra.Command {
 		Use:     cliUidListShort,
 		Short:   cmdUidListShort,
 		Aliases: []string{"list"},
+		Args:    cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				stdout("need volume name\n")
-				return
-			}
 			if len(args) == 2 {
 				if args[1] == uidAll {
 					uidListAll = true
@@ -119,12 +128,8 @@ func newUidDelCmd(client *master.MasterClient) *cobra.Command {
 		Use:     CliUidDel,
 		Short:   cmdUidDelShort,
 		Aliases: []string{"del"},
+		Args:    cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) <= 1 {
-				stdout("USAGE:./cfs-cli uid uidDel volName\n")
-				return
-			}
-
 			var err error
 			defer func() {
 				if err != nil {
@@ -148,12 +153,8 @@ func newUidCheckCmd(client *master.MasterClient) *cobra.Command {
 		Use:     CliUidCheck,
 		Short:   cmdUidCheckShort,
 		Aliases: []string{"check"},
+		Args:    cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) <= 1 {
-				stdout("USAGE:./cfs-cli uid uidCheck volName\n")
-				return
-			}
-
 			var err error
 			defer func() {
 				if err != nil {

--- a/cli/cmd/uid_test.go
+++ b/cli/cmd/uid_test.go
@@ -1,0 +1,172 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestUidCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("uid", "help")
+	assert.NoError(t, err)
+}
+
+func TestUidAddCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"testVol", "1", "20"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/uidOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("uid", "add")
+	r.runTestCases(t, testCases)
+}
+
+func TestUidListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"testVol"},
+			expectErr: false,
+		},
+		{
+			name:      "List all volumes",
+			args:      []string{"testVol", "all"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.UidSpaceRsp{
+		Info: "",
+		OK:   true,
+		UidSpaceArr: []*proto.UidSpaceInfo{
+			{
+				VolName: "vol1",
+				Uid:     1,
+			},
+			{
+				VolName: "vol2",
+				Uid:     1,
+			},
+		},
+		Reserve: "",
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/uidOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("uid", "list")
+	r.runTestCases(t, testCases)
+}
+
+func TestUidDelCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"uid", "del", "testVol", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{"uid", "del"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/uidOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient)
+	r.runTestCases(t, testCases)
+}
+
+func TestUidCheckCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"uid", "check", "testVol", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{"uid", "check"},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/uidOp":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient)
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/user_test.go
+++ b/cli/cmd/user_test.go
@@ -1,0 +1,280 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestUserCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("user", "help")
+	assert.NoError(t, err)
+}
+
+func TestUserCreateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"user1", "--password", "123456", "--access-key", "key1", "--secret-key", "key2", "--user-type", "admin"},
+			expectErr: false,
+		},
+		{
+			name:      "Valid arguments in default",
+			args:      []string{"user1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodPost && p == "/user/create":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("user", "create")
+	r.runTestCases(t, testCases)
+}
+
+func TestUserUpdateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"user1", "--access-key", "key1", "--secret-key", "key2", "--user-type", "admin"},
+			expectErr: false,
+		},
+		{
+			name:      "No update",
+			args:      []string{"user1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodPost && p == "/user/update":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("user", "update")
+	r.runTestCases(t, testCases)
+}
+
+func TestUserDeleteCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"user1", "-y"},
+			expectErr: false,
+		},
+		{
+			name:      "Delete without confirmation",
+			args:      []string{"user1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodPost && p == "/user/delete":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("user", "delete")
+	r.runTestCases(t, testCases)
+}
+
+func TestUserInfoCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"user1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.UserInfo{
+		UserID:    "user1",
+		AccessKey: "key1",
+		SecretKey: "key2",
+		Policy: &proto.UserPolicy{
+			OwnVols:        []string{"vol1", "vol2"},
+			AuthorizedVols: map[string][]string{"vol1": {"vol1"}},
+		},
+		Mu: sync.RWMutex{},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/user/info":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("user", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestUserPermCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"user1", "vol1", "rw"},
+			expectErr: false,
+		},
+		{
+			name:      "Valid arguments in remove permission",
+			args:      []string{"user1", "vol1", "none"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"user1", "vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 3 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid permission",
+			args:      []string{"user1", "vol1", "invalid"},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.UserInfo{
+		UserID:    "user1",
+		AccessKey: "key1",
+		SecretKey: "key2",
+		Policy: &proto.UserPolicy{
+			OwnVols:        []string{"vol1", "vol2"},
+			AuthorizedVols: map[string][]string{"vol1": {"vol1"}},
+		},
+		UserType:    0,
+		CreateTime:  "",
+		Description: "",
+		Mu:          sync.RWMutex{},
+		EMPTY:       false,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/user/info":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		case m == http.MethodPost && p == "/user/updatePolicy":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		case m == http.MethodPost && p == "/user/removePolicy":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("user", "perm")
+	r.runTestCases(t, testCases)
+}
+
+func TestUserListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := []*proto.UserInfo{
+		{
+			UserID: "user1",
+			Policy: &proto.UserPolicy{
+				OwnVols:        []string{"vol1", "vol2"},
+				AuthorizedVols: map[string][]string{"vol1": {"vol1"}},
+			},
+			Mu: sync.RWMutex{},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/user/list":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("user", "list")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/vol_test.go
+++ b/cli/cmd/vol_test.go
@@ -1,0 +1,625 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestVolCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("volume", "help")
+	assert.NoError(t, err)
+}
+
+func TestVolListCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := []*proto.VolInfo{
+		{
+			Name:  "vol1",
+			Owner: "cfs",
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/vol/list":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "list")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolCreateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "user1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/createVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "create")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolUpdateCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1"},
+			expectErr: false,
+		},
+		{
+			name: "Valid arguments with more options",
+			args: []string{"vol1",
+				"--description", "test",
+				"--zone-name", "zone1",
+				"--capacity", "10",
+				"--replica-num", "3",
+				"--follower-read", "true",
+				"--ebs-blk-size", "8388608",
+				"--transaction-mask", "create|mkdir|remove|rename|mknod|symlink|link",
+				"--transaction-timeout", "5",
+				"--tx-conflict-retry-num", "2",
+				"--tx-conflict-retry-Interval", "5",
+				"--cache-capacity", "10",
+				"--cache-action", "0",
+				"--cache-high-water", "80",
+				"--cache-low-water", "60",
+				"--cache-lru-interval", "5",
+				"--cache-rule", "rule",
+				"--cache-threshold", "10485760",
+				"--cache-ttl", "30",
+				"--readonly-when-full", "true",
+			},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	volumeV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(volumeV1)}, nil
+
+		case m == http.MethodGet && p == "/vol/update":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "update")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolInfoCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1"},
+			expectErr: false,
+		},
+		{
+			name:      "Valid arguments with more options",
+			args:      []string{"vol1", "--meta-partition", "--data-partition"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	volumeV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	metaPartitionV1 := []*proto.MetaPartitionView{
+		{
+			PartitionID: 1,
+			Members:     []string{},
+		},
+	}
+
+	dataPartitionV1 := &proto.DataPartitionsView{
+		DataPartitions: []*proto.DataPartitionResponse{
+			{
+				PartitionID: 1,
+				Hosts:       []string{},
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(volumeV1)}, nil
+
+		case m == http.MethodGet && p == "/client/metaPartitions":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(metaPartitionV1)}, nil
+
+		case m == http.MethodGet && p == "/client/partitions":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(dataPartitionV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "info")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolDeleteCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "-y"},
+			expectErr: false,
+		},
+		{
+			name:      "Delete without confirmation",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		case m == http.MethodGet && p == "/vol/delete":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "delete")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolTransferCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "user1", "-y"},
+			expectErr: false,
+		},
+		{
+			name:      "Transfer without confirmation",
+			args:      []string{"vol1", "user1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	volumeV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	userV1 := &proto.UserInfo{
+		UserID:    "user1",
+		AccessKey: "key1",
+		SecretKey: "key2",
+		Policy: &proto.UserPolicy{
+			OwnVols:        []string{"vol1", "vol2"},
+			AuthorizedVols: map[string][]string{"vol1": {"vol1"}},
+		},
+		UserType:    0,
+		CreateTime:  "",
+		Description: "",
+		Mu:          sync.RWMutex{},
+		EMPTY:       false,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(volumeV1)}, nil
+
+		case m == http.MethodGet && p == "/user/info":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(userV1)}, nil
+
+		case m == http.MethodPost && p == "/user/transferVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "transfer")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolAddDPCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "count too small",
+			args:      []string{"vol1", "0"},
+			expectErr: true,
+		},
+		{
+			name:      "invalid count",
+			args:      []string{"vol1", "t"},
+			expectErr: true,
+		},
+	}
+
+	volumeV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(volumeV1)}, nil
+
+		case m == http.MethodGet && p == "/dataPartition/create":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "add-dp")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolExpandCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "400"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid capacity",
+			args:      []string{"vol1", "t"},
+			expectErr: true,
+		},
+		{
+			name:      "Capacity smaller than before",
+			args:      []string{"vol1", "1"},
+			expectErr: true,
+		},
+	}
+
+	volumeV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(volumeV1)}, nil
+
+		case m == http.MethodGet && p == "/vol/expand":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "expand")
+	r.runTestCases(t, testCases)
+}
+
+func TestVolShrinkCmd(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"vol1", "1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing 1 arguments",
+			args:      []string{"vol1"},
+			expectErr: true,
+		},
+		{
+			name:      "Missing 2 arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+		{
+			name:      "Invalid capacity",
+			args:      []string{"vol1", "t"},
+			expectErr: true,
+		},
+		{
+			name:      "Capacity bigger than before",
+			args:      []string{"vol1", "400"},
+			expectErr: true,
+		},
+	}
+
+	volumeV1 := &proto.SimpleVolView{
+		ID:                      1,
+		Name:                    "vol1",
+		Owner:                   "user1",
+		ZoneName:                "zone1",
+		DpReplicaNum:            3,
+		MpReplicaNum:            3,
+		InodeCount:              1,
+		DentryCount:             0,
+		MaxMetaPartitionID:      3,
+		Status:                  0,
+		Capacity:                100,
+		RwDpCnt:                 6,
+		MpCnt:                   3,
+		DpCnt:                   20,
+		CreateTime:              "2023-04-29 17:27:17",
+		EnableTransaction:       "create|mkdir",
+		TxTimeout:               1,
+		TxConflictRetryNum:      10,
+		TxConflictRetryInterval: 20,
+		VolType:                 1,
+		Uids:                    nil,
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/admin/getVol":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(volumeV1)}, nil
+
+		case m == http.MethodGet && p == "/vol/shrink":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(nil)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("volume", "shrink")
+	r.runTestCases(t, testCases)
+}

--- a/cli/cmd/zone_test.go
+++ b/cli/cmd/zone_test.go
@@ -1,0 +1,150 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/fake"
+)
+
+func TestZoneCmd(t *testing.T) {
+	r := newCliTestRunner()
+	err := r.testRun("zone", "help")
+	assert.NoError(t, err)
+}
+
+func TestZoneList(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{},
+			expectErr: false,
+		},
+	}
+
+	successV1 := []*proto.ZoneView{
+		{
+			Name:   "zone1",
+			Status: "available",
+			NodeSet: map[uint64]*proto.NodeSetView{
+				1: {
+					DataNodeLen: 3,
+					MetaNodeLen: 3,
+					MetaNodes: []proto.NodeView{
+						{
+							Addr:       "172.16.1.101:17210",
+							Status:     false,
+							DomainAddr: "172.16.1.101:17010",
+							ID:         1,
+							IsWritable: false,
+						},
+					},
+					DataNodes: []proto.NodeView{
+						{
+							Addr:       "172.16.1.101:17310",
+							Status:     false,
+							DomainAddr: "172.16.1.101:17010",
+							ID:         1,
+							IsWritable: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/zone/list":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("zone", "list")
+	r.runTestCases(t, testCases)
+}
+
+func TestZoneInfo(t *testing.T) {
+	testCases := []*TestCase{
+		{
+			name:      "Valid arguments",
+			args:      []string{"zone1"},
+			expectErr: false,
+		},
+		{
+			name:      "Missing arguments",
+			args:      []string{},
+			expectErr: true,
+		},
+	}
+
+	successV1 := &proto.TopologyView{
+		Zones: []*proto.ZoneView{
+			{
+				Name:   "zone1",
+				Status: "available",
+				NodeSet: map[uint64]*proto.NodeSetView{
+					1: {
+						DataNodeLen: 3,
+						MetaNodeLen: 3,
+						MetaNodes: []proto.NodeView{
+							{
+								Addr:       "172.16.1.101:17210",
+								Status:     false,
+								DomainAddr: "172.16.1.101:17010",
+								ID:         1,
+								IsWritable: false,
+							},
+						},
+						DataNodes: []proto.NodeView{
+							{
+								Addr:       "172.16.1.101:17310",
+								Status:     false,
+								DomainAddr: "172.16.1.101:17010",
+								ID:         1,
+								IsWritable: false,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+		switch m, p := req.Method, req.URL.Path; {
+
+		case m == http.MethodGet && p == "/topo/get":
+			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil
+
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+
+	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("zone", "info")
+	r.runTestCases(t, testCases)
+}

--- a/util/fake/fake.go
+++ b/util/fake/fake.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fake
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func CreateHTTPClient(roundTripper func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{
+		Transport: roundTripperFunc(roundTripper),
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func SuccessJsonBody(data interface{}) io.ReadCloser {
+	respWrapper := struct {
+		Code int32
+		Msg  string
+		Data interface{}
+	}{
+		Code: 0,
+		Msg:  "success",
+		Data: data,
+	}
+
+	responseBody, err := json.Marshal(respWrapper)
+	if err != nil {
+		panic(err)
+	}
+	return io.NopCloser(bytes.NewReader(responseBody))
+}


### PR DESCRIPTION
## **What this PR does / why we need it**:
Support unit test for cli. Code refactoring of #2279

## How to mock data
I create fake clients and inject them into the sdk to intercept the request and return the mock data. So we can easily mock the data in test function.

```go
fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
	switch m, p := req.Method, req.URL.Path; {

	case m == http.MethodGet && p == "/admin/aclOp":
		return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil

	default:
		t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
		return nil, nil
	}
})
```

## How to record errors

I rewrited the `errout` function to support modifying the handling of errors. By default, when the `errout` function is called, it will automatically execute the `OsExitWithLogFlush` function, and the program will stop immediately. When test files start running, we will change the `erroutHandler` so that program won't stop and the error will be recorded.

```go
var erroutHandler = OsExitWithLogFlush

func errout(format string, a ...interface{}) {
	log.LogErrorf(format, a...)
	_, _ = fmt.Fprintf(os.Stderr, format, a...)
	erroutHandler(format, a)
}

func OsExitWithLogFlush(_ string, _ ...interface{}) {
	log.LogFlush()
	os.Exit(1)
}
```
```go
func setupTestErrorRecorder() *testErrorRecorder {
	recorder := &testErrorRecorder{}
	erroutHandler = func(format string, args ...interface{}) {
		_, _ = fmt.Fprintf(recorder, format, args...)
	}
	return recorder
}
```

## How to write test cases

I defined a TestCase for unified management of test case execution. In most of the test functions, we only need to write the test case slice and then call the `runTestCases` function for execution.

```go
type TestCase struct {
	name      string    // name of test case
	args      []string  // arguments of test command
	expectErr bool      // whether the error is expected
}

func (c *cliTestRunner) runTestCases(t *testing.T, testCases []*TestCase) {
	for _, tc := range testCases {
		t.Run(tc.name, func(t *testing.T) {
			args := append(c.command, tc.args...)
			err := c.testRun(args...)
			if tc.expectErr {
				assert.Error(t, err)
			} else {
				assert.NoError(t, err)
			}
		})
	}
}
```
```go
func TestAclAddCmd(t *testing.T) {
        // cases for test
	testCases := []*TestCase{
		{
			name:      "Valid arguments",
			args:      []string{"testVol", "192.168.0.1"},
			expectErr: false,
		},
		{
			name:      "missing arguments",
			args:      []string{"testVol"},
			expectErr: true,
		},
	}

        // mock http response
	successV1 := &proto.AclRsp{
		OK: true,
		List: []*proto.AclIpInfo{
			{
				Ip:    "192.168.0.1",
				CTime: 1689091200,
			},
		},
	}

        // fake client for http mock
	fakeClient := fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
		switch m, p := req.Method, req.URL.Path; {

		case m == http.MethodGet && p == "/admin/aclOp":
			return &http.Response{StatusCode: http.StatusOK, Header: defaultHeader(), Body: fake.SuccessJsonBody(successV1)}, nil

		default:
			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
			return nil, nil
		}
	})

        // run test
	r := newCliTestRunner().setHttpClient(fakeClient).setCommand("acl", "add")
	r.runTestCases(t, testCases)
}
```
