### PR TITLE
fix(Raft): fix the error when Raft has no leader which not handler he…

### DIFF
--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -316,7 +316,10 @@ func (s *raft) run() {
 				(m.Type == proto.ReqMsgVote && s.raftFsm.raftLog.isUpToDate(m.Index, m.LogTerm, 0, 0)) {
 				switch m.Type {
 				case proto.ReqMsgHeartBeat:
-					if s.raftFsm.leader == m.From && m.From != s.config.NodeID {
+					// if s.raftFsm.leader == no leader, also need handler heartbeat request.
+					// Otherwise PreCandidate will not change his state to Follower.
+					// So remove the condition s.raftFsm.leader == m.From
+					if m.From != s.config.NodeID {
 						s.raftFsm.Step(m)
 					}
 				case proto.RespMsgHeartBeat:

--- a/depends/tiglabs/raft/server.go
+++ b/depends/tiglabs/raft/server.go
@@ -441,7 +441,6 @@ func (rs *RaftServer) sendHeartbeat() {
 		msg.From = rs.config.NodeID
 		msg.To = to
 		msg.Context = proto.EncodeHBConext(ctx)
-		logger.Debug("send heartbeat msg[%v] to id:%d", msg, to)
 		rs.config.transport.Send(msg)
 	}
 }

--- a/depends/tiglabs/raft/transport_heartbeat.go
+++ b/depends/tiglabs/raft/transport_heartbeat.go
@@ -101,7 +101,7 @@ func (t *heartbeatTransport) handleConn(conn *util.ConnTimeout) {
 					logger.Error(fmt.Sprintf("[heartbeatTransport] recive message from conn error, %s", err.Error()))
 					return
 				} else {
-					logger.Debug(fmt.Sprintf("Recive %v from (%v)", msg.ToString(), conn.RemoteAddr()))
+					//logger.Debug(fmt.Sprintf("Recive %v from (%v)", msg.ToString(), conn.RemoteAddr()))
 					t.raftServer.reciveMessage(msg)
 				}
 			}


### PR DESCRIPTION
…artbeat request

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1.The RAFT node was unable to receive the null entry message that leder change will send when it restarts.As a result, this node will become PreCandidate. The Raft that has no leader will not handle heartbeat messages, so it will never change to a follower until an append request is received.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #
1. Let PreCandidate handle heartbeat requests so it can quickly switch to follower if the cluster has a normal leader.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
