### PR TITLE
fix(log): fix bug of empty log file during log rotation due to concur…

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -110,6 +110,7 @@ type asyncWriter struct {
 	flushC      chan bool
 	rotateDay   chan struct{} // TODO rotateTime?
 	mu          sync.Mutex
+	rotateMu    sync.Mutex
 }
 
 func (writer *asyncWriter) flushScheduler() {
@@ -172,6 +173,7 @@ func (writer *asyncWriter) flushToFile() {
 	default:
 	}
 	flushLength := writer.flushTmp.Len()
+	writer.rotateMu.Lock()
 	if (writer.logSize+int64(flushLength)) >= writer.
 		rollingSize || isRotateDay {
 		oldFile := writer.fileName + "." + time.Now().Format(
@@ -187,6 +189,7 @@ func (writer *asyncWriter) flushToFile() {
 			}
 		}
 	}
+	writer.rotateMu.Unlock()
 	writer.logSize += int64(flushLength)
 	// TODO Unhandled errors
 	writer.file.Write(writer.flushTmp.Bytes())


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current log service may have problems with concurrency, where log rotation is not protected by lock, which may result in empty log files.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2581 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
