### PR TITLE
add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Always check-out / check-in files with LF line endings.
+* text=auto eol=lf


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Developers are using different OSes (Windows and MacOS) the default for the line ending will differ. On the Windows machine the default for the line ending is CRLF, whereas on Linux/MacOS it's a LF.

After adding .gitattributes, any changes or new changes will automatically use the line endings specified.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
