### PR TITLE
[Feature]: Supports write disable option

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -148,6 +148,7 @@ func formatSimpleVolView(svv *proto.SimpleVolView) string {
 	sb.WriteString(fmt.Sprintf("  Tx conflict retry num           : %v\n", svv.TxConflictRetryNum))
 	sb.WriteString(fmt.Sprintf("  Tx conflict retry interval(ms)  : %v\n", svv.TxConflictRetryInterval))
 	sb.WriteString(fmt.Sprintf("  Tx limit interval(s)            : %v\n", svv.TxOpLimit))
+	sb.WriteString(fmt.Sprintf("  Forbidden                       : %v\n", svv.Forbidden))
 	sb.WriteString(fmt.Sprintf("  Quota                           : %v\n", formatEnabledDisabled(svv.EnableQuota)))
 	if svv.VolType == 1 {
 		sb.WriteString(fmt.Sprintf("  ObjBlockSize         : %v byte\n", svv.ObjBlockSize))
@@ -424,6 +425,7 @@ func formatDataPartitionInfo(partition *proto.DataPartitionInfo) string {
 	sb.WriteString(fmt.Sprintf("ISRdOnly      : %v\n", partition.RdOnly))
 	sb.WriteString(fmt.Sprintf("IsDiscard     : %v\n", partition.IsDiscard))
 	sb.WriteString(fmt.Sprintf("ReplicaNum    : %v\n", partition.ReplicaNum))
+	sb.WriteString(fmt.Sprintf("Forbidden     : %v\n", partition.Forbidden))
 	sb.WriteString("\n")
 	sb.WriteString(fmt.Sprintf("Replicas : \n"))
 	sb.WriteString(fmt.Sprintf("%v\n", formatDataReplicaTableHeader()))
@@ -483,6 +485,7 @@ func formatMetaPartitionInfo(partition *proto.MetaPartitionInfo) string {
 	sb.WriteString(fmt.Sprintf("Start         : %v\n", partition.Start))
 	sb.WriteString(fmt.Sprintf("End           : %v\n", partition.End))
 	sb.WriteString(fmt.Sprintf("MaxInodeID    : %v\n", partition.MaxInodeID))
+	sb.WriteString(fmt.Sprintf("Forbidden     : %v\n", partition.Forbidden))
 	sb.WriteString("\n")
 	sb.WriteString(fmt.Sprintf("Replicas : \n"))
 	sb.WriteString(fmt.Sprintf("%v\n", formatMetaReplicaTableHeader()))

--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -49,6 +49,7 @@ func newVolCmd(client *master.MasterClient) *cobra.Command {
 		newVolDeleteCmd(client),
 		newVolTransferCmd(client),
 		newVolAddDPCmd(client),
+		newVolSetForbiddenCmd(client),
 	)
 	return cmd
 }
@@ -941,5 +942,38 @@ func newVolSetCapacityCmd(use, short string, r clientHandler) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, r.(*volumeClient).client.ClientIDKey(), CliUsageClientIDKey)
+	return cmd
+}
+
+var (
+	cmdVolSetForbiddenUse   = "set-forbidden [VOLUME] [FORBIDDEN]"
+	cmdVolSetForbiddenShort = "Set the forbidden property for volume"
+)
+
+func newVolSetForbiddenCmd(client *master.MasterClient) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   cmdVolSetForbiddenUse,
+		Short: cmdVolSetForbiddenShort,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var name = args[0]
+			var settingStr = args[1]
+			var err error
+			defer func() {
+				if err != nil {
+					errout("Error: %v\n", err)
+				}
+			}()
+			forbidden, err := strconv.ParseBool(settingStr)
+			if err != nil {
+				return
+			}
+			if err = client.AdminAPI().SetVolumeForbidden(name, forbidden); err != nil {
+				return
+			}
+			stdout("Volume forbidden property has been set successfully, please wait few minutes for the settings to take effect.\n")
+			return
+		},
+	}
 	return cmd
 }

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -155,6 +155,14 @@ type DataPartition struct {
 	recoverErrCnt              uint64 //donot reset, if reach max err cnt, delete this dp
 }
 
