### PR TITLE
feat(objectnode): support local and external audit log

### DIFF
--- a/objectnode/api_context.go
+++ b/objectnode/api_context.go
@@ -31,7 +31,8 @@ const (
 	ContextKeyErrorMessage  = "error_message"
 	ContextKeyBucket        = "bucket"
 	ContextKeyObject        = "object"
-	ContextKeyUid           = "uid"
+	ContextKeyRequester     = "requester"
+	ContextKeyOwner         = "owner"
 	ContextKeyAccessKey     = "access_key"
 )
 

--- a/objectnode/api_handler.go
+++ b/objectnode/api_handler.go
@@ -61,6 +61,22 @@ func (p *RequestParam) AccessKey() string {
 	return p.accessKey
 }
 
+func (p *RequestParam) API() string {
+	return p.apiName
+}
+
+func (p *RequestParam) Owner() string {
+	return p.vars[ContextKeyOwner]
+}
+
+func (p *RequestParam) Requester() string {
+	return p.vars[ContextKeyRequester]
+}
+
+func (p *RequestParam) RequestID() string {
+	return p.vars[ContextKeyRequestID]
+}
+
 func ParseRequestParam(r *http.Request) *RequestParam {
 	p := new(RequestParam)
 	p.r = r

--- a/objectnode/audit.go
+++ b/objectnode/audit.go
@@ -1,0 +1,195 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cubefs/cubefs/blobstore/common/rpc/auditlog"
+	"github.com/cubefs/cubefs/util/log"
+)
+
+const (
+	auditVersion = "1.0"
+)
+
+type AuditLogger interface {
+	Name() string
+	Send(data []byte) error
+	Close() error
+}
+
+type AuditEntry struct {
+	Version   string    `json:"Version"`
+	Time      time.Time `json:"Time"`
+	RequestID string    `json:"RequestID"`
+	Requester string    `json:"Requester"`
+	AccessKey string    `json:"AccessKey"`
+	Owner     string    `json:"Owner"`
+
+	Request struct {
+		API      string            `json:"API,omitempty"`
+		Bucket   string            `json:"Bucket,omitempty"`
+		Object   string            `json:"Object,omitempty"`
+		Method   string            `json:"Method,omitempty"`
+		Proto    string            `json:"Proto,omitempty"`
+		Path     string            `json:"Path,omitempty"`
+		Query    map[string]string `json:"Query,omitempty"`
+		Header   map[string]string `json:"Header,omitempty"`
+		Host     string            `json:"Host,omitempty"`
+		RemoteIP string            `json:"RemoteIP,omitempty"`
+	} `json:"Request"`
+
+	Response struct {
+		Status     string            `json:"Status,omitempty"`
+		StatusCode int               `json:"StatusCode,omitempty"`
+		Header     map[string]string `json:"Header,omitempty"`
+		Error      string            `json:"Error,omitempty"`
+	} `json:"Response"`
+
+	BytesRequest  int64  `json:"BytesRequest,omitempty"`
+	BytesResponse int64  `json:"BytesResponse,omitempty"`
+	Duration      string `json:"Duration,omitempty"`
+	DurationNS    string `json:"DurationNS,omitempty"`
+}
+
+type AuditLogConfig struct {
+	Local *auditlog.Config `json:"local,omitempty"`
+	// The key of map is a unique identifier of audit
+	Kafka   map[string]KafkaAuditConfig   `json:"kafka,omitempty"`
+	Webhook map[string]WebhookAuditConfig `json:"webhook,omitempty"`
+}
+
+type ExternalAudit struct {
+	loggers []AuditLogger
+
+	sync.RWMutex
+}
+
+func NewExternalAudit() *ExternalAudit {
+	return &ExternalAudit{}
+}
+
+func (a *ExternalAudit) AddLoggers(al ...AuditLogger) {
+	a.Lock()
+	defer a.Unlock()
+
+	a.loggers = append(a.loggers, al...)
+}
+
+func (a *ExternalAudit) Close() {
+	a.Lock()
+	loggers := a.loggers
+	a.loggers = nil
+	a.Unlock()
+
+	for _, logger := range loggers {
+		if logger != nil {
+			logger.Close()
+		}
+	}
+}
+
+func (a *ExternalAudit) getLoggers() []AuditLogger {
+	a.RLock()
+	defer a.RUnlock()
+
+	return a.loggers
+}
+
+func (a *ExternalAudit) Logger(w http.ResponseWriter, r *http.Request) {
+	loggers := a.getLoggers()
+	if len(loggers) <= 0 || w == nil || r == nil {
+		return
+	}
+
+	var (
+		statusCode int
+		respBytes  int64
+		timeCost   time.Duration
+	)
+	startTime := time.Now().UTC()
+	if rs, ok := w.(*ResponseStater); ok {
+		statusCode = rs.StatusCode
+		respBytes = rs.Written
+		startTime = rs.StartTime
+		timeCost = time.Now().UTC().Sub(startTime)
+	}
+	duration := strconv.FormatInt(timeCost.Nanoseconds(), 10)
+	param := ParseRequestParam(r)
+	entry := AuditEntry{
+		Version:       auditVersion,
+		Time:          startTime,
+		RequestID:     param.RequestID(),
+		Requester:     param.Requester(),
+		AccessKey:     param.AccessKey(),
+		Owner:         param.Owner(),
+		BytesRequest:  r.ContentLength,
+		BytesResponse: respBytes,
+		DurationNS:    duration,
+		Duration:      duration + "ns",
+	}
+
+	entry.Request.API = param.API()
+	entry.Request.Bucket = param.Bucket()
+	entry.Request.Object = param.Object()
+	entry.Request.Method = r.Method
+	entry.Request.Proto = r.Proto
+	entry.Request.Path = r.URL.Path
+	entry.Request.Host = r.Host
+	entry.Request.RemoteIP = getRequestIP(r)
+	query := r.URL.Query()
+	reqQuery := make(map[string]string, len(query))
+	for k, v := range query {
+		reqQuery[k] = strings.Join(v, ",")
+	}
+	entry.Request.Query = reqQuery
+	header := make(map[string]string, len(r.Header))
+	for k, v := range r.Header {
+		header[k] = strings.Join(v, ",")
+	}
+	entry.Request.Header = header
+
+	rh := w.Header()
+	header = make(map[string]string, len(rh))
+	for k, v := range rh {
+		header[k] = strings.Join(v, ",")
+	}
+	entry.Response.Header = header
+	entry.Response.StatusCode = statusCode
+	entry.Response.Status = http.StatusText(statusCode)
+	entry.Response.Error = getResponseErrorMessage(r)
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		log.LogErrorf("audit entry json marshal failed: %v", err)
+		return
+	}
+
+	for _, logger := range loggers {
+		if logger != nil {
+			go func(logger AuditLogger) {
+				if err = logger.Send(data); err != nil {
+					log.LogErrorf("send to external '%s' failed: %v", logger.Name(), err)
+				}
+			}(logger)
+		}
+	}
+}

