### PR TITLE
enhance(log).output not be used as normal log output and normalize lo…

### DIFF
--- a/sdk/master/client.go
+++ b/sdk/master/client.go
@@ -181,7 +181,7 @@ func (c *MasterClient) serveRequest(r *request) (repsData []byte, err error) {
 			}
 			return []byte(body.Data), nil
 		default:
-			err = errors.New(fmt.Sprintf("err(%v)", strings.Replace(string(repsData), "\n", "", -1)))
+			err = errors.New(fmt.Sprintf("unknown status (%v) body(%v)", stateCode, strings.Replace(string(repsData), "\n", "", -1)))
 			log.LogErrorf("serveRequest: unknown status: host(%v) uri(%v) status(%v) body(%s).",
 				resp.Request.URL.String(), host, stateCode, strings.Replace(string(repsData), "\n", "", -1))
 			continue

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -494,10 +494,8 @@ func LogWarn(v ...interface{}) {
 	}
 	s := fmt.Sprintln(v...)
 	s = gLog.SetPrefix(s, levelPrefixes[2])
-	gLog.debugLogger.Output(2, s)
 	gLog.warnLogger.Output(2, s)
-	gLog.infoLogger.Output(2, s)
-	gLog.outputStderr(2, s)
+	//gLog.outputStderr(2, s)
 }
 
 // LogWarnf indicates the warnings with specific format.
@@ -510,10 +508,8 @@ func LogWarnf(format string, v ...interface{}) {
 	}
 	s := fmt.Sprintf(format, v...)
 	s = gLog.SetPrefix(s, levelPrefixes[2])
-	gLog.debugLogger.Output(2, s)
 	gLog.warnLogger.Output(2, s)
-	gLog.infoLogger.Output(2, s)
-	gLog.outputStderr(2, s)
+	// gLog.outputStderr(2, s)
 }
 
 // LogInfo indicates log the information. TODO explain
@@ -526,7 +522,6 @@ func LogInfo(v ...interface{}) {
 	}
 	s := fmt.Sprintln(v...)
 	s = gLog.SetPrefix(s, levelPrefixes[1])
-	gLog.debugLogger.Output(2, s)
 	gLog.infoLogger.Output(2, s)
 }
 
@@ -540,7 +535,6 @@ func LogInfof(format string, v ...interface{}) {
 	}
 	s := fmt.Sprintf(format, v...)
 	s = gLog.SetPrefix(s, levelPrefixes[1])
-	gLog.debugLogger.Output(2, s)
 	gLog.infoLogger.Output(2, s)
 }
 
@@ -561,10 +555,9 @@ func LogError(v ...interface{}) {
 	}
 	s := fmt.Sprintln(v...)
 	s = gLog.SetPrefix(s, levelPrefixes[3])
-	gLog.debugLogger.Output(2, s)
-	gLog.infoLogger.Output(2, s)
+
 	gLog.errorLogger.Output(2, s)
-	gLog.outputStderr(2, s)
+	//gLog.outputStderr(2, s)
 }
 
 // LogErrorf logs the errors with the specified format.
@@ -577,10 +570,8 @@ func LogErrorf(format string, v ...interface{}) {
 	}
 	s := fmt.Sprintf(format, v...)
 	s = gLog.SetPrefix(s, levelPrefixes[3])
-	gLog.debugLogger.Output(2, s)
 	gLog.errorLogger.Print(s)
-	gLog.infoLogger.Output(2, s)
-	gLog.outputStderr(2, s)
+	//gLog.outputStderr(2, s)
 }
 
 // LogDebug logs the debug information.


### PR DESCRIPTION
…g print level

Temporarily disable writing logs to the output log file during initialization due to its excessively large size.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
