### PR TITLE
fix(log): fix bug of the current log service does not have any record…

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	blog "github.com/cubefs/cubefs/blobstore/util/log"
+	syslog "log"
 )
 
 type Level uint8
@@ -185,8 +186,14 @@ func (writer *asyncWriter) flushToFile() {
 					writer.file = fp
 					writer.logSize = 0
 					_ = os.Chmod(writer.fileName, 0666)
+				} else {
+					syslog.Printf("log rotate: openFile %v error: %v", writer.fileName, err)
 				}
+			} else {
+				syslog.Printf("log rotate: rename %v error: %v ", oldFile, err)
 			}
+		} else {
+			syslog.Printf("log rotate: lstat error: %v already exists", oldFile)
 		}
 	}
 	writer.rotateMu.Unlock()


### PR DESCRIPTION
… of rotation errors.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current log service does not record any log rotation errors, making it impossible to troubleshoot errors in the rotation process.Therefore, this pr will write the error information to the system log when an error occurs during the rotation process to facilitate subsequent troubleshooting.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2600 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