--- a/objectnode/audit_kafka.go
+++ b/objectnode/audit_kafka.go
@@ -1,0 +1,84 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"github.com/Shopify/sarama"
+)
+
+type KafkaAuditConfig struct {
+	Enable bool `json:"enable"`
+	IsTest bool `json:"-"`
+
+	KafkaConfig
+}
+
+type KafkaAudit struct {
+	name     string
+	producer sarama.SyncProducer
+
+	KafkaAuditConfig
+}
+
+func NewKafkaAudit(id string, conf KafkaAuditConfig) (*KafkaAudit, error) {
+	if err := conf.FixConfig(); err != nil {
+		return nil, err
+	}
+
+	producer, err := conf.BuildSyncProducer()
+	if err != nil {
+		return nil, err
+	}
+
+	a := &KafkaAudit{
+		name:             "kafka-audit-" + id,
+		producer:         producer,
+		KafkaAuditConfig: conf,
+	}
+	if !conf.IsTest {
+		if err = a.sendTest(); err != nil {
+			a.producer.Close()
+			return nil, err
+		}
+	}
+
+	return a, nil
+}
+
+func (k *KafkaAudit) sendTest() error {
+	return k.Send([]byte("{}"))
+}
+
+func (k *KafkaAudit) Name() string {
+	return k.name
+}
+
+func (k *KafkaAudit) Send(data []byte) error {
+	_, _, err := k.producer.SendMessage(&sarama.ProducerMessage{
+		Topic: k.Topic,
+		Value: sarama.ByteEncoder(data),
+	})
+
+	return err
+}
+
+func (k *KafkaAudit) Close() error {
+	var err error
+	if k.producer != nil {
+		err = k.producer.Close()
+	}
+
+	return err
+}

--- a/objectnode/audit_kafka_test.go
+++ b/objectnode/audit_kafka_test.go
@@ -1,0 +1,101 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	auditKafkaUnitTestBroker = "127.0.0.1:9095"
+	auditKafkaUnitTestTopic  = "audit-kafka-unit-test"
+)
+
+func TestNewKafkaAudit(t *testing.T) {
+	mockFetchResponse := sarama.NewMockFetchResponse(t, 1)
+	broker := sarama.NewMockBrokerAddr(t, 0, auditKafkaUnitTestBroker)
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetLeader(auditKafkaUnitTestTopic, 0, broker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(auditKafkaUnitTestTopic, 0, sarama.OffsetOldest, 0).
+			SetOffset(auditKafkaUnitTestTopic, 0, sarama.OffsetNewest, 2345),
+		"FetchRequest": mockFetchResponse,
+	})
+	defer broker.Close()
+
+	conf := KafkaAuditConfig{IsTest: true}
+	_, err := NewKafkaAudit("cubefs", conf)
+	require.Error(t, err)
+
+	conf.Brokers = broker.Addr()
+	_, err = NewKafkaAudit("cubefs", conf)
+	require.Error(t, err)
+
+	conf.Topic = auditKafkaUnitTestTopic
+	conf.Version = "invalid version"
+	_, err = NewKafkaAudit("cubefs", conf)
+	require.Error(t, err)
+
+	conf.Version = sarama.V2_1_0_0.String()
+	audit, err := NewKafkaAudit("cubefs", conf)
+	require.NoError(t, err)
+	require.NoError(t, audit.Close())
+}
+
+func TestKafkaAudit(t *testing.T) {
+	mockFetchResponse := sarama.NewMockFetchResponse(t, 1)
+	broker := sarama.NewMockBrokerAddr(t, 0, auditKafkaUnitTestBroker)
+	broker.SetHandlerByMap(map[string]sarama.MockResponse{
+		"MetadataRequest": sarama.NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()).
+			SetLeader(auditKafkaUnitTestTopic, 0, broker.BrokerID()),
+		"OffsetRequest": sarama.NewMockOffsetResponse(t).
+			SetOffset(auditKafkaUnitTestTopic, 0, sarama.OffsetOldest, 0).
+			SetOffset(auditKafkaUnitTestTopic, 0, sarama.OffsetNewest, 2345),
+		"FetchRequest": mockFetchResponse,
+	})
+	defer broker.Close()
+
+	conf := KafkaAuditConfig{IsTest: true}
+	conf.Topic = auditKafkaUnitTestTopic
+	conf.Brokers = broker.Addr()
+	audit, err := NewKafkaAudit("cubefs", conf)
+	require.NoError(t, err)
+	require.Equal(t, "kafka-audit-cubefs", audit.Name())
+
+	mockProducer := mocks.NewSyncProducer(t, nil)
+	audit.producer = mockProducer
+
+	// send test
+	mockProducer.ExpectSendMessageAndSucceed()
+	require.NoError(t, audit.sendTest())
+
+	// send data
+	entry := &AuditEntry{}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	mockProducer.ExpectSendMessageAndSucceed()
+	require.NoError(t, audit.Send(data))
+
+	// audit is closed
+	require.NoError(t, audit.Close())
+}