+func (dp *DataPartition) IsForbidden() bool {
+	return dp.config.Forbidden
+}
+
+func (dp *DataPartition) SetForbidden(status bool) {
+	dp.config.Forbidden = status
+}
+
 func CreateDataPartition(dpCfg *dataPartitionCfg, disk *Disk, request *proto.CreateDataPartitionRequest) (dp *DataPartition, err error) {
 
 	if dp, err = newDataPartition(dpCfg, disk, true); err != nil {

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -49,6 +49,7 @@ type dataPartitionCfg struct {
 	ReplicaNum    int
 	VerSeq        uint64 `json:"ver_seq"`
 	CreateType    int
+	Forbidden     bool
 }
 
 func (dp *DataPartition) raftPort() (heartbeat, replica int, err error) {

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -396,6 +396,7 @@ func (manager *SpaceManager) CreatePartition(request *proto.CreateDataPartitionR
 		ReplicaNum:    request.ReplicaNum,
 		VerSeq:        request.VerSeq,
 		CreateType:    request.CreateType,
+		Forbidden:     false,
 	}
 	log.LogInfof("action[CreatePartition] dp %v dpCfg.Peers %v request.Members %v",
 		dpCfg.PartitionID, dpCfg.Peers, request.Members)
@@ -452,11 +453,11 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 	stat.Unlock()
 
 	response.ZoneName = s.zoneName
-	response.PartitionReports = make([]*proto.PartitionReport, 0)
+	response.PartitionReports = make([]*proto.DataPartitionReport, 0)
 	space := s.space
 	space.RangePartitions(func(partition *DataPartition) bool {
 		leaderAddr, isLeader := partition.IsRaftLeader()
-		vr := &proto.PartitionReport{
+		vr := &proto.DataPartitionReport{
 			VolName:                    partition.volumeID,
 			PartitionID:                uint64(partition.partitionID),
 			PartitionStatus:            partition.Status(),

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -1024,6 +1024,13 @@ func parseAndExtractStatus(r *http.Request) (status bool, err error) {
 	return extractStatus(r)
 }
 
+func parseAndExtractForbidden(r *http.Request) (forbidden bool, err error) {
+	if err = r.ParseForm(); err != nil {
+		return
+	}
+	return extractForbidden(r)
+}
+
 func extractStatus(r *http.Request) (status bool, err error) {
 	var value string
 	if value = r.FormValue(enableKey); value == "" {
@@ -1031,6 +1038,18 @@ func extractStatus(r *http.Request) (status bool, err error) {
 		return
 	}
 	if status, err = strconv.ParseBool(value); err != nil {
+		return
+	}
+	return
+}
+
+func extractForbidden(r *http.Request) (forbidden bool, err error) {
+	var value string
+	if value = r.FormValue(forbiddenKey); value == "" {
+		err = keyNotFound(forbiddenKey)
+		return
+	}
+	if forbidden, err = strconv.ParseBool(value); err != nil {
 		return
 	}
 	return

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -635,6 +635,14 @@ func (c *Cluster) checkDataNodeHeartbeat() {
 		node := dataNode.(*DataNode)
 		node.checkLiveness()
 		task := node.createHeartbeatTask(c.masterAddr(), c.diskQosEnable)
+		hbReq := task.Request.(*proto.HeartBeatRequest)
+		c.volMutex.RLock()
+		defer c.volMutex.RUnlock()
+		for _, vol := range c.vols {
+			if vol.Forbidden {
+				hbReq.ForbiddenVols = append(hbReq.ForbiddenVols, vol.Name)
+			}
+		}
 		tasks = append(tasks, task)
 		return true
 	})
@@ -655,6 +663,9 @@ func (c *Cluster) checkMetaNodeHeartbeat() {
 		for _, vol := range c.vols {
 			if vol.FollowerRead {
 				hbReq.FLReadVols = append(hbReq.FLReadVols, vol.Name)
+			}
+			if vol.Forbidden {
+				hbReq.ForbiddenVols = append(hbReq.ForbiddenVols, vol.Name)
 			}
 
 			spaceInfo := vol.uidSpaceManager.getSpaceOp()
@@ -1321,6 +1332,11 @@ func (c *Cluster) batchCreateDataPartition(vol *Vol, reqCount int, init bool) (e
 		if c.DisableAutoAllocate {
 			log.LogWarn("disable auto allocate dataPartition")
 			return fmt.Errorf("cluster is disable auto allocate dataPartition")
+		}
+
+		if vol.Forbidden {
+			log.LogWarn("disable auto allocate dataPartition by forbidden volume")
+			return fmt.Errorf("volume is forbidden")
 		}
 
 		if _, err = c.createDataPartition(vol.Name, nil); err != nil {
@@ -2650,6 +2666,7 @@ func (c *Cluster) updateDataPartitionOfflinePeerIDWithLock(dp *DataPartition, pe
 	}
 	return
 }
+
 func (c *Cluster) deleteDataReplica(dp *DataPartition, dataNode *DataNode) (err error) {
 
 	dp.Lock()

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -408,7 +408,7 @@ func (c *Cluster) deleteMetaPartition(partition *MetaPartition, removeMetaNode *
 	partition.Unlock()
 	_, err = removeMetaNode.Sender.syncSendAdminTask(task)
 	if err != nil {
-		log.LogErrorf("action[deleteMetaPartition] vol[%v],data partition[%v],err[%v]", partition.volName, partition.PartitionID, err)
+		log.LogErrorf("action[deleteMetaPartition] vol[%v],meta partition[%v],err[%v]", partition.volName, partition.PartitionID, err)
 	}
 	return nil
 }
@@ -663,14 +663,16 @@ func (c *Cluster) doLoadDataPartition(dp *DataPartition) {
 	dp.resetFilesWithMissingReplica()
 	loadTasks := dp.createLoadTasks()
 	c.addDataNodeTasks(loadTasks)
+	success := false
 	for i := 0; i < timeToWaitForResponse; i++ {
 		if dp.checkLoadResponse(c.cfg.DataPartitionTimeOutSec) {
+			success = true
 			break
 		}
 		time.Sleep(time.Second)
 	}
 
-	if dp.checkLoadResponse(c.cfg.DataPartitionTimeOutSec) == false {
+	if !success {
 		return
 	}
 
@@ -1072,7 +1074,7 @@ func (c *Cluster) adjustDataNode(dataNode *DataNode) {
 }
 
 /*if node report data partition infos,so range data partition infos,then update data partition info*/
-func (c *Cluster) updateDataNode(dataNode *DataNode, dps []*proto.PartitionReport) {
+func (c *Cluster) updateDataNode(dataNode *DataNode, dps []*proto.DataPartitionReport) {
 	for _, vr := range dps {
 		if vr == nil {
 			continue

--- a/master/const.go
+++ b/master/const.go
@@ -45,6 +45,7 @@ const (
 	metaNodesetSelectorKey = "metaNodesetSelector"
 	dataNodeSelectorKey    = "dataNodeSelector"
 	metaNodeSelectorKey    = "metaNodeSelector"
+	forbiddenKey           = "forbidden"
 
 	forceDelVolKey             = "forceDelVol"
 	ebsBlkSizeKey              = "ebsBlkSize"

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -44,7 +44,7 @@ type DataNode struct {
 	UsageRatio                float64           // used / total space
 	SelectedTimes             uint64            // number times that this datanode has been selected as the location for a data partition.
 	TaskManager               *AdminTaskManager `graphql:"-"`
-	DataPartitionReports      []*proto.PartitionReport
+	DataPartitionReports      []*proto.DataPartitionReport
 	DataPartitionCount        uint32
 	TotalPartitionSize        uint64
 	NodeSetID                 uint64
@@ -262,6 +262,7 @@ func (dataNode *DataNode) createHeartbeatTask(masterAddr string, enableDiskQos b
 	request.QosIopsWriteLimit = dataNode.QosIopsWLimit
 	request.QosFlowReadLimit = dataNode.QosFlowRLimit
 	request.QosFlowWriteLimit = dataNode.QosFlowWLimit
+
 	task = proto.NewAdminTask(proto.OpDataNodeHeartbeat, dataNode.Addr, request)
 	return
 }

--- a/master/data_node_test.go
+++ b/master/data_node_test.go
@@ -11,7 +11,11 @@ func TestDataNode(t *testing.T) {
 	// /dataNode/add and /dataNode/response processed by mock data server
 	var err error
 	addr := "127.0.0.1:9096"
-	addDataServer(addr, DefaultZoneName)
+	func() {
+		mockServerLock.Lock()
+		defer mockServerLock.Unlock()
+		mockDataServers = append(mockDataServers, addDataServer(addr, DefaultZoneName))
+	}()
 	server.cluster.checkDataNodeHeartbeat()
 	time.Sleep(5 * time.Second)
 	getDataNodeInfo(addr, t)

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -708,7 +708,7 @@ func (partition *DataPartition) update(action, volName string, newPeers []proto.
 	return
 }
 
-func (partition *DataPartition) updateMetric(vr *proto.PartitionReport, dataNode *DataNode, c *Cluster) {
+func (partition *DataPartition) updateMetric(vr *proto.DataPartitionReport, dataNode *DataNode, c *Cluster) {
 
 	if !partition.hasHost(dataNode.Addr) {
 		return
@@ -967,6 +967,14 @@ func (partition *DataPartition) buildDpInfo(c *Cluster) *proto.DataPartitionInfo
 		}
 	}
 
+	forbidden := true
+	vol, err := c.getVol(partition.VolName)
+	if err == nil {
+		forbidden = vol.Forbidden
+	} else {
+		log.LogErrorf("action[buildDpInfo]failed to get volume %v, err %v", partition.VolName, err)
+	}
+
 	return &proto.DataPartitionInfo{
 		PartitionID:              partition.PartitionID,
 		PartitionTTL:             partition.PartitionTTL,
@@ -988,6 +996,7 @@ func (partition *DataPartition) buildDpInfo(c *Cluster) *proto.DataPartitionInfo
 		FilesWithMissingReplica:  partition.FilesWithMissingReplica,
 		IsDiscard:                partition.IsDiscard,
 		SingleDecommissionStatus: partition.GetSpecialReplicaDecommissionStep(),
+		Forbidden:                forbidden,
 	}
 }
 

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -287,6 +287,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 		Path(proto.AdminClusterFreeze).
 		HandlerFunc(m.setupAutoAllocation)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminVolForbidden).
+		HandlerFunc(m.forbidVolume)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminClusterForbidMpDecommission).
 		HandlerFunc(m.setupForbidMetaPartitionDecommission)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/meta_node_test.go
+++ b/master/meta_node_test.go
@@ -10,7 +10,11 @@ import (
 func TestMetaNode(t *testing.T) {
 	// /metaNode/add and /metaNode/response processed by mock meta server
 	addr := mms7Addr
-	addMetaServer(addr, testZone3)
+	func() {
+		mockServerLock.Lock()
+		defer mockServerLock.Unlock()
+		mockMetaServers = append(mockMetaServers, addMetaServer(addr, testZone3))
+	}()
 	server.cluster.checkMetaNodeHeartbeat()
 	time.Sleep(5 * time.Second)
 	getMetaNodeInfo(addr, t)

--- a/master/mocktest/partition.go
+++ b/master/mocktest/partition.go
@@ -1,6 +1,8 @@
 package mocktest
 
 import (
+	"sync/atomic"
+
 	"github.com/cubefs/cubefs/proto"
 )
 
@@ -10,6 +12,19 @@ type MockDataPartition struct {
 	total            int
 	used             uint64
 	VolName          string
+	Forbidden        int32
+}
+
+func (md *MockDataPartition) IsForbidden() bool {
+	return atomic.LoadInt32(&md.Forbidden) != 0
+}
+
+func (md *MockDataPartition) SetForbidden(status bool) {
+	val := 0
+	if status {
+		val = 1
+	}
+	atomic.StoreInt32(&md.Forbidden, int32(val))
 }
 
 type MockMetaPartition struct {
@@ -21,6 +36,7 @@ type MockMetaPartition struct {
 	VolName     string
 	Members     []proto.Peer
 	Replicas    []*MockMetaReplica
+	Forbidden   int32
 }
 
 // MockMetaReplica defines the replica of a meta partition
@@ -46,4 +62,16 @@ func (mm *MockMetaPartition) isLeaderMetaNode(addr string) bool {
 	}
 
 	return false
+}
+
+func (mm *MockMetaPartition) IsForbidden() bool {
+	return atomic.LoadInt32(&mm.Forbidden) != 0
+}
+
+func (mm *MockMetaPartition) SetForbidden(status bool) {
+	val := 0
+	if status {
+		val = 1
+	}
+	atomic.StoreInt32(&mm.Forbidden, int32(val))
 }

--- a/master/vol.go
+++ b/master/vol.go
@@ -109,6 +109,7 @@ type Vol struct {
 	quotaManager            *MasterQuotaManager
 	enableQuota             bool
 	VersionMgr              *VolVersionManager
+	Forbidden               bool
 }
 
 func newVol(vv volValue) (vol *Vol) {
@@ -196,6 +197,7 @@ func newVolFromVolValue(vv *volValue) (vol *Vol) {
 	if vol.txConflictRetryInterval == 0 {
 		vol.txConflictRetryInterval = proto.DefaultTxConflictRetryInterval
 	}
+	vol.Forbidden = vv.Forbidden
 	return vol
 }
 
@@ -670,7 +672,7 @@ func (vol *Vol) checkAutoDataPartitionCreation(c *Cluster) {
 
 	vol.setStatus(normal)
 	log.LogInfof("action[autoCreateDataPartitions] vol[%v] before autoCreateDataPartitions", vol.Name)
-	if !c.DisableAutoAllocate {
+	if !c.DisableAutoAllocate && !vol.Forbidden {
 		vol.autoCreateDataPartitions(c)
 	}
 }
@@ -1156,7 +1158,7 @@ func (vol *Vol) doSplitMetaPartition(c *Cluster, mp *MetaPartition, end uint64, 
 }
 
 func (vol *Vol) splitMetaPartition(c *Cluster, mp *MetaPartition, end uint64, metaPartitionInodeIdStep uint64) (err error) {
-	if c.DisableAutoAllocate {
+	if c.DisableAutoAllocate || vol.Forbidden {
 		return
 	}
 

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -47,6 +47,18 @@ func (m *metadataManager) checkFollowerRead(volNames []string, partition MetaPar
 	return
 }
 
+func (m *metadataManager) checkForbiddenVolume(volNames []string, partition MetaPartition) {
+	volName := partition.GetBaseConfig().VolName
+	for _, name := range volNames {
+		if name == volName {
+			partition.SetForbidden(true)
+			return
+		}
+	}
+	partition.SetForbidden(false)
+	return
+}
+
 func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 	remoteAddr string) (err error) {
 	// For ack to master
@@ -83,6 +95,7 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 
 		m.Range(func(id uint64, partition MetaPartition) bool {
 			m.checkFollowerRead(req.FLReadVols, partition)
+			m.checkForbiddenVolume(req.ForbiddenVols, partition)
 			partition.SetUidLimit(req.UidLimitInfo)
 			partition.SetTxInfo(req.TxInfo)
 			partition.setQuotaHbInfo(req.QuotaHbInfos)

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -92,6 +92,7 @@ type MetaPartitionConfig struct {
 	AfterStop     func()              `json:"-"`
 	RaftStore     raftstore.RaftStore `json:"-"`
 	ConnPool      *util.ConnectPool   `json:"-"`
+	Forbidden     bool                `json:"forbidden"`
 }
 
 func (c *MetaPartitionConfig) checkMeta() (err error) {
@@ -265,6 +266,8 @@ type MetaPartition interface {
 	LoadSnapshot(path string) error
 	ForceSetMetaPartitionToLoadding()
 	ForceSetMetaPartitionToFininshLoad()
+	IsForbidden() bool
+	SetForbidden(status bool)
 }
 
 type UidManager struct {
@@ -503,6 +506,14 @@ type metaPartition struct {
 	versionLock            sync.Mutex
 }
 
+func (mp *metaPartition) IsForbidden() bool {
+	return mp.config.Forbidden
+}
+
+func (mp *metaPartition) SetForbidden(status bool) {
+	mp.config.Forbidden = status
+}
+
 func (mp *metaPartition) acucumRebuildStart() bool {
 	return mp.uidManager.accumRebuildStart()
 }
@@ -524,7 +535,6 @@ func (mp *metaPartition) getVerList() []*proto.VolVersionInfo {
 }
 
 func (mp *metaPartition) checkAndUpdateVerList(verSeq uint64) (err error) {
-
 	mp.multiVersionList.Lock()
 	defer mp.multiVersionList.Unlock()
 

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -249,7 +249,6 @@ func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet) (err erro
 			return
 		}
 	}
-
 	dentry := &Dentry{
 		ParentId: req.ParentID,
 		Name:     req.Name,
@@ -289,7 +288,6 @@ func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet) (err erro
 
 // DeleteDentry deletes a dentry.
 func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet) (err error) {
-
 	db := make(DentryBatch, 0, len(req.Dens))
 
 	for _, d := range req.Dens {

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -469,7 +469,6 @@ func (mp *metaPartition) BatchExtentAppend(req *proto.AppendExtentKeysRequest, p
 }
 
 func (mp *metaPartition) BatchObjExtentAppend(req *proto.AppendObjExtentKeysRequest, p *Packet) (err error) {
-
 	var ino *Inode
 	if ino, _, err = mp.CheckQuota(req.Inode, p); err != nil {
 		log.LogErrorf("BatchObjExtentAppend fail status [%v]", err)

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -213,7 +213,6 @@ func (mp *metaPartition) QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p 
 }
 
 func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packet) (err error) {
-
 	txInfo := req.TxInfo.GetCopy()
 	var status uint8
 	var respIno *Inode

--- a/metanode/partition_op_transaction.go
+++ b/metanode/partition_op_transaction.go
@@ -17,9 +17,10 @@ package metanode
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
+
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util/log"
-	"sync"
 )
 
 func (mp *metaPartition) TxCreate(req *proto.TxCreateRequest, p *Packet) error {

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -44,6 +44,7 @@ const (
 	AdminUpdateVol                            = "/vol/update"
 	AdminVolShrink                            = "/vol/shrink"
 	AdminVolExpand                            = "/vol/expand"
+	AdminVolForbidden                         = "/vol/forbidden"
 	AdminCreateVol                            = "/admin/createVol"
 	AdminGetVol                               = "/admin/getVol"
 	AdminClusterFreeze                        = "/cluster/freeze"
@@ -584,10 +585,11 @@ type HeartBeatRequest struct {
 	UidLimitToMetaNode
 	QuotaHeartBeatInfos
 	TxInfos
+	ForbiddenVols []string
 }
 
-// PartitionReport defines the partition report.
-type PartitionReport struct {
+// DataPartitionReport defines the partition report.
+type DataPartitionReport struct {
 	VolName                    string
 	PartitionID                uint64
 	PartitionStatus            int
@@ -620,7 +622,7 @@ type DataNodeHeartbeatResponse struct {
 	MaxCapacity         uint64 // maximum capacity to create partition
 	StartTime           int64
 	ZoneName            string
-	PartitionReports    []*PartitionReport
+	PartitionReports    []*DataPartitionReport
 	Status              uint8
 	Result              string
 	BadDisks            []string
@@ -811,6 +813,7 @@ type VolView struct {
 	DeleteLockTime int64
 	CacheTTL       int
 	VolType        int
+	Forbidden      bool
 }
 
 func (v *VolView) SetOwner(owner string) {
@@ -975,8 +978,9 @@ type SimpleVolView struct {
 	CacheRule        string
 	PreloadCapacity  uint64
 	Uids             []UidSimpleInfo
-	// multi version snapsho t
+	// multi version snapshot
 	LatestVer uint64
+	Forbidden bool
 }
 
 type NodeSetInfo struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -59,7 +59,7 @@ type DataNodeInfo struct {
 	IsWriteAble               bool
 	UsageRatio                float64 // used / total space
 	SelectedTimes             uint64  // number times that this datanode has been selected as the location for a data partition.
-	DataPartitionReports      []*PartitionReport
+	DataPartitionReports      []*DataPartitionReport
 	DataPartitionCount        uint32
 	NodeSetID                 uint64
 	PersistenceDataPartitions []uint64
@@ -90,6 +90,7 @@ type MetaPartitionInfo struct {
 	OfflinePeerID uint64
 	MissNodes     map[string]int64
 	LoadResponse  []*MetaPartitionLoadResponse
+	Forbidden     bool
 }
 
 // MetaReplica defines the replica of a meta partition
@@ -267,6 +268,7 @@ type DataPartitionInfo struct {
 	SingleDecommissionAddr   string
 	RdOnly                   bool
 	IsDiscard                bool
+	Forbidden                bool
 }
 
 // FileInCore define file in data partition

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -506,6 +506,16 @@ func (api *AdminAPI) GetVolumeSimpleInfo(volName string) (vv *proto.SimpleVolVie
 	return
 }
 
+func (api *AdminAPI) SetVolumeForbidden(volName string, forbidden bool) (err error) {
+	request := newAPIRequest(http.MethodGet, proto.AdminVolForbidden)
+	request.addParam("name", volName)
+	request.addParam("forbidden", strconv.FormatBool(forbidden))
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) GetMonitorPushAddr() (addr string, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.AdminGetMonitorPushAddr)
 	var buf []byte


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Supports write disable option("Forbidden")
 ```log
 ┌──(root💀LAPTOP-9TS0FG11)-[/home/nature/cubefs]
└─# ./build/bin/cfs-cli vol set-forbidden ltptest true
Volume forbidden property has been set successfully.

┌──(root💀LAPTOP-9TS0FG11)-[/home/nature/cubefs]
└─# ./build/bin/cfs-cli vol set-forbidden ltptest false
Volume forbidden property has been set successfully.
 ```

**NOTE: master will put partition status to node, only when their status inconsistent with master, this check process will be completed by heartbeat.**

**Forbid a volume:**

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ rm a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt
-bash: echo: write error: Input/output error

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt
-bash: echo: write error: Input/output error

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> a.txt
-bash: echo: write error: Input/output error

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ cat a.txt
1
1
1
1
1
1
1
```

**Unforbid a volume:**

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "1" >> b.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ cat b.txt
1

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ echo "2" >> a.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ ls
a.txt  b.txt

┌──(nature㉿LAPTOP-9TS0FG11)-[~/disk/client/mnt]
└─$ cat a.txt
1
1
1
1
1
1
1
2

```

*NOTE: When I unforbid the partition, execute `echo "2" >> a.txt` still get a I/O error, but it will success when I execute `echo "1" >> b.txt`, I don't know what cause the problem, please let me know if you have any idea about it.*

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2477

**Special notes for your reviewer**:

* Please contract me, if the pull request passed the review.

* Maybe update client to check "forbidden partition error" is necessarily.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
