### PR TITLE
enhance(metanode).add interface of IsRestoring to raft store for bett…

### DIFF
--- a/depends/tiglabs/raft/server.go
+++ b/depends/tiglabs/raft/server.go
@@ -218,6 +218,15 @@ func (rs *RaftServer) ChangeMember(id uint64, changeType proto.ConfChangeType, p
 	return
 }
 
+func (rs *RaftServer) IsRestoring(id uint64) bool {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	if raft, ok := rs.rafts[id]; ok {
+		return raft.restoringSnapshot.Get() || raft.applied() == 0
+	}
+	return true
+}
+
 func (rs *RaftServer) Status(id uint64) (status *Status) {
 	rs.mu.RLock()
 	raft, ok := rs.rafts[id]

--- a/metanode/mocktest/raftstore/partition.go
+++ b/metanode/mocktest/raftstore/partition.go
@@ -78,6 +78,20 @@ func (mr *MockPartitionMockRecorder) CommittedIndex() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommittedIndex", reflect.TypeOf((*MockPartition)(nil).CommittedIndex))
 }
 
+// IsRestoring mocks base method.
+func (m *MockPartition) IsRestoring() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRestoring")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsRestoring indicates an expected call of IsRestoring.
+func (mr *MockPartitionMockRecorder) IsRestoring() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRestoring", reflect.TypeOf((*MockPartition)(nil).IsRestoring))
+}
+
 // Delete mocks base method.
 func (m *MockPartition) Delete() error {
 	m.ctrl.T.Helper()

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -885,8 +885,7 @@ func (mp *metaPartition) IsFollowerRead() (ok bool) {
 		return false
 	}
 
-	status := mp.raftPartition.Status()
-	if status == nil || status.RestoringSnapshot || status.Applied == 0 {
+	if mp.raftPartition.IsRestoring() {
 		return false
 	}
 

--- a/raftstore/partition.go
+++ b/raftstore/partition.go
@@ -49,6 +49,9 @@ type Partition interface {
 	// Status returns the current raft status.
 	Status() (status *PartitionStatus)
 
+	// Much faster then status().RestoringSnapshot.
+	IsRestoring() bool
+
 	// LeaderTerm returns the current term of leader in the raft group. TODO what is term?
 	LeaderTerm() (leaderID, term uint64)
 
@@ -108,6 +111,10 @@ func (p *partition) Delete() (err error) {
 	}
 	err = os.RemoveAll(p.walPath)
 	return
+}
+
+func (p *partition) IsRestoring() bool {
+	return p.raft.IsRestoring(p.id)
 }
 
 // Status returns the current raft status.


### PR DESCRIPTION
…er performace while do IsFollowerRead jugement


To ensure that the partition is not in a snapshot state during metanode's followRead, we queried the status interface of the raft. However, the Status() interface of raft is implemented using a channel for lock-free operation, which leads to poor performance. To address this, we are adding an interface here that allows us to retrieve only the required status instead of the entire raft state.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
