### PR TITLE
[Fix]: For compatibility, set dp and mp's Status to ReadOnly when forbid volume write

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -239,6 +239,12 @@ func (m *Server) forbidVolume(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}
+	if status {
+		// set data partition status to write only
+		vol.setDpRdOnly()
+		// set meta partition status to read only
+		vol.setMpRdOnly()
+	}
 	sendOkReply(w, r, newSuccessHTTPReply(fmt.Sprintf("set volume forbidden to (%v) success", status)))
 }
 

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -1353,6 +1353,20 @@ func TestForbiddenVolume(t *testing.T) {
 	forbidUrl := fmt.Sprintf("%v?name=%v&%v=true", reqUrl, vol.Name, forbiddenKey)
 	unforbidUrl := fmt.Sprintf("%v?name=%v&%v=false", reqUrl, vol.Name, forbiddenKey)
 	process(forbidUrl, t)
+	dps := vol.cloneDataPartitionMap()
+	mps := vol.cloneMetaPartitionMap()
+	for _, dp := range dps {
+		if dp.Status == proto.ReadWrite {
+			t.Errorf("failed to set dp rd only")
+			return
+		}
+	}
+	for _, mp := range mps {
+		if mp.Status == proto.ReadWrite {
+			t.Errorf("failed to set mp rd only")
+			return
+		}
+	}
 	ok := checkVolForbidden(vol.Name, vol.Forbidden)
 	if !ok {
 		t.Errorf("failed to forbid volume, check timeout")
@@ -1363,5 +1377,17 @@ func TestForbiddenVolume(t *testing.T) {
 	if !ok {
 		t.Errorf("failed to unforbid volume, check timeout")
 		return
+	}
+	for _, dp := range dps {
+		if dp.Status != proto.ReadWrite {
+			t.Errorf("failed to set dp rd only")
+			return
+		}
+	}
+	for _, mp := range mps {
+		if mp.Status != proto.ReadWrite {
+			t.Errorf("failed to set mp rd only")
+			return
+		}
 	}
 }

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (partition *DataPartition) checkStatus(clusterName string, needLog bool, dpTimeOutSec int64, c *Cluster,
-	shouldDpInhibitWriteByVolFull bool) {
+	shouldDpInhibitWriteByVolFull bool, forbiddenVol bool) {
 	partition.Lock()
 	defer partition.Unlock()
 	var liveReplicas []*DataReplica
@@ -50,12 +50,18 @@ func (partition *DataPartition) checkStatus(clusterName string, needLog bool, dp
 			partition.hasEnoughAvailableSpace() &&
 			!shouldDpInhibitWriteByVolFull {
 
+			writable := false
 			if proto.IsNormalDp(partition.PartitionType) {
 				if partition.getLeaderAddr() != "" {
-					partition.Status = proto.ReadWrite
+					writable = true
 				}
 			} else {
 				// cold volume has no leader
+				writable = true
+			}
+			// if the volume is not forbidden
+			// set status to ReadWrite
+			if writable && !forbiddenVol {
 				partition.Status = proto.ReadWrite
 			}
 		}

--- a/master/meta_partition.go
+++ b/master/meta_partition.go
@@ -294,7 +294,7 @@ func (mp *MetaPartition) checkLeader(clusterID string) {
 	return
 }
 
-func (mp *MetaPartition) checkStatus(clusterID string, writeLog bool, replicaNum int, maxPartitionID uint64, metaPartitionInodeIdStep uint64) (doSplit bool) {
+func (mp *MetaPartition) checkStatus(clusterID string, writeLog bool, replicaNum int, maxPartitionID uint64, metaPartitionInodeIdStep uint64, forbiddenVol bool) (doSplit bool) {
 	mp.Lock()
 	defer mp.Unlock()
 
@@ -337,7 +337,7 @@ func (mp *MetaPartition) checkStatus(clusterID string, writeLog bool, replicaNum
 		}
 	}
 
-	if mp.PartitionID >= maxPartitionID && mp.Status == proto.ReadOnly {
+	if mp.PartitionID >= maxPartitionID && mp.Status == proto.ReadOnly && !forbiddenVol {
 		mp.Status = proto.ReadWrite
 	}
 

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -278,7 +278,7 @@ func checkMetaPartitionsWritableTest(vol *Vol, t *testing.T) {
 	maxPartitionID := vol.maxPartitionID()
 	maxMp := vol.MetaPartitions[maxPartitionID]
 	//after check meta partitions ,the status must be writable
-	maxMp.checkStatus(server.cluster.Name, false, int(vol.mpReplicaNum), maxPartitionID, 4194304)
+	maxMp.checkStatus(server.cluster.Name, false, int(vol.mpReplicaNum), maxPartitionID, 4194304, vol.Forbidden)
 	if maxMp.Status != proto.ReadWrite {
 		t.Errorf("expect partition status[%v],real status[%v]\n", proto.ReadWrite, maxMp.Status)
 		return

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -92,7 +92,7 @@ type MetaPartitionConfig struct {
 	AfterStop     func()              `json:"-"`
 	RaftStore     raftstore.RaftStore `json:"-"`
 	ConnPool      *util.ConnectPool   `json:"-"`
-	Forbidden     bool                `json:"forbidden"`
+	Forbidden     bool                `json:"-"`
 }
 
 func (c *MetaPartitionConfig) checkMeta() (err error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Set dp and mp's Status to ReadOnly when forbid volume write.
* `splitMetaPartition` returns error when cluster disable and volume is forbidden.
* ~Datanode/Metanode persist config, when volume's forbidden changed.~

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