--- a/objectnode/audit_webhook.go
+++ b/objectnode/audit_webhook.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cubefs/cubefs/blobstore/util/retry"
+)
+
+var AuditWebhookUserAgent = "Golang cubefs/objectnode audit webhook"
+
+type WebhookAuditConfig struct {
+	Enable bool `json:"enable"`
+
+	WebhookConfig
+}
+
+type WebhookAudit struct {
+	name   string
+	client *http.Client
+
+	WebhookAuditConfig
+}
+
+func NewWebhookAudit(id string, conf WebhookAuditConfig) (*WebhookAudit, error) {
+	if err := conf.FixConfig(); err != nil {
+		return nil, err
+	}
+
+	client, err := conf.BuildClient()
+	if err != nil {
+		return nil, err
+	}
+
+	a := &WebhookAudit{
+		name:               "webhook-audit-" + id,
+		client:             client,
+		WebhookAuditConfig: conf,
+	}
+	if err = a.sendTest(); err != nil {
+		return nil, fmt.Errorf("webhook: send test data to '%s' failed: %v", a.Endpoint, err)
+	}
+
+	return a, nil
+}
+
+func (w *WebhookAudit) sendTest() error {
+	return w.send([]byte("{}"))
+}
+
+func (w *WebhookAudit) send(data []byte) error {
+	req, err := http.NewRequest(http.MethodPost, w.Endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set(ContentType, ValueContentTypeJSON)
+	req.Header.Set(UserAgent, AuditWebhookUserAgent)
+	if w.Authorization != "" {
+		req.Header.Set(Authorization, w.Authorization)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	resp, err := w.client.Do(req.WithContext(ctx))
+	if resp != nil && resp.Body != nil {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+	if err != nil || resp.StatusCode/100 == 2 {
+		return err
+	}
+
+	return fmt.Errorf("%s returns '%s' statuscode", w.Endpoint, resp.Status)
+}
+
+func (w *WebhookAudit) Name() string {
+	return w.name
+}
+
+func (w *WebhookAudit) Send(data []byte) error {
+	return retry.ExponentialBackoff(5, 100).On(func() error {
+		return w.send(data)
+	})
+}
+
+func (w *WebhookAudit) Close() error {
+	return nil
+}

--- a/objectnode/audit_webhook_test.go
+++ b/objectnode/audit_webhook_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWebhookAudit(t *testing.T) {
+	config := WebhookAuditConfig{}
+	_, err := NewWebhookAudit("cubefs", config)
+	require.Error(t, err)
+
+	config.Endpoint = "127.0.0.1:80808"
+	_, err = NewWebhookAudit("cubefs", config)
+	require.Error(t, err)
+
+	config.Endpoint = "tcp://127.0.0.1:80808"
+	_, err = NewWebhookAudit("cubefs", config)
+	require.Error(t, err)
+
+	config.Endpoint = "http://127.0.0.1:80808"
+	_, err = NewWebhookAudit("cubefs", config)
+	require.Error(t, err)
+
+	server := CreateWebhookTestServer()
+	defer server.Close()
+	config.Endpoint = server.URL
+	webhook, err := NewWebhookAudit("cubefs", config)
+	require.NoError(t, err)
+	require.NoError(t, webhook.Close())
+}
+
+func CreateWebhookTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestWebhookAudit(t *testing.T) {
+	server := CreateWebhookTestServer()
+	defer server.Close()
+
+	conf := WebhookAuditConfig{}
+	conf.Endpoint = server.URL
+	audit, err := NewWebhookAudit("cubefs", conf)
+	require.NoError(t, err)
+	require.Equal(t, "webhook-audit-cubefs", audit.Name())
+
+	// send test
+	require.NoError(t, audit.sendTest())
+
+	// send data
+	entry := &AuditEntry{}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, audit.Send(data))
+
+	// audit is closed
+	require.NoError(t, audit.Close())
+}

--- a/objectnode/auth.go
+++ b/objectnode/auth.go
@@ -218,8 +218,9 @@ func (o *ObjectNode) validateAuthInfo(r *http.Request, auth Auther) (err error) 
 		uid, ak, sk = sts.UserInfo.UserID, sts.UserInfo.AccessKey, sts.FedSK
 	}
 
-	mux.Vars(r)[ContextKeyUid] = uid
 	mux.Vars(r)[ContextKeyAccessKey] = ak
+	mux.Vars(r)[ContextKeyRequester] = uid
+
 	if !param.action.IsNone() && o.signatureIgnoredActions.Contains(param.action) {
 		return nil
 	}

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -44,6 +44,7 @@ const (
 	Connection         = "Connection"
 	Signature          = "Signature"
 	Origin             = "Origin"
+	UserAgent          = "User-Agent"
 
 	AccessControlRequestMethod    = "Access-Control-Request-Method"
 	AccessControlRequestHeaders   = "Access-Control-Request-Headers"

--- a/objectnode/http_transport.go
+++ b/objectnode/http_transport.go
@@ -1,0 +1,98 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+type TransportConfig struct {
+	// DialTimeoutMs dial timeout in milliseconds
+	DialTimeoutMs int64 `json:"dial_timeout_ms"`
+	// ResponseHeaderTimeoutMs response header timeout after send the request
+	ResponseHeaderTimeoutMs int64 `json:"response_header_timeout_ms"`
+
+	MaxConnsPerHost     int `json:"max_conns_per_host"`
+	MaxIdleConns        int `json:"max_idle_conns"`
+	MaxIdleConnsPerHost int `json:"max_idle_conns_per_host"`
+	// IdleConnTimeout is the maximum amount of time an idle (keep-alive)
+	// connection will remain idle before closing itself.
+	IdleConnTimeoutMs int64 `json:"idle_conn_timeout_ms"`
+	// DisableCompression, if true, prevents the Transport from
+	// requesting compression with an "Accept-Encoding: gzip"
+	DisableCompression bool `json:"disable_compression"`
+
+	// RootRAFile is the root CA file path
+	RootRAFile string `json:"root_ra_file"`
+}
+
+func (c *TransportConfig) FixConfig() error {
+	if c.DialTimeoutMs <= 0 {
+		c.DialTimeoutMs = 5 * 1000
+	}
+	if c.ResponseHeaderTimeoutMs <= 0 {
+		c.ResponseHeaderTimeoutMs = 60 * 1000
+	}
+	if c.MaxConnsPerHost <= 0 {
+		c.MaxConnsPerHost = 1024
+	}
+	if c.MaxIdleConns <= 0 {
+		c.MaxIdleConns = 1024
+	}
+	if c.MaxIdleConnsPerHost <= 0 {
+		c.MaxIdleConnsPerHost = 10
+	}
+	if c.IdleConnTimeoutMs <= 0 {
+		c.IdleConnTimeoutMs = 15 * 1000
+	}
+	if !c.DisableCompression {
+		c.DisableCompression = true
+	}
+
+	return nil
+}
+
+// BuildTransport builds an HTTP transport based on the TransportConfig.
+func (c *TransportConfig) BuildTransport() (*http.Transport, error) {
+	var tlsConfig tls.Config
+	if c.RootRAFile != "" {
+		rootCAs, err := GetRootCAs(c.RootRAFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = rootCAs
+	}
+	dialer := &net.Dialer{
+		KeepAlive: 30 * time.Second,
+		Timeout:   time.Duration(c.DialTimeoutMs) * time.Millisecond,
+	}
+
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxConnsPerHost:       c.MaxConnsPerHost,
+		MaxIdleConns:          c.MaxIdleConns,
+		MaxIdleConnsPerHost:   c.MaxIdleConnsPerHost,
+		IdleConnTimeout:       time.Duration(c.IdleConnTimeoutMs) * time.Millisecond,
+		ResponseHeaderTimeout: time.Duration(c.ResponseHeaderTimeoutMs) * time.Millisecond,
+		DisableCompression:    c.DisableCompression,
+		WriteBufferSize:       1 << 16,
+		ReadBufferSize:        1 << 16,
+		TLSClientConfig:       &tlsConfig,
+		DialContext:           dialer.DialContext,
+	}, nil
+}

--- a/objectnode/kafka.go
+++ b/objectnode/kafka.go
@@ -1,0 +1,121 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"crypto/tls"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/Shopify/sarama"
+)
+
+type KafkaConfig struct {
+	Brokers  string `json:"brokers"`
+	Topic    string `json:"topic"`
+	Version  string `json:"version"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	TLS      struct {
+		Enable     bool   `json:"enable"`
+		SkipVerify bool   `json:"skip_verify"`
+		ClientAuth int    `json:"client_auth"`
+		ClientKey  string `json:"client_key"`
+		ClientCert string `json:"client_cert"`
+		RootCAFile string `json:"root_ca_file"`
+	} `json:"tls"`
+	TimeoutMs int64 `json:"timeout_ms"`
+}
+
+// FixConfig validates and fixes the configuration.
+func (c *KafkaConfig) FixConfig() error {
+	if c.Brokers == "" || len(strings.Split(c.Brokers, ",")) <= 0 {
+		return errors.New("kafka: no broker found")
+	}
+	if c.Topic == "" {
+		return errors.New("kafka: no topic found")
+	}
+	if c.Version != "" {
+		if _, err := sarama.ParseKafkaVersion(c.Version); err != nil {
+			return err
+		}
+	}
+	if c.Username != "" && c.Password == "" || c.Username == "" && c.Password != "" {
+		return errors.New("kafka: username and password must be a pair")
+	}
+	if c.TLS.ClientKey != "" && c.TLS.ClientCert == "" || c.TLS.ClientKey == "" && c.TLS.ClientCert != "" {
+		return errors.New("kafka: client_cert and client_key must be a pair")
+	}
+	if c.TimeoutMs <= 0 {
+		c.TimeoutMs = 5000
+	}
+
+	return nil
+}
+
+// newSaramaConfig creates a new Sarama configuration.
+func (c *KafkaConfig) newSaramaConfig() (*sarama.Config, error) {
+	cfg := sarama.NewConfig()
+	cfg.Version = sarama.V2_1_0_0
+	if c.Version != "" {
+		version, err := sarama.ParseKafkaVersion(c.Version)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Version = version
+	}
+	cfg.Metadata.Retry.Max = 2
+	cfg.Metadata.RefreshFrequency = 120 * time.Second
+
+	cfg.Producer.RequiredAcks = sarama.WaitForAll
+	cfg.Producer.Return.Errors = true
+	cfg.Producer.Return.Successes = true
+	cfg.Producer.Timeout = time.Duration(c.TimeoutMs) * time.Millisecond
+
+	if c.Username != "" && c.Password != "" {
+		cfg.Net.SASL.Enable = true
+		cfg.Net.SASL.User = c.Username
+		cfg.Net.SASL.Password = c.Password
+	}
+	cfg.Net.KeepAlive = 60 * time.Second
+
+	tslConfig, err := NewTLSConfig(c.TLS.ClientCert, c.TLS.ClientKey)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Net.TLS.Enable = c.TLS.Enable
+	cfg.Net.TLS.Config = tslConfig
+	cfg.Net.TLS.Config.InsecureSkipVerify = c.TLS.SkipVerify
+	cfg.Net.TLS.Config.ClientAuth = tls.ClientAuthType(c.TLS.ClientAuth)
+	if c.TLS.RootCAFile != "" {
+		if cfg.Net.TLS.Config.RootCAs, err = GetRootCAs(c.TLS.RootCAFile); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg, nil
+}
+
+// BuildSyncProducer creates a synchronous Kafka producer.
+// Make sure to call FixConfig before calling it to validate and fix the configuration.
+func (c *KafkaConfig) BuildSyncProducer() (sarama.SyncProducer, error) {
+	cfg, err := c.newSaramaConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return sarama.NewSyncProducer(strings.Split(c.Brokers, ","), cfg)
+}

--- a/objectnode/result.go
+++ b/objectnode/result.go
@@ -15,6 +15,8 @@
 package objectnode
 
 import (
+	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"net/url"
 	"regexp"
@@ -39,6 +41,16 @@ func UnmarshalXMLEntity(bytes []byte, data interface{}) error {
 		return err
 	}
 	return nil
+}
+
+func ParseJSONEntity(raw interface{}, entity interface{}) error {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(entity)
 }
 
 type LocationResponse struct {

--- a/objectnode/webhook.go
+++ b/objectnode/webhook.go
@@ -1,0 +1,70 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type WebhookConfig struct {
+	Endpoint      string          `json:"endpoint"`
+	Authorization string          `json:"authorization"`
+	Proxy         string          `json:"proxy"`
+	Transport     TransportConfig `json:"transport"`
+}
+
+// FixConfig validates and fixes the configuration.
+func (c *WebhookConfig) FixConfig() error {
+	if c.Endpoint == "" {
+		return errors.New("webhook: no endpoint found")
+	}
+
+	u, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return fmt.Errorf("webhook: invalid endpoint '%s'", c.Endpoint)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("webhook: unsupported scheme in '%s'", c.Endpoint)
+	}
+
+	return c.Transport.FixConfig()
+}
+
+// BuildClient creates a HTTP client.
+// Make sure to call FixConfig before calling it to validate and fix the configuration.
+func (c *WebhookConfig) BuildClient() (*http.Client, error) {
+	transport, err := c.Transport.BuildTransport()
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Proxy != "" {
+		proxyURL, err := url.Parse(c.Proxy)
+		if err != nil {
+			return nil, err
+		}
+		if proxyURL != nil {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		}
+	}
+
+	return &http.Client{Transport: transport}, nil
+}

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -75,6 +75,11 @@ func (c *Config) parse(fileName string) error {
 	return err
 }
 
+// GetValue returns the raw data for the config key.
+func (c *Config) GetValue(key string) interface{} {
+	return c.data[key]
+}
+
 // GetString returns a string for the config key.
 func (c *Config) GetString(key string) string {
 	x, present := c.data[key]

--- a/vendor/github.com/Shopify/sarama/mocks/README.md
+++ b/vendor/github.com/Shopify/sarama/mocks/README.md
@@ -1,0 +1,13 @@
+# sarama/mocks
+
+The `mocks` subpackage includes mock implementations that implement the interfaces of the major sarama types.
+You can use them to test your sarama applications using dependency injection.
+
+The following mock objects are available:
+
+- [Consumer](https://pkg.go.dev/github.com/Shopify/sarama/mocks#Consumer), which will create [PartitionConsumer](https://pkg.go.dev/github.com/Shopify/sarama/mocks#PartitionConsumer) mocks.
+- [AsyncProducer](https://pkg.go.dev/github.com/Shopify/sarama/mocks#AsyncProducer)
+- [SyncProducer](https://pkg.go.dev/github.com/Shopify/sarama/mocks#SyncProducer)
+
+The mocks allow you to set expectations on them. When you close the mocks, the expectations will be verified,
+and the results will be reported to the `*testing.T` object you provided when creating the mock.

--- a/vendor/github.com/Shopify/sarama/mocks/async_producer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/async_producer.go
@@ -1,0 +1,216 @@
+package mocks
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+// AsyncProducer implements sarama's Producer interface for testing purposes.
+// Before you can send messages to it's Input channel, you have to set expectations
+// so it knows how to handle the input; it returns an error if the number of messages
+// received is bigger then the number of expectations set. You can also set a
+// function in each expectation so that the message is checked by this function and
+// an error is returned if the match fails.
+type AsyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	closed       chan struct{}
+	input        chan *sarama.ProducerMessage
+	successes    chan *sarama.ProducerMessage
+	errors       chan *sarama.ProducerError
+	lastOffset   int64
+	*TopicConfig
+}
+
+// NewAsyncProducer instantiates a new Producer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is used to determine whether it
+// should ack successes on the Successes channel and to handle partitioning.
+func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	mp := &AsyncProducer{
+		t:            t,
+		closed:       make(chan struct{}),
+		expectations: make([]*producerExpectation, 0),
+		input:        make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		successes:    make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		errors:       make(chan *sarama.ProducerError, config.ChannelBufferSize),
+		TopicConfig:  NewTopicConfig(),
+	}
+
+	go func() {
+		defer func() {
+			close(mp.successes)
+			close(mp.errors)
+			close(mp.closed)
+		}()
+
+		partitioners := make(map[string]sarama.Partitioner, 1)
+
+		for msg := range mp.input {
+			partitioner := partitioners[msg.Topic]
+			if partitioner == nil {
+				partitioner = config.Producer.Partitioner(msg.Topic)
+				partitioners[msg.Topic] = partitioner
+			}
+			mp.l.Lock()
+			if mp.expectations == nil || len(mp.expectations) == 0 {
+				mp.expectations = nil
+				mp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+			} else {
+				expectation := mp.expectations[0]
+				mp.expectations = mp.expectations[1:]
+
+				partition, err := partitioner.Partition(msg, mp.partitions(msg.Topic))
+				if err != nil {
+					mp.t.Errorf("Partitioner returned an error: %s", err.Error())
+					mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+				} else {
+					msg.Partition = partition
+					if expectation.CheckFunction != nil {
+						err := expectation.CheckFunction(msg)
+						if err != nil {
+							mp.t.Errorf("Check function returned an error: %s", err.Error())
+							mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+						}
+					}
+					if errors.Is(expectation.Result, errProduceSuccess) {
+						mp.lastOffset++
+						if config.Producer.Return.Successes {
+							msg.Offset = mp.lastOffset
+							mp.successes <- msg
+						}
+					} else {
+						if config.Producer.Return.Errors {
+							mp.errors <- &sarama.ProducerError{Err: expectation.Result, Msg: msg}
+						}
+					}
+				}
+			}
+			mp.l.Unlock()
+		}
+
+		mp.l.Lock()
+		if len(mp.expectations) > 0 {
+			mp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(mp.expectations))
+		}
+		mp.l.Unlock()
+	}()
+
+	return mp
+}
+
+////////////////////////////////////////////////
+// Implement Producer interface
+////////////////////////////////////////////////
+
+// AsyncClose corresponds with the AsyncClose method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) AsyncClose() {
+	close(mp.input)
+}
+
+// Close corresponds with the Close method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) Close() error {
+	mp.AsyncClose()
+	<-mp.closed
+	return nil
+}
+
+// Input corresponds with the Input method of sarama's Producer implementation.
+// You have to set expectations on the mock producer before writing messages to the Input
+// channel, so it knows how to handle them. If there is no more remaining expectations and
+// a messages is written to the Input channel, the mock producer will write an error to the test
+// state object.
+func (mp *AsyncProducer) Input() chan<- *sarama.ProducerMessage {
+	return mp.input
+}
+
+// Successes corresponds with the Successes method of sarama's Producer implementation.
+func (mp *AsyncProducer) Successes() <-chan *sarama.ProducerMessage {
+	return mp.successes
+}
+
+// Errors corresponds with the Errors method of sarama's Producer implementation.
+func (mp *AsyncProducer) Errors() <-chan *sarama.ProducerError {
+	return mp.errors
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectInputWithMessageCheckerFunctionAndSucceed sets an expectation on the mock producer that a
+// message will be provided on the input channel. The mock producer will call the given function to
+// check the message. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it produced successfully, i.e. it will make it
+// available on the Successes channel if the Producer.Return.Successes setting is set to true.
+func (mp *AsyncProducer) ExpectInputWithMessageCheckerFunctionAndSucceed(cf MessageChecker) *AsyncProducer {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+
+	return mp
+}
+
+// ExpectInputWithMessageCheckerFunctionAndFail sets an expectation on the mock producer that a
+// message will be provided on the input channel. The mock producer will first call the given
+// function to check the message. If an error is returned it will be made available on the Errors
+// channel otherwise the mock will handle the message as if it failed to produce successfully. This
+// means it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputWithMessageCheckerFunctionAndFail(cf MessageChecker, err error) *AsyncProducer {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+
+	return mp
+}
+
+// ExpectInputWithCheckerFunctionAndSucceed sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will call the given function to check
+// the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it produced successfully, i.e. it will make
+// it available on the Successes channel if the Producer.Return.Successes setting is set to true.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndSucceed(cf ValueChecker) *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndSucceed(messageValueChecker(cf))
+
+	return mp
+}
+
+// ExpectInputWithCheckerFunctionAndFail sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will first call the given function to
+// check the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it failed to produce successfully. This means
+// it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndFail(cf ValueChecker, err error) *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndFail(messageValueChecker(cf), err)
+
+	return mp
+}
+
+// ExpectInputAndSucceed sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it is produced successfully,
+// i.e. it will make it available on the Successes channel if the Producer.Return.Successes setting
+// is set to true.
+func (mp *AsyncProducer) ExpectInputAndSucceed() *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndSucceed(nil)
+
+	return mp
+}
+
+// ExpectInputAndFail sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it failed to produce
+// successfully. This means it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputAndFail(err error) *AsyncProducer {
+	mp.ExpectInputWithMessageCheckerFunctionAndFail(nil, err)
+
+	return mp
+}

--- a/vendor/github.com/Shopify/sarama/mocks/consumer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/consumer.go
@@ -1,0 +1,435 @@
+package mocks
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/Shopify/sarama"
+)
+
+// Consumer implements sarama's Consumer interface for testing purposes.
+// Before you can start consuming from this consumer, you have to register
+// topic/partitions using ExpectConsumePartition, and set expectations on them.
+type Consumer struct {
+	l                  sync.Mutex
+	t                  ErrorReporter
+	config             *sarama.Config
+	partitionConsumers map[string]map[int32]*PartitionConsumer
+	metadata           map[string][]int32
+}
+
+// NewConsumer returns a new mock Consumer instance. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument can be set to nil.
+func NewConsumer(t ErrorReporter, config *sarama.Config) *Consumer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+
+	c := &Consumer{
+		t:                  t,
+		config:             config,
+		partitionConsumers: make(map[string]map[int32]*PartitionConsumer),
+	}
+	return c
+}
+
+///////////////////////////////////////////////////
+// Consumer interface implementation
+///////////////////////////////////////////////////
+
+// ConsumePartition implements the ConsumePartition method from the sarama.Consumer interface.
+// Before you can start consuming a partition, you have to set expectations on it using
+// ExpectConsumePartition. You can only consume a partition once per consumer.
+func (c *Consumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil || c.partitionConsumers[topic][partition] == nil {
+		c.t.Errorf("No expectations set for %s/%d", topic, partition)
+		return nil, errOutOfExpectations
+	}
+
+	pc := c.partitionConsumers[topic][partition]
+	if pc.consumed {
+		return nil, sarama.ConfigurationError("The topic/partition is already being consumed")
+	}
+
+	if pc.offset != AnyOffset && pc.offset != offset {
+		c.t.Errorf("Unexpected offset when calling ConsumePartition for %s/%d. Expected %d, got %d.", topic, partition, pc.offset, offset)
+	}
+
+	pc.consumed = true
+	return pc, nil
+}
+
+// Topics returns a list of topics, as registered with SetTopicMetadata
+func (c *Consumer) Topics() ([]string, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Topics. Initialize the mock's topic metadata with SetTopicMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+
+	var result []string
+	for topic := range c.metadata {
+		result = append(result, topic)
+	}
+	return result, nil
+}
+
+// Partitions returns the list of parititons for the given topic, as registered with SetTopicMetadata
+func (c *Consumer) Partitions(topic string) ([]int32, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Partitions. Initialize the mock's topic metadata with SetTopicMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+	if c.metadata[topic] == nil {
+		return nil, sarama.ErrUnknownTopicOrPartition
+	}
+
+	return c.metadata[topic], nil
+}
+
+func (c *Consumer) HighWaterMarks() map[string]map[int32]int64 {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	hwms := make(map[string]map[int32]int64, len(c.partitionConsumers))
+	for topic, partitionConsumers := range c.partitionConsumers {
+		hwm := make(map[int32]int64, len(partitionConsumers))
+		for partition, pc := range partitionConsumers {
+			hwm[partition] = pc.HighWaterMarkOffset()
+		}
+		hwms[topic] = hwm
+	}
+
+	return hwms
+}
+
+// Close implements the Close method from the sarama.Consumer interface. It will close
+// all registered PartitionConsumer instances.
+func (c *Consumer) Close() error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			_ = partitionConsumer.Close()
+		}
+	}
+
+	return nil
+}
+
+// Pause implements Consumer.
+func (c *Consumer) Pause(topicPartitions map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for topic, partitions := range topicPartitions {
+		for _, partition := range partitions {
+			if topicConsumers, ok := c.partitionConsumers[topic]; ok {
+				if partitionConsumer, ok := topicConsumers[partition]; ok {
+					partitionConsumer.Pause()
+				}
+			}
+		}
+	}
+}
+
+// Resume implements Consumer.
+func (c *Consumer) Resume(topicPartitions map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for topic, partitions := range topicPartitions {
+		for _, partition := range partitions {
+			if topicConsumers, ok := c.partitionConsumers[topic]; ok {
+				if partitionConsumer, ok := topicConsumers[partition]; ok {
+					partitionConsumer.Resume()
+				}
+			}
+		}
+	}
+}
+
+// PauseAll implements Consumer.
+func (c *Consumer) PauseAll() {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			partitionConsumer.Pause()
+		}
+	}
+}
+
+// ResumeAll implements Consumer.
+func (c *Consumer) ResumeAll() {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			partitionConsumer.Resume()
+		}
+	}
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// SetTopicMetadata sets the clusters topic/partition metadata,
+// which will be returned by Topics() and Partitions().
+func (c *Consumer) SetTopicMetadata(metadata map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	c.metadata = metadata
+}
+
+// ExpectConsumePartition will register a topic/partition, so you can set expectations on it.
+// The registered PartitionConsumer will be returned, so you can set expectations
+// on it using method chaining. Once a topic/partition is registered, you are
+// expected to start consuming it using ConsumePartition. If that doesn't happen,
+// an error will be written to the error reporter once the mock consumer is closed. It will
+// also expect that the
+func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset int64) *PartitionConsumer {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil {
+		c.partitionConsumers[topic] = make(map[int32]*PartitionConsumer)
+	}
+
+	if c.partitionConsumers[topic][partition] == nil {
+		highWatermarkOffset := offset
+		if offset == sarama.OffsetOldest {
+			highWatermarkOffset = 0
+		}
+
+		c.partitionConsumers[topic][partition] = &PartitionConsumer{
+			highWaterMarkOffset: highWatermarkOffset,
+			t:                   c.t,
+			topic:               topic,
+			partition:           partition,
+			offset:              offset,
+			messages:            make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
+			suppressedMessages:  make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
+			errors:              make(chan *sarama.ConsumerError, c.config.ChannelBufferSize),
+		}
+	}
+
+	return c.partitionConsumers[topic][partition]
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer mock type
+///////////////////////////////////////////////////
+
+// PartitionConsumer implements sarama's PartitionConsumer interface for testing purposes.
+// It is returned by the mock Consumers ConsumePartitionMethod, but only if it is
+// registered first using the Consumer's ExpectConsumePartition method. Before consuming the
+// Errors and Messages channel, you should specify what values will be provided on these
+// channels using YieldMessage and YieldError.
+type PartitionConsumer struct {
+	highWaterMarkOffset           int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	l                             sync.Mutex
+	t                             ErrorReporter
+	topic                         string
+	partition                     int32
+	offset                        int64
+	messages                      chan *sarama.ConsumerMessage
+	suppressedMessages            chan *sarama.ConsumerMessage
+	suppressedHighWaterMarkOffset int64
+	errors                        chan *sarama.ConsumerError
+	singleClose                   sync.Once
+	consumed                      bool
+	errorsShouldBeDrained         bool
+	messagesShouldBeDrained       bool
+	paused                        bool
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer interface implementation
+///////////////////////////////////////////////////
+
+// AsyncClose implements the AsyncClose method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) AsyncClose() {
+	pc.singleClose.Do(func() {
+		close(pc.suppressedMessages)
+		close(pc.messages)
+		close(pc.errors)
+	})
+}
+
+// Close implements the Close method from the sarama.PartitionConsumer interface. It will
+// verify whether the partition consumer was actually started.
+func (pc *PartitionConsumer) Close() error {
+	if !pc.consumed {
+		pc.t.Errorf("Expectations set on %s/%d, but no partition consumer was started.", pc.topic, pc.partition)
+		return errPartitionConsumerNotStarted
+	}
+
+	if pc.errorsShouldBeDrained && len(pc.errors) > 0 {
+		pc.t.Errorf("Expected the errors channel for %s/%d to be drained on close, but found %d errors.", pc.topic, pc.partition, len(pc.errors))
+	}
+
+	if pc.messagesShouldBeDrained && len(pc.messages) > 0 {
+		pc.t.Errorf("Expected the messages channel for %s/%d to be drained on close, but found %d messages.", pc.topic, pc.partition, len(pc.messages))
+	}
+
+	pc.AsyncClose()
+
+	var (
+		closeErr error
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		errs := make(sarama.ConsumerErrors, 0)
+		for err := range pc.errors {
+			errs = append(errs, err)
+		}
+
+		if len(errs) > 0 {
+			closeErr = errs
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range pc.messages {
+			// drain
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range pc.suppressedMessages {
+			// drain
+		}
+	}()
+
+	wg.Wait()
+	return closeErr
+}
+
+// Errors implements the Errors method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	return pc.errors
+}
+
+// Messages implements the Messages method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return pc.messages
+}
+
+func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {
+	return atomic.LoadInt64(&pc.highWaterMarkOffset) + 1
+}
+
+// Pause implements the Pause method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Pause() {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	pc.suppressedHighWaterMarkOffset = atomic.LoadInt64(&pc.highWaterMarkOffset)
+
+	pc.paused = true
+}
+
+// Resume implements the Resume method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Resume() {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	pc.highWaterMarkOffset = atomic.LoadInt64(&pc.suppressedHighWaterMarkOffset)
+	for len(pc.suppressedMessages) > 0 {
+		msg := <-pc.suppressedMessages
+		pc.messages <- msg
+	}
+
+	pc.paused = false
+}
+
+// IsPaused implements the IsPaused method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) IsPaused() bool {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	return pc.paused
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// YieldMessage will yield a messages Messages channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this
+// message was consumed from the Messages channel, because there are legitimate
+// reasons forthis not to happen. ou can call ExpectMessagesDrainedOnClose so it will
+// verify that the channel is empty on close.
+func (pc *PartitionConsumer) YieldMessage(msg *sarama.ConsumerMessage) *PartitionConsumer {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	msg.Topic = pc.topic
+	msg.Partition = pc.partition
+
+	if pc.paused {
+		msg.Offset = atomic.AddInt64(&pc.suppressedHighWaterMarkOffset, 1) - 1
+		pc.suppressedMessages <- msg
+	} else {
+		msg.Offset = atomic.AddInt64(&pc.highWaterMarkOffset, 1) - 1
+		pc.messages <- msg
+	}
+
+	return pc
+}
+
+// YieldError will yield an error on the Errors channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this error was
+// consumed from the Errors channel, because there are legitimate reasons for this
+// not to happen. You can call ExpectErrorsDrainedOnClose so it will verify that
+// the channel is empty on close.
+func (pc *PartitionConsumer) YieldError(err error) *PartitionConsumer {
+	pc.errors <- &sarama.ConsumerError{
+		Topic:     pc.topic,
+		Partition: pc.partition,
+		Err:       err,
+	}
+
+	return pc
+}
+
+// ExpectMessagesDrainedOnClose sets an expectation on the partition consumer
+// that the messages channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectMessagesDrainedOnClose() *PartitionConsumer {
+	pc.messagesShouldBeDrained = true
+
+	return pc
+}
+
+// ExpectErrorsDrainedOnClose sets an expectation on the partition consumer
+// that the errors channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectErrorsDrainedOnClose() *PartitionConsumer {
+	pc.errorsShouldBeDrained = true
+
+	return pc
+}

--- a/vendor/github.com/Shopify/sarama/mocks/mocks.go
+++ b/vendor/github.com/Shopify/sarama/mocks/mocks.go
@@ -1,0 +1,108 @@
+/*
+Package mocks provides mocks that can be used for testing applications
+that use Sarama. The mock types provided by this package implement the
+interfaces Sarama exports, so you can use them for dependency injection
+in your tests.
+
+All mock instances require you to set expectations on them before you
+can use them. It will determine how the mock will behave. If an
+expectation is not met, it will make your test fail.
+
+NOTE: this package currently does not fall under the API stability
+guarantee of Sarama as it is still considered experimental.
+*/
+package mocks
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+)
+
+// ErrorReporter is a simple interface that includes the testing.T methods we use to report
+// expectation violations when using the mock objects.
+type ErrorReporter interface {
+	Errorf(string, ...interface{})
+}
+
+// ValueChecker is a function type to be set in each expectation of the producer mocks
+// to check the value passed.
+type ValueChecker func(val []byte) error
+
+// MessageChecker is a function type to be set in each expectation of the producer mocks
+// to check the message passed.
+type MessageChecker func(*sarama.ProducerMessage) error
+
+// messageValueChecker wraps a ValueChecker into a MessageChecker.
+// Failure to encode the message value will return an error and not call
+// the wrapped ValueChecker.
+func messageValueChecker(f ValueChecker) MessageChecker {
+	if f == nil {
+		return nil
+	}
+	return func(msg *sarama.ProducerMessage) error {
+		val, err := msg.Value.Encode()
+		if err != nil {
+			return fmt.Errorf("Input message encoding failed: %w", err)
+		}
+		return f(val)
+	}
+}
+
+var (
+	errProduceSuccess              error = nil
+	errOutOfExpectations                 = errors.New("No more expectations set on mock")
+	errPartitionConsumerNotStarted       = errors.New("The partition consumer was never started")
+)
+
+const AnyOffset int64 = -1000
+
+type producerExpectation struct {
+	Result        error
+	CheckFunction MessageChecker
+}
+
+// TopicConfig describes a mock topic structure for the mock producers’ partitioning needs.
+type TopicConfig struct {
+	overridePartitions map[string]int32
+	defaultPartitions  int32
+}
+
+// NewTopicConfig makes a configuration which defaults to 32 partitions for every topic.
+func NewTopicConfig() *TopicConfig {
+	return &TopicConfig{
+		overridePartitions: make(map[string]int32, 0),
+		defaultPartitions:  32,
+	}
+}
+
+// SetDefaultPartitions sets the number of partitions any topic not explicitly configured otherwise
+// (by SetPartitions) will have from the perspective of created partitioners.
+func (pc *TopicConfig) SetDefaultPartitions(n int32) {
+	pc.defaultPartitions = n
+}
+
+// SetPartitions sets the number of partitions the partitioners will see for specific topics. This
+// only applies to messages produced after setting them.
+func (pc *TopicConfig) SetPartitions(partitions map[string]int32) {
+	for p, n := range partitions {
+		pc.overridePartitions[p] = n
+	}
+}
+
+func (pc *TopicConfig) partitions(topic string) int32 {
+	if n, found := pc.overridePartitions[topic]; found {
+		return n
+	}
+	return pc.defaultPartitions
+}
+
+// NewTestConfig returns a config meant to be used by tests.
+// Due to inconsistencies with the request versions the clients send using the default Kafka version
+// and the response versions our mocks use, we default to the minimum Kafka version in most tests
+func NewTestConfig() *sarama.Config {
+	config := sarama.NewConfig()
+	config.Version = sarama.MinVersion
+	return config
+}

--- a/vendor/github.com/Shopify/sarama/mocks/sync_producer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/sync_producer.go
@@ -1,0 +1,209 @@
+package mocks
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+// SyncProducer implements sarama's SyncProducer interface for testing purposes.
+// Before you can use it, you have to set expectations on the mock SyncProducer
+// to tell it how to handle calls to SendMessage, so you can easily test success
+// and failure scenarios.
+type SyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	lastOffset   int64
+
+	*TopicConfig
+	newPartitioner sarama.PartitionerConstructor
+	partitioners   map[string]sarama.Partitioner
+}
+
+// NewSyncProducer instantiates a new SyncProducer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is used to handle partitioning.
+func NewSyncProducer(t ErrorReporter, config *sarama.Config) *SyncProducer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	return &SyncProducer{
+		t:              t,
+		expectations:   make([]*producerExpectation, 0),
+		TopicConfig:    NewTopicConfig(),
+		newPartitioner: config.Producer.Partitioner,
+		partitioners:   make(map[string]sarama.Partitioner, 1),
+	}
+}
+
+////////////////////////////////////////////////
+// Implement SyncProducer interface
+////////////////////////////////////////////////
+
+// SendMessage corresponds with the SendMessage method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessage, so it knows
+// how to handle them. You can set a function in each expectation so that the message value
+// checked by this function and an error is returned if the match fails.
+// If there is no more remaining expectation when SendMessage is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		expectation := sp.expectations[0]
+		sp.expectations = sp.expectations[1:]
+		topic := msg.Topic
+		partition, err := sp.partitioner(topic).Partition(msg, sp.partitions(topic))
+		if err != nil {
+			sp.t.Errorf("Partitioner returned an error: %s", err.Error())
+			return -1, -1, err
+		}
+		msg.Partition = partition
+		if expectation.CheckFunction != nil {
+			errCheck := expectation.CheckFunction(msg)
+			if errCheck != nil {
+				sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+				return -1, -1, errCheck
+			}
+		}
+		if errors.Is(expectation.Result, errProduceSuccess) {
+			sp.lastOffset++
+			msg.Offset = sp.lastOffset
+			return 0, msg.Offset, nil
+		}
+		return -1, -1, expectation.Result
+	}
+	sp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+	return -1, -1, errOutOfExpectations
+}
+
+// SendMessages corresponds with the SendMessages method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessages, so it knows
+// how to handle them. If there is no more remaining expectations when SendMessages is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) >= len(msgs) {
+		expectations := sp.expectations[0:len(msgs)]
+		sp.expectations = sp.expectations[len(msgs):]
+
+		for i, expectation := range expectations {
+			topic := msgs[i].Topic
+			partition, err := sp.partitioner(topic).Partition(msgs[i], sp.partitions(topic))
+			if err != nil {
+				sp.t.Errorf("Partitioner returned an error: %s", err.Error())
+				return err
+			}
+			msgs[i].Partition = partition
+			if expectation.CheckFunction != nil {
+				errCheck := expectation.CheckFunction(msgs[i])
+				if errCheck != nil {
+					sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+					return errCheck
+				}
+			}
+			if !errors.Is(expectation.Result, errProduceSuccess) {
+				return expectation.Result
+			}
+			sp.lastOffset++
+			msgs[i].Offset = sp.lastOffset
+		}
+		return nil
+	}
+	sp.t.Errorf("Insufficient expectations set on this mock producer to handle the input messages.")
+	return errOutOfExpectations
+}
+
+func (sp *SyncProducer) partitioner(topic string) sarama.Partitioner {
+	partitioner := sp.partitioners[topic]
+	if partitioner == nil {
+		partitioner = sp.newPartitioner(topic)
+		sp.partitioners[topic] = partitioner
+	}
+	return partitioner
+}
+
+// Close corresponds with the Close method of sarama's SyncProducer implementation.
+// By closing a mock syncproducer, you also tell it that no more SendMessage calls will follow,
+// so it will write an error to the test state if there's any remaining expectations.
+func (sp *SyncProducer) Close() error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		sp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(sp.expectations))
+	}
+
+	return nil
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectSendMessageWithMessageCheckerFunctionAndSucceed sets an expectation on the mock producer
+// that SendMessage will be called. The mock producer will first call the given function to check
+// the message. It will cascade the error of the function, if any, or handle the message as if it
+// produced successfully, i.e. by returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageWithMessageCheckerFunctionAndSucceed(cf MessageChecker) *SyncProducer {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+
+	return sp
+}
+
+// ExpectSendMessageWithMessageCheckerFunctionAndFail sets an expectation on the mock producer that
+// SendMessage will be called. The mock producer will first call the given function to check the
+// message. It will cascade the error of the function, if any, or handle the message as if it
+// failed to produce successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageWithMessageCheckerFunctionAndFail(cf MessageChecker, err error) *SyncProducer {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+
+	return sp
+}
+
+// ExpectSendMessageWithCheckerFunctionAndSucceed sets an expectation on the mock producer that SendMessage
+// will be called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it produced
+// successfully, i.e. by returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndSucceed(cf ValueChecker) *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(messageValueChecker(cf))
+
+	return sp
+}
+
+// ExpectSendMessageWithCheckerFunctionAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it failed
+// to produce successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndFail(cf ValueChecker, err error) *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndFail(messageValueChecker(cf), err)
+
+	return sp
+}
+
+// ExpectSendMessageAndSucceed sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it produced successfully, i.e. by
+// returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageAndSucceed() *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(nil)
+
+	return sp
+}
+
+// ExpectSendMessageAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it failed to produce
+// successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageAndFail(err error) *SyncProducer {
+	sp.ExpectSendMessageWithMessageCheckerFunctionAndFail(nil, err)
+
+	return sp
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add ObjectNode to support the audit log feature, mainly for two points:
1. Local file, write the information requested by the user into the local file.
2. External services, mainly Kafka and Webhook, parse the information requested by the user into a specific AuditEntry and then write it to the external service in the service configuration. This step may increase the time required for the user's request.

Local audit log：
```text
REQ	OBJECT	16977050372829952	PUT	/cfs-bucket/cfs-object-key.json	{"Accept-Encoding":"gzip","BodySize":20,"Content-Length":"20","Content-Type":"application/json","Host":"127.0.0.1:17410","IP":"127.0.0.1","User-Agent":"aws-sdk-go/1.45.3 (go1.17.13; linux; amd64)"}		0	{"Api":"PutObject","Connection":"keep-alive","ETag":"\"e9c6a6caff59de9773a6e7e13c0dd329\"","Owner":"cubefs","Requester":"cubefs","Server":"CubeFS","Tbl":"cfs-bucket","Trace-Tags":["span.kind:server"],"Vary":"Origin,Access-Control-Request-Method,Access-Control-Request-Headers","X-Amz-Request-Id":"7db549b9042d4342a12add4dacfa3826"}		0	3976619
```

External AuditEntry:
```json
{
	"Version": "1.0",
	"Time": "2023-10-10T02:56:39.241908829Z",
	"RequestID": "e03f9f6c70644e788e4fa2c6a8e3a80c",
	"Requester": "yhjiango",
	"AccessKey": "JGhI3d1VDFHQidsf",
	"Owner": "yhjiango",
	"Request": {
		"API": "GetObject",
		"Bucket": "yhjogging",
		"Object": "yhj-test01.json",
		"Method": "GET",
		"Proto": "HTTP/1.1",
		"Path": "/yhjogging/yhj-test01.json",
		"Header": {
			"Accept-Encoding": "gzip",
			"Authorization": "AWS4-HMAC-SHA256 Credential=JGhI3d1VDFHQidsf/20231010/cfs-dev/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=2ab55d5a4934806df3b105e36944537df142ee533f10a4c5d769b48ec57738fe",
			"User-Agent": "aws-sdk-go/1.45.3 (go1.17.13; linux; amd64)",
			"X-Amz-Content-Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
			"X-Amz-Date": "20231010T025639Z"
		},
		"Host": "127.0.0.1:17410",
		"RemoteIP": "127.0.0.1"
	},
	"Response": {
		"Status": "OK",
		"StatusCode": 200,
		"Header": {
			"Accept-Ranges": "bytes",
			"Connection": "keep-alive",
			"Content-Length": "20",
			"Content-Type": "application/json",
			"ETag": "\"e9c6a6caff59de9773a6e7e13c0dd329\"",
			"Last-Modified": "Mon, 18 Sep 2023 10:38:20 GMT",
			"Server": "CubeFS",
			"Trace-Log": "OBJECT:2690",
			"Trace-Tags": "span.kind:server",
			"Vary": "Origin,Access-Control-Request-Method,Access-Control-Request-Headers",
			"X-Amz-Meta-Filemd5": "fd0062ecf3fb52d6c9dfcfd48e8494bd",
			"X-Amz-Request-Id": "e03f9f6c70644e788e4fa2c6a8e3a80c",
			"X-Object-Trace-Id": "1c0bb92e22685228"
		}
	},
	"BytesResponse": 20,
	"Duration": "2690276717ns",
	"DurationNS": "2690276717"
}
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #
