### PR TITLE
fix some bugs related to snapshot

### DIFF
--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2370,7 +2370,6 @@ func (m *metadataManager) checkMultiVersionStatus(mp MetaPartition, p *Packet) (
 		log.LogWarnf("action[checkmultiSnap.multiVersionstatus] vol %v mp ver %v, client use old ver before snapshot", mp.GetVolName(), mp.GetVerSeq())
 		return fmt.Errorf("client use old ver before snapshot")
 	}
-	p.ExtentType |= ^uint8(proto.MultiVersionFlag)
 
 	// meta node do not need to check verSeq as strictly as datanode,file append or modAppendWrite on meta node is invisible to other files.
 	// only need to guarantee the verSeq wrote on meta nodes grow up linearly on client's angle

--- a/metanode/sorted_extents.go
+++ b/metanode/sorted_extents.go
@@ -338,7 +338,7 @@ func (se *SortedExtents) AppendWithCheck(inodeID uint64, ek proto.ExtentKey, add
 		se.eks = append(se.eks, ek)
 		return
 	}
-	idx := len(se.eks)-1
+	idx := len(se.eks) - 1
 	lastKey := &se.eks[idx]
 	log.LogDebugf("action[AppendWithCheck] ek %v,lastKey %v", ek, lastKey)
 	if lastKey.FileOffset+uint64(lastKey.Size) <= ek.FileOffset {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
enhance(metanode): check version no need to reset all mask euqual towq MultiVersionFlag
fix(master):snapshot.make WaitGroup usage clear in aync job in 2phase version managment in case of wrong number counter
fix(metanode):snapshot.Extent append by diff verseq need consider as split key and add to refMap,or else the ek drop caused by modification and be considered as normal discard , the whole extent would be dropped


**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
