### PR TITLE
fix(metanode):snapshot.extent key in append need consider the probabi…

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -117,7 +117,6 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		ValidateOwner:   opt.Authenticate || opt.AccessKey == "",
 		EnableSummary:   opt.EnableSummary && opt.EnableXattr,
 		MetaSendTimeout: opt.MetaSendTimeout,
-		VerReadSeq:      opt.VerReadSeq,
 	}
 	s.mw, err = meta.NewMetaWrapper(metaConfig)
 	if err != nil {
@@ -242,6 +241,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	if err != nil {
 		return nil, errors.Trace(err, "NewExtentClient failed!")
 	}
+	s.mw.VerReadSeq = s.ec.GetReadVer()
 	if proto.IsCold(opt.VolType) {
 		s.ebsc, err = blobstore.NewEbsClient(access.Config{
 			ConnMode: access.NoLimitConnMode,

--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -111,7 +111,7 @@ func (dp *DataPartition) repair(extentType uint8) {
 		log.LogError(errors.Stack(err))
 		return
 	}
-
+	log.LogDebugf("DoRepair")
 	// ask the leader to do the repair
 	dp.DoRepair(repairTasks)
 	end := time.Now().UnixNano()
@@ -149,7 +149,7 @@ func (dp *DataPartition) buildDataPartitionRepairTask(repairTasks []*DataPartiti
 			log.LogErrorf("buildDataPartitionRepairTask PartitionID(%v) on (%v) err(%v)", dp.partitionID, replica[index], err)
 			continue
 		}
-		log.LogInfof("buildDataPartitionRepairTask dp %v,add new add %v,  extent type %v", dp.partitionID, replica[index], extentType)
+		log.LogInfof("buildDataPartitionRepairTask dp %v,  add new add %v,  extent type %v", dp.partitionID, replica[index], extentType)
 		repairTasks[index] = NewDataPartitionRepairTask(extents, leaderTinyDeleteRecordFileSize, replica[index], replica[0])
 		repairTasks[index].addr = replica[index]
 	}
@@ -239,7 +239,9 @@ func (dp *DataPartition) DoRepair(repairTasks []*DataPartitionRepairTask) {
 
 		store.Create(extentInfo.FileID)
 	}
+	log.LogDebugf("action[DoRepair] leader to repair len[%v], {%v}", len(repairTasks[0].ExtentsToBeRepaired), repairTasks[0].ExtentsToBeRepaired)
 	for _, extentInfo := range repairTasks[0].ExtentsToBeRepaired {
+		log.LogDebugf("action[DoRepair] leader to repair len[%v], {%v}", len(repairTasks[0].ExtentsToBeRepaired), extentInfo)
 		err := dp.streamRepairExtent(extentInfo)
 		if err != nil {
 			err = errors.Trace(err, "doStreamExtentFixRepair %v", dp.applyRepairKey(int(extentInfo.FileID)))
@@ -310,10 +312,11 @@ func (dp *DataPartition) prepareRepairTasks(repairTasks []*DataPartitionRepairTa
 			if !ok {
 				extentInfoMap[extentID] = extentInfo
 			} else {
-				if extentInfo.Size > extentWithMaxSize.Size {
+				if extentInfo.TotalSize() > extentWithMaxSize.TotalSize() {
 					extentInfoMap[extentID] = extentInfo
 				}
 			}
+			log.LogInfof("action[prepareRepairTasks] dp %v extentid %v addr[dst %v,leader %v] info %v", dp.partitionID, extentID, repairTask.addr, repairTask.LeaderAddr, extentInfoMap[extentID])
 		}
 	}
 	for extentID := range deleteExtents {
@@ -349,7 +352,7 @@ func (dp *DataPartition) buildExtentCreationTasks(repairTasks []*DataPartitionRe
 				if dp.ExtentStore().IsDeletedNormalExtent(extentID) {
 					continue
 				}
-				ei := &storage.ExtentInfo{Source: extentInfo.Source, FileID: extentID, Size: extentInfo.Size}
+				ei := &storage.ExtentInfo{Source: extentInfo.Source, FileID: extentID, Size: extentInfo.Size, SnapshotDataOff: extentInfo.SnapshotDataOff}
 				repairTask.ExtentsToBeCreated = append(repairTask.ExtentsToBeCreated, ei)
 				repairTask.ExtentsToBeRepaired = append(repairTask.ExtentsToBeRepaired, ei)
 				log.LogInfof("action[generatorAddExtentsTasks] addFile(%v_%v) on Index(%v).", dp.partitionID, ei, index)
@@ -379,8 +382,8 @@ func (dp *DataPartition) buildExtentRepairTasks(repairTasks []*DataPartitionRepa
 			if dp.ExtentStore().IsDeletedNormalExtent(extentID) {
 				continue
 			}
-			if extentInfo.Size < maxFileInfo.Size {
-				fixExtent := &storage.ExtentInfo{Source: maxFileInfo.Source, FileID: extentID, Size: maxFileInfo.Size}
+			if extentInfo.TotalSize() < maxFileInfo.TotalSize() {
+				fixExtent := &storage.ExtentInfo{Source: maxFileInfo.Source, FileID: extentID, Size: maxFileInfo.Size, SnapshotDataOff: maxFileInfo.SnapshotDataOff}
 				repairTasks[index].ExtentsToBeRepaired = append(repairTasks[index].ExtentsToBeRepaired, fixExtent)
 				log.LogInfof("action[generatorFixExtentSizeTasks] fixExtent(%v_%v) on Index(%v) on(%v).",
 					dp.partitionID, fixExtent, index, repairTasks[index].addr)
@@ -482,8 +485,10 @@ func (dp *DataPartition) applyRepairKey(extentID int) (m string) {
 
 // The actual repair of an extent happens here.
 func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo) (err error) {
+	log.LogDebugf("streamRepairExtent dp %v remote info %v", dp.partitionID, remoteExtentInfo)
 	store := dp.ExtentStore()
 	if !store.HasExtent(remoteExtentInfo.FileID) {
+		log.LogDebugf("streamRepairExtent remote info %v not exist", remoteExtentInfo)
 		return
 	}
 	if !AutoRepairStatus && !storage.IsTinyExtent(remoteExtentInfo.FileID) {
@@ -492,147 +497,157 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 	}
 	localExtentInfo, err := store.Watermark(remoteExtentInfo.FileID)
 	if err != nil {
+		log.LogDebugf("streamRepairExtent local v% remote info %v", localExtentInfo, remoteExtentInfo)
 		return errors.Trace(err, "streamRepairExtent Watermark error")
 	}
-
+	log.LogDebugf("streamRepairExtent dp %v remote info %v,local %v", dp.partitionID, remoteExtentInfo, localExtentInfo)
 	if dp.ExtentStore().IsDeletedNormalExtent(remoteExtentInfo.FileID) {
+		log.LogDebugf("streamRepairExtent local %v remote info %v", localExtentInfo, remoteExtentInfo)
 		return nil
 	}
 
-	if localExtentInfo.Size >= remoteExtentInfo.Size {
+	if localExtentInfo.Size >= remoteExtentInfo.Size && localExtentInfo.SnapshotDataOff >= remoteExtentInfo.SnapshotDataOff {
+		log.LogDebugf("streamRepairExtent local v% remote info %v", localExtentInfo, remoteExtentInfo)
 		return nil
 	}
+
+	doWork := func(wType int, currFixOffset uint64, dstOffset uint64, request *repl.Packet) (err error) {
+		log.LogDebugf("streamRepairExtent. currFixOffset %v dstOffset %v, request %v", currFixOffset, dstOffset, request)
+		var conn net.Conn
+		conn, err = dp.getRepairConn(remoteExtentInfo.Source)
+		if err != nil {
+			return errors.Trace(err, "streamRepairExtent get conn from host(%v) error", remoteExtentInfo.Source)
+		}
+		defer func() {
+			dp.putRepairConn(conn, err != nil)
+		}()
+
+		if err = request.WriteToConn(conn); err != nil {
+			err = errors.Trace(err, "streamRepairExtent send streamRead to host(%v) error", remoteExtentInfo.Source)
+			log.LogWarnf("action[streamRepairExtent] err(%v).", err)
+			return
+		}
+
+		var (
+			hasRecoverySize uint64
+		)
+		var loopTimes uint64
+		for currFixOffset < dstOffset {
+			if currFixOffset >= dstOffset {
+				break
+			}
+			reply := repl.NewPacket()
+
+			// read 64k streaming repair packet
+			if err = reply.ReadFromConn(conn, 60); err != nil {
+				err = errors.Trace(err, "streamRepairExtent receive data error,localExtentSize(%v) remoteExtentSize(%v)", currFixOffset, dstOffset)
+				return
+			}
+
+			if reply.ResultCode != proto.OpOk {
+				err = errors.Trace(fmt.Errorf("unknow result code"),
+					"streamRepairExtent receive opcode error(%v) ,localExtentSize(%v) remoteExtentSize(%v)", string(reply.Data[:intMin(len(reply.Data), int(reply.Size))]), currFixOffset, remoteExtentInfo.Size)
+				return
+			}
+
+			if reply.ReqID != request.ReqID || reply.PartitionID != request.PartitionID ||
+				reply.ExtentID != request.ExtentID {
+				err = errors.Trace(fmt.Errorf("unavali reply"), "streamRepairExtent receive unavalid "+
+					"request(%v) reply(%v) ,localExtentSize(%v) remoteExtentSize(%v)", request.GetUniqueLogId(), reply.GetUniqueLogId(), currFixOffset, dstOffset)
+				return
+			}
+
+			if !storage.IsTinyExtent(reply.ExtentID) && (reply.Size == 0 || reply.ExtentOffset != int64(currFixOffset)) {
+				err = errors.Trace(fmt.Errorf("unavali reply"), "streamRepairExtent receive unavalid "+
+					"request(%v) reply(%v) localExtentSize(%v) remoteExtentSize(%v)", request.GetUniqueLogId(), reply.GetUniqueLogId(), currFixOffset, dstOffset)
+				return
+			}
+			if loopTimes%100 == 0 {
+				log.LogInfof(fmt.Sprintf("action[streamRepairExtent] fix(%v_%v) start fix from (%v)"+
+					" remoteSize(%v)localSize(%v) reply(%v).", dp.partitionID, localExtentInfo.FileID, remoteExtentInfo.String(),
+					dstOffset, currFixOffset, reply.GetUniqueLogId()))
+			}
+			loopTimes++
+
+			actualCrc := crc32.ChecksumIEEE(reply.Data[:reply.Size])
+			if reply.CRC != crc32.ChecksumIEEE(reply.Data[:reply.Size]) {
+				err = fmt.Errorf("streamRepairExtent crc mismatch expectCrc(%v) actualCrc(%v) extent(%v_%v) start fix from (%v)"+
+					" remoteSize(%v) localSize(%v) request(%v) reply(%v) ", reply.CRC, actualCrc, dp.partitionID, remoteExtentInfo.String(),
+					remoteExtentInfo.Source, dstOffset, currFixOffset, request.GetUniqueLogId(), reply.GetUniqueLogId())
+				return errors.Trace(err, "streamRepairExtent receive data error")
+			}
+			isEmptyResponse := false
+			// Write it to local extent file
+			if storage.IsTinyExtent(uint64(localExtentInfo.FileID)) {
+				currRecoverySize := uint64(reply.Size)
+				var remoteAvaliSize uint64
+				if reply.ArgLen == TinyExtentRepairReadResponseArgLen {
+					remoteAvaliSize = binary.BigEndian.Uint64(reply.Arg[9:TinyExtentRepairReadResponseArgLen])
+				}
+				if reply.Arg != nil { //compact v1.2.0 recovery
+					isEmptyResponse = reply.Arg[0] == EmptyResponse
+				}
+				if isEmptyResponse {
+					currRecoverySize = binary.BigEndian.Uint64(reply.Arg[1:9])
+					reply.Size = uint32(currRecoverySize)
+				}
+				err = store.TinyExtentRecover(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(currRecoverySize), reply.Data, reply.CRC, isEmptyResponse)
+				if hasRecoverySize+currRecoverySize >= remoteAvaliSize {
+					log.LogInfof("streamRepairTinyExtent(%v) recover fininsh,remoteAvaliSize(%v) "+
+						"hasRecoverySize(%v) currRecoverySize(%v)", dp.applyRepairKey(int(localExtentInfo.FileID)),
+						remoteAvaliSize, hasRecoverySize+currRecoverySize, currRecoverySize)
+					break
+				}
+			} else {
+				log.LogDebugf("streamRepairExtent reply size %v, currFixoffset %v, reply %v ", reply.Size, currFixOffset, reply)
+				_, err = store.Write(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(reply.Size), reply.Data, reply.CRC, wType, BufferWrite)
+			}
+			//log.LogDebugf("streamRepairExtent reply size %v, currFixoffset %v, reply %v err %v", reply.Size, currFixOffset, reply, err)
+			// write to the local extent file
+			if err != nil {
+				err = errors.Trace(err, "streamRepairExtent repair data error ")
+				return
+			}
+			hasRecoverySize += uint64(reply.Size)
+			currFixOffset += uint64(reply.Size)
+			if currFixOffset >= dstOffset {
+				log.LogWarnf(fmt.Sprintf("action[streamRepairExtent] fix(%v_%v) start fix from (%v)"+
+					" remoteSize(%v)localSize(%v) reply(%v).", dp.partitionID, localExtentInfo.FileID, remoteExtentInfo.String(),
+					dstOffset, currFixOffset, reply.GetUniqueLogId()))
+				break
+			}
+		}
+		return
+	}
+
 	// size difference between the local extent and the remote extent
 	var request *repl.Packet
 	sizeDiff := remoteExtentInfo.Size - localExtentInfo.Size
+
 	if storage.IsTinyExtent(remoteExtentInfo.FileID) {
 		if sizeDiff >= math.MaxUint32 {
 			sizeDiff = math.MaxUint32 - util.MB
 		}
 		request = repl.NewTinyExtentRepairReadPacket(dp.partitionID, remoteExtentInfo.FileID, int(localExtentInfo.Size), int(sizeDiff))
+		currFixOffset := localExtentInfo.Size
+		return doWork(0, currFixOffset, remoteExtentInfo.Size, request)
 	} else {
-		request = repl.NewExtentRepairReadPacket(dp.partitionID, remoteExtentInfo.FileID, int(localExtentInfo.Size), int(sizeDiff))
-	}
-	var conn net.Conn
-	conn, err = dp.getRepairConn(remoteExtentInfo.Source)
-	if err != nil {
-		return errors.Trace(err, "streamRepairExtent get conn from host(%v) error", remoteExtentInfo.Source)
-	}
-
-	isNetError := false
-	defer func() {
-		dp.putRepairConn(conn, isNetError)
-	}()
-
-	if err = request.WriteToConn(conn); err != nil {
-		err = errors.Trace(err, "streamRepairExtent send streamRead to host(%v) error", remoteExtentInfo.Source)
-		log.LogWarnf("action[streamRepairExtent] err(%v).", err)
-		isNetError = true
-		return
-	}
-	currFixOffset := localExtentInfo.Size
-	var hasRecoverySize uint64
-	var loopTimes uint64
-	for currFixOffset < remoteExtentInfo.Size {
-		if dp.stopRecover && dp.isDecommissionRecovering() {
-			log.LogWarnf("streamRepairExtent %v [extent %v]receive stop signal", dp.partitionID, remoteExtentInfo.FileID)
-			return
-		}
-		if !dp.Disk().CanWrite() {
-			return fmt.Errorf("disk is full, can't do repair write any more")
-		}
-
-		if currFixOffset >= remoteExtentInfo.Size {
-			break
-		}
-		reply := repl.NewPacket()
-
-		// read 64k streaming repair packet
-		if err = reply.ReadFromConn(conn, 60); err != nil {
-			err = errors.Trace(err, "streamRepairExtent receive data error,localExtentSize(%v) remoteExtentSize(%v)", currFixOffset, remoteExtentInfo.Size)
-			isNetError = true
-			return
-		}
-
-		if reply.ResultCode != proto.OpOk {
-			err = errors.Trace(fmt.Errorf("unknow result code"),
-				"streamRepairExtent receive opcode error(%v) ,localExtentSize(%v) remoteExtentSize(%v)", string(reply.Data[:intMin(len(reply.Data), int(reply.Size))]), currFixOffset, remoteExtentInfo.Size)
-			return
-		}
-
-		if reply.ReqID != request.ReqID || reply.PartitionID != request.PartitionID ||
-			reply.ExtentID != request.ExtentID {
-			err = errors.Trace(fmt.Errorf("unavali reply"), "streamRepairExtent receive unavalid "+
-				"request(%v) reply(%v) ,localExtentSize(%v) remoteExtentSize(%v)", request.GetUniqueLogId(), reply.GetUniqueLogId(), currFixOffset, remoteExtentInfo.Size)
-			return
-		}
-
-		if !storage.IsTinyExtent(reply.ExtentID) && (reply.Size == 0 || reply.ExtentOffset != int64(currFixOffset)) {
-			err = errors.Trace(fmt.Errorf("unavali reply"), "streamRepairExtent receive unavalid "+
-				"request(%v) reply(%v) localExtentSize(%v) remoteExtentSize(%v)", request.GetUniqueLogId(), reply.GetUniqueLogId(), currFixOffset, remoteExtentInfo.Size)
-			return
-		}
-		if loopTimes%100 == 0 {
-			log.LogInfof(fmt.Sprintf("action[streamRepairExtent] fix(%v_%v) start fix from (%v)"+
-				" remoteSize(%v)localSize(%v) reply(%v).", dp.partitionID, localExtentInfo.FileID, remoteExtentInfo.String(),
-				remoteExtentInfo.Size, currFixOffset, reply.GetUniqueLogId()))
-		}
-		loopTimes++
-
-		actualCrc := crc32.ChecksumIEEE(reply.Data[:reply.Size])
-		if reply.CRC != actualCrc {
-			err = fmt.Errorf("streamRepairExtent crc mismatch expectCrc(%v) actualCrc(%v) extent(%v_%v) start fix from (%v)"+
-				" remoteSize(%v) localSize(%v) request(%v) reply(%v) ", reply.CRC, actualCrc, dp.partitionID, remoteExtentInfo.String(),
-				remoteExtentInfo.Source, remoteExtentInfo.Size, currFixOffset, request.GetUniqueLogId(), reply.GetUniqueLogId())
-			return errors.Trace(err, "streamRepairExtent receive data error")
-		}
-		isEmptyResponse := false
-		// Write it to local extent file
-		if storage.IsTinyExtent(uint64(localExtentInfo.FileID)) {
-			currRecoverySize := uint64(reply.Size)
-			var remoteAvaliSize uint64
-			if reply.ArgLen == TinyExtentRepairReadResponseArgLen {
-				remoteAvaliSize = binary.BigEndian.Uint64(reply.Arg[9:TinyExtentRepairReadResponseArgLen])
+		if sizeDiff > 0 {
+			log.LogDebugf("streamRepairExtent. local info %v, remote %v", localExtentInfo, remoteExtentInfo)
+			request = repl.NewExtentRepairReadPacket(dp.partitionID, remoteExtentInfo.FileID, int(localExtentInfo.Size), int(sizeDiff))
+			currFixOffset := localExtentInfo.Size
+			if err = doWork(storage.AppendWriteType, currFixOffset, remoteExtentInfo.Size, request); err != nil {
+				return
 			}
-			if reply.Arg != nil { // compact v1.2.0 recovery
-				isEmptyResponse = reply.Arg[0] == EmptyResponse
-			}
-			if isEmptyResponse {
-				currRecoverySize = binary.BigEndian.Uint64(reply.Arg[1:9])
-				reply.Size = uint32(currRecoverySize)
-			}
-
-			dp.disk.allocCheckLimit(proto.FlowWriteType, uint32(reply.Size))
-			dp.disk.allocCheckLimit(proto.IopsWriteType, 1)
-
-			err = store.TinyExtentRecover(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(currRecoverySize), reply.Data, reply.CRC, isEmptyResponse)
-			if hasRecoverySize+currRecoverySize >= remoteAvaliSize {
-				log.LogInfof("streamRepairTinyExtent(%v) recover finish,remoteAvaliSize(%v) "+
-					"hasRecoverySize(%v) currRecoverySize(%v)", dp.applyRepairKey(int(localExtentInfo.FileID)),
-					remoteAvaliSize, hasRecoverySize+currRecoverySize, currRecoverySize)
-				break
-			}
-		} else {
-			dp.disk.allocCheckLimit(proto.FlowWriteType, uint32(reply.Size))
-			dp.disk.allocCheckLimit(proto.IopsWriteType, 1)
-			_, err = store.Write(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(reply.Size), reply.Data, reply.CRC, storage.AppendWriteType, BufferWrite)
 		}
-
-		// write to the local extent file
-		if err != nil {
-			err = errors.Trace(err, "streamRepairExtent repair data error ")
-			return
+		sizeDiffVerAppend := remoteExtentInfo.SnapshotDataOff - localExtentInfo.SnapshotDataOff
+		if sizeDiffVerAppend > 0 {
+			request = repl.NewExtentRepairReadPacket(dp.partitionID, remoteExtentInfo.FileID, int(localExtentInfo.SnapshotDataOff), int(sizeDiffVerAppend))
+			currFixOffset := localExtentInfo.SnapshotDataOff
+			return doWork(storage.AppendRandomWriteType, currFixOffset, remoteExtentInfo.SnapshotDataOff, request)
 		}
-		hasRecoverySize += uint64(reply.Size)
-		currFixOffset += uint64(reply.Size)
-		if currFixOffset >= remoteExtentInfo.Size {
-			log.LogWarnf(fmt.Sprintf("action[streamRepairExtent] fix(%v_%v) start fix from (%v)"+
-				" remoteSize(%v)localSize(%v) reply(%v).", dp.partitionID, localExtentInfo.FileID, remoteExtentInfo.String(),
-				remoteExtentInfo.Size, currFixOffset, reply.GetUniqueLogId()))
-			break
-		}
-
 	}
+
 	return
 }
 

--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -497,7 +497,7 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 	}
 	localExtentInfo, err := store.Watermark(remoteExtentInfo.FileID)
 	if err != nil {
-		log.LogDebugf("streamRepairExtent local v% remote info %v", localExtentInfo, remoteExtentInfo)
+		log.LogDebugf("streamRepairExtent local %v remote info %v", localExtentInfo, remoteExtentInfo)
 		return errors.Trace(err, "streamRepairExtent Watermark error")
 	}
 	log.LogDebugf("streamRepairExtent dp %v remote info %v,local %v", dp.partitionID, remoteExtentInfo, localExtentInfo)
@@ -507,7 +507,7 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 	}
 
 	if localExtentInfo.Size >= remoteExtentInfo.Size && localExtentInfo.SnapshotDataOff >= remoteExtentInfo.SnapshotDataOff {
-		log.LogDebugf("streamRepairExtent local v% remote info %v", localExtentInfo, remoteExtentInfo)
+		log.LogDebugf("streamRepairExtent local %v remote info %v", localExtentInfo, remoteExtentInfo)
 		return nil
 	}
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -131,8 +131,8 @@ type DataPartition struct {
 	verSeq                     uint64
 	verSeqPrepare              uint64
 	verSeqCommitStatus         int8
-	multiVersionList           []*MetaMultiSnapshotInfo
-	decommissionRepairProgress float64 // record repair progress for decommission datapartition
+	volVersionInfoList         *proto.VolVersionInfoList
+	decommissionRepairProgress float64 //record repair progress for decommission datapartition
 	stopRecover                bool
 	recoverErrCnt              uint64 // donot reset, if reach max err cnt, delete this dp
 }
@@ -311,6 +311,7 @@ func newDataPartition(dpCfg *dataPartitionCfg, disk *Disk, isCreate bool) (dp *D
 		raftStatus:              RaftStatusStopped,
 		verSeq:                  dpCfg.VerSeq,
 		DataPartitionCreateType: dpCfg.CreateType,
+		volVersionInfoList:      &proto.VolVersionInfoList{},
 	}
 	atomic.StoreUint64(&partition.recoverErrCnt, 0)
 	log.LogInfof("action[newDataPartition] dp %v replica num %v", partitionID, dpCfg.ReplicaNum)

--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -203,15 +203,15 @@ func (si *ItemIterator) Next() (data []byte, err error) {
 }
 
 // ApplyRandomWrite random write apply
-func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (resp interface{}, err error) {
+func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (respStatus interface{}, err error) {
 	opItem := &rndWrtOpItem{}
-	resp = proto.OpOk
+	respStatus = proto.OpOk
 	defer func() {
 		if err == nil {
 			dp.uploadApplyID(raftApplyID)
 			log.LogDebug("action[ApplyRandomWrite] success!")
 		} else {
-			if resp == proto.OpExistErr { // for tryAppendWrite
+			if respStatus == proto.OpExistErr { // for tryAppendWrite
 				err = nil
 				log.LogDebugf("[ApplyRandomWrite] ApplyID(%v) Partition(%v)_Extent(%v)_ExtentOffset(%v)_Size(%v) apply err(%v) retry[20]",
 					raftApplyID, dp.partitionID, opItem.extentID, opItem.offset, opItem.size, err)
@@ -221,8 +221,8 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 				raftApplyID, dp.partitionID, opItem.extentID, opItem.offset, opItem.size, err)
 			log.LogErrorf("action[ApplyRandomWrite] failed err %v", err)
 			exporter.Warning(err.Error())
-			if resp == proto.OpOk {
-				resp = proto.OpDiskErr
+			if respStatus == proto.OpOk {
+				respStatus = proto.OpDiskErr
 			}
 			panic(newRaftApplyError(err))
 		}
@@ -243,7 +243,7 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 		dp.disk.allocCheckLimit(proto.FlowWriteType, uint32(opItem.size))
 		dp.disk.allocCheckLimit(proto.IopsWriteType, 1)
 
-		resp, err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, storage.RandomWriteType, opItem.opcode == proto.OpSyncRandomWrite)
+		respStatus, err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, storage.RandomWriteType, opItem.opcode == proto.OpSyncRandomWrite)
 		var syncWrite bool
 		writeType := storage.RandomWriteType
 		if opItem.opcode == proto.OpRandomWrite || opItem.opcode == proto.OpSyncRandomWrite {
@@ -262,7 +262,7 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 			syncWrite = true
 		}
 
-		resp, err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, writeType, syncWrite)
+		respStatus, err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, writeType, syncWrite)
 		if err == nil {
 			break
 		}
@@ -273,11 +273,12 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 			err = nil
 			return
 		}
-		if (opItem.opcode == proto.OpTryWriteAppend || opItem.opcode == proto.OpSyncTryWriteAppend) && resp == proto.OpTryOtherExtent {
+		if (opItem.opcode == proto.OpTryWriteAppend || opItem.opcode == proto.OpSyncTryWriteAppend) && respStatus == proto.OpTryOtherExtent {
 			err = nil
 			return
 		}
-		log.LogErrorf("[ApplyRandomWrite] ApplyID(%v) Partition(%v)_Extent(%v)_ExtentOffset(%v)_Size(%v) apply err(%v) retry(%v)", raftApplyID, dp.partitionID, opItem.extentID, opItem.offset, opItem.size, err, i)
+		log.LogErrorf("[ApplyRandomWrite] ApplyID(%v) Partition(%v)_Extent(%v)_ExtentOffset(%v)_Size(%v) apply err(%v) retry(%v)",
+			raftApplyID, dp.partitionID, opItem.extentID, opItem.offset, opItem.size, err, i)
 	}
 
 	return

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -266,7 +266,6 @@ func (dp *DataPartition) StartRaftLoggingSchedule() {
 // It can only happens after all the extent files are repaired by the leader.
 // When the repair is finished, the local dp.partitionSize is same as the leader's dp.partitionSize.
 // The repair task can be done in statusUpdateScheduler->LaunchRepair.
-
 func (dp *DataPartition) StartRaftAfterRepair(isLoad bool) {
 	log.LogDebugf("StartRaftAfterRepair enter")
 	// cache or preload partition not support raft and repair.
@@ -291,10 +290,12 @@ func (dp *DataPartition) StartRaftAfterRepair(isLoad bool) {
 				log.LogDebugf("PartitionID(%v) leader started.", dp.partitionID)
 				return
 			}
+
 			if dp.stopRecover && dp.isDecommissionRecovering() {
 				log.LogDebugf("action[StartRaftAfterRepair] PartitionID(%v) receive stop signal.", dp.partitionID)
 				continue
 			}
+
 			// wait for dp.replicas to be updated
 			if dp.getReplicaLen() == 0 {
 				continue
@@ -685,6 +686,7 @@ func (dp *DataPartition) getLeaderPartitionSize(maxExtentID uint64) (size uint64
 }
 
 func (dp *DataPartition) getMaxExtentIDAndPartitionSize(target string) (maxExtentID, PartitionSize uint64, err error) {
+
 	var conn *net.TCPConn
 	p := NewPacketToGetMaxExtentIDAndPartitionSIze(dp.partitionID)
 
@@ -721,6 +723,12 @@ func (dp *DataPartition) getMaxExtentIDAndPartitionSize(target string) (maxExten
 // Get the MaxExtentID partition  from the leader.
 func (dp *DataPartition) getLeaderMaxExtentIDAndPartitionSize() (maxExtentID, PartitionSize uint64, err error) {
 	target := dp.getReplicaAddr(0)
+	return dp.getMaxExtentIDAndPartitionSize(target)
+}
+
+// Get the MaxExtentID partition  from the leader.
+func (dp *DataPartition) getMemberExtentIDAndPartitionSize() (maxExtentID, PartitionSize uint64, err error) {
+	target := dp.getReplicaAddr(1)
 	return dp.getMaxExtentIDAndPartitionSize(target)
 }
 

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -329,7 +329,7 @@ func (s *DataNode) commitCreateVersion(volumeID string, verSeq uint64) (err erro
 		return
 	}
 
-	log.LogWarnf("action[commitCreateVersion] vol %v not found %v", volumeID)
+	log.LogWarnf("action[commitCreateVersion] vol %v not found seq %v", volumeID, verSeq)
 	return
 }
 

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/cubefs/cubefs/depends/tiglabs/raft"
@@ -260,15 +259,33 @@ func (s *DataNode) handlePacketToCreateDataPartition(p *repl.Packet) {
 	p.PacketOkWithBody([]byte(dp.Disk().Path))
 }
 
-func (s *DataNode) commitCreateVersion(volumeID string, verSeq uint64) (err error) {
-	for _, dp := range s.space.partitions {
-		if dp.volumeID != volumeID {
+func (s *DataNode) commitDelVersion(volumeID string, verSeq uint64) (err error) {
+	for _, partition := range s.space.partitions {
+		if partition.config.VolName != volumeID {
 			continue
 		}
-		dp.UpdateVersion(verSeq)
+		verListMgr := partition.volVersionInfoList
+		verListMgr.Lock()
+		for i, ver := range verListMgr.VerList {
+			if i == len(verListMgr.VerList)-1 {
+				log.LogWarnf("action[fsmVersionOp] mp[%v] seq %v, seqArray size %v newest ver %v",
+					partition.config.PartitionID, verSeq, len(verListMgr.VerList), ver.Ver)
+				break
+			}
+			if ver.Ver == verSeq {
+				log.LogInfof("action[fsmVersionOp] mp[%v] seq %v,seqArray size %v", partition.config.PartitionID, verSeq, len(verListMgr.VerList))
+				// mp.multiVersionList = append(mp.multiVersionList[:i], mp.multiVersionList[i+1:]...)
+				verListMgr.VerList = append(verListMgr.VerList[:i], verListMgr.VerList[i+1:]...)
+				break
+			}
+		}
+		verListMgr.Unlock()
 	}
-	log.LogInfof("action[commitCreateVersion] handle master version reqeust seq %v", verSeq)
+	return
+}
 
+func (s *DataNode) commitCreateVersion(volumeID string, verSeq uint64) (err error) {
+	log.LogInfof("action[commitCreateVersion] handle master version reqeust seq %v", verSeq)
 	if value, ok := s.volUpdating.Load(volumeID); ok {
 		ver2Phase := value.(*verOp2Phase)
 		log.LogWarnf("action[commitCreateVersion] try commit volume %v prepare seq %v with commit seq %v",
@@ -288,11 +305,31 @@ func (s *DataNode) commitCreateVersion(volumeID string, verSeq uint64) (err erro
 		ver2Phase.status = proto.VersionWorkingFinished
 		log.LogWarnf("action[commitCreateVersion] commit volume %v prepare seq %v with commit seq %v",
 			volumeID, ver2Phase.verPrepare, verSeq)
+		for _, partition := range s.space.partitions {
+			if partition.config.VolName != volumeID {
+				continue
+			}
+			partition.volVersionInfoList.Lock()
+			cnt := len(partition.volVersionInfoList.VerList)
+			if cnt > 0 && partition.volVersionInfoList.VerList[cnt-1].Ver >= verSeq {
+				log.LogWarnf("action[HandleVersionOp] reqeust seq %v lessOrEqual last exist snapshot seq %v",
+					partition.volVersionInfoList.VerList[cnt-1].Ver, verSeq)
+				partition.volVersionInfoList.Unlock()
+				continue
+			}
+			newVer := &proto.VolVersionInfo{
+				Status: proto.VersionNormal,
+				Ver:    verSeq,
+			}
+			partition.verSeq = verSeq
+			partition.volVersionInfoList.VerList = append(partition.volVersionInfoList.VerList, newVer)
+			partition.volVersionInfoList.Unlock()
+		}
+
 		return
 	}
 
-	err = fmt.Errorf("vol %v not found", volumeID)
-	log.LogErrorf("action[commitCreateVersion] err %v", err)
+	log.LogWarnf("action[commitCreateVersion] vol %v not found %v", volumeID)
 	return
 }
 
@@ -323,58 +360,8 @@ func (s *DataNode) prepareCreateVersion(req *proto.MultiVersionOpRequest) (err e
 	return
 }
 
-func (s *DataNode) checkMultiVersionStatus(volName string) (err error) {
-	log.LogDebugf("action[checkMultiVersionStatus] volumeName %v", volName)
-	var info *proto.VolumeVerInfo
-	if value, ok := s.volUpdating.Load(volName); ok {
-		ver2Phase := value.(*verOp2Phase)
-
-		if atomic.LoadUint32(&ver2Phase.status) != proto.VersionWorkingAbnormal &&
-			atomic.LoadUint32(&ver2Phase.step) == proto.CreateVersionPrepare {
-
-			ver2Phase.Lock() // here trylock may be better after go1.18 adapted to compile
-			defer ver2Phase.Unlock()
-
-			// check again in case of sth already happened by other goroutine during be blocked by lock
-			if atomic.LoadUint32(&ver2Phase.status) == proto.VersionWorkingAbnormal ||
-				atomic.LoadUint32(&ver2Phase.step) != proto.CreateVersionPrepare {
-
-				log.LogWarnf("action[checkMultiVersionStatus] volumeName %v status %v step %v",
-					volName, atomic.LoadUint32(&ver2Phase.status), atomic.LoadUint32(&ver2Phase.step))
-				return
-			}
-
-			if info, err = MasterClient.AdminAPI().GetVerInfo(volName); err != nil {
-				log.LogErrorf("action[checkMultiVersionStatus] volumeName %v status %v step %v err %v",
-					volName, atomic.LoadUint32(&ver2Phase.status), atomic.LoadUint32(&ver2Phase.step), err)
-				return
-			}
-
-			log.LogDebugf("action[checkMultiVersionStatus] vol %v info %v", volName, info)
-
-			if info.VerSeqPrepare != ver2Phase.verPrepare {
-				atomic.StoreUint32(&ver2Phase.status, proto.VersionWorkingAbnormal)
-				err = fmt.Errorf("volumeName %v status %v step %v",
-					volName, atomic.LoadUint32(&ver2Phase.status), atomic.LoadUint32(&ver2Phase.step))
-				log.LogErrorf("action[checkMultiVersionStatus] err %v", err)
-				return
-			}
-			if info.VerPrepareStatus == proto.VersionNormal {
-				if err = s.commitCreateVersion(info.Name, info.VerSeq); err != nil {
-					log.LogErrorf("action[checkMultiVersionStatus] err %v", err)
-					return
-				}
-			}
-		}
-	} else {
-		log.LogDebugf("action[checkMultiVersionStatus] volumeName %v not found", volName)
-	}
-	return
-}
-
 // Handle OpHeartbeat packet.
 func (s *DataNode) handleUpdateVerPacket(p *repl.Packet) {
-	log.LogWarnf("action[handleUpdateVerPacket] enter in p %v", p)
 	var err error
 	defer func() {
 		if err != nil {
@@ -390,57 +377,58 @@ func (s *DataNode) handleUpdateVerPacket(p *repl.Packet) {
 		log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
 		return
 	}
+	request := &proto.MultiVersionOpRequest{}
+	response := &proto.MultiVersionOpResponse{}
+	response.Op = task.OpCode
+	response.Status = proto.TaskSucceeds
 
-	log.LogWarnf("action[handleUpdateVerPacket] task %v", task)
-
-	go func() {
-		request := &proto.MultiVersionOpRequest{}
-		response := &proto.MultiVersionOpResponse{}
-		response.Op = task.OpCode
-		response.Status = proto.TaskSucceeds
-
-		if task.OpCode == proto.OpVersionOperation {
-			marshaled, _ := json.Marshal(task.Request)
-			if err = json.Unmarshal(marshaled, request); err != nil {
-				log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
-				response.Status = proto.TaskFailed
-				goto end
-			}
-
-			if request.Op == proto.CreateVersionPrepare {
-				if err, _ = s.prepareCreateVersion(request); err != nil {
-					log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
-					goto end
-				}
-			} else if request.Op == proto.CreateVersionCommit {
-				if err = s.commitCreateVersion(request.VolumeID, request.VerSeq); err != nil {
-					log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
-					goto end
-				}
-			}
-
-			response.VerSeq = request.VerSeq
-			response.Op = request.Op
-			response.Addr = request.Addr
-			response.VolumeID = request.VolumeID
-
-		} else {
-			err = fmt.Errorf("illegal opcode")
+	if task.OpCode == proto.OpVersionOperation {
+		marshaled, _ := json.Marshal(task.Request)
+		if err = json.Unmarshal(marshaled, request); err != nil {
 			log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
+			response.Status = proto.TaskFailed
 			goto end
 		}
-	end:
-		if err != nil {
-			response.Result = err.Error()
+
+		if request.Op == proto.CreateVersionPrepare {
+			if err, _ = s.prepareCreateVersion(request); err != nil {
+				log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
+				goto end
+			}
+		} else if request.Op == proto.CreateVersionCommit {
+			if err = s.commitCreateVersion(request.VolumeID, request.VerSeq); err != nil {
+				log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
+				goto end
+			}
+		} else if request.Op == proto.DeleteVersion {
+			if err = s.commitDelVersion(request.VolumeID, request.VerSeq); err != nil {
+				log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
+				goto end
+			}
 		}
-		task.Response = response
-		log.LogInfof("action[handleUpdateVerPacket] rsp to client,req vol %v, verseq %v, op %v", request.VolumeID, request.VerSeq, request.Op)
-		if err = MasterClient.NodeAPI().ResponseDataNodeTask(task); err != nil {
-			err = errors.Trace(err, "handleUpdateVerPacket to master failed.")
-			log.LogErrorf(err.Error())
-			return
-		}
-	}()
+
+		response.VerSeq = request.VerSeq
+		response.Op = request.Op
+		response.Addr = request.Addr
+		response.VolumeID = request.VolumeID
+
+	} else {
+		err = fmt.Errorf("illegal opcode")
+		log.LogErrorf("action[handleUpdateVerPacket] handle master version reqeust err %v", err)
+		goto end
+	}
+end:
+	if err != nil {
+		response.Result = err.Error()
+	}
+	task.Response = response
+	log.LogInfof("action[handleUpdateVerPacket] rsp to client,req vol %v, verseq %v, op %v", request.VolumeID, request.VerSeq, request.Op)
+	if err = MasterClient.NodeAPI().ResponseDataNodeTask(task); err != nil {
+		err = errors.Trace(err, "handleUpdateVerPacket to master failed.")
+		log.LogErrorf(err.Error())
+		return
+	}
+
 }
 
 func (s *DataNode) checkVolumeForbidden(volNames []string) {
@@ -633,7 +621,7 @@ func (s *DataNode) handleMarkDeletePacket(p *repl.Packet, c net.Conn) {
 	// even the partition is forbidden, because
 	// the inode already be deleted in meta partition
 	// if we prevent it, we will get "orphan extents"
-	if p.ExtentType == proto.TinyExtentType || p.Opcode == proto.OpSplitMarkDelete {
+	if proto.IsTinyExtentType(p.ExtentType) || p.Opcode == proto.OpSplitMarkDelete {
 		ext := new(proto.TinyExtentDeleteRecord)
 		err = json.Unmarshal(p.Data, ext)
 		if err == nil {
@@ -714,7 +702,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 		return
 	}
 	store := partition.ExtentStore()
-	if p.ExtentType == proto.TinyExtentType {
+	if proto.IsTinyExtentType(p.ExtentType) {
 		if !shallDegrade {
 			partitionIOMetric = exporter.NewTPCnt(MetricPartitionIOName)
 		}
@@ -827,26 +815,6 @@ func (s *DataNode) handleRandomWritePacket(p *repl.Packet) {
 	if !shallDegrade {
 		metricPartitionIOLabels = GetIoMetricLabels(partition, "randwrite")
 		partitionIOMetric = exporter.NewTPCnt(MetricPartitionIOName)
-	}
-
-	if partition.verSeq > 0 {
-		log.LogDebugf("action[handleRandomWritePacket] opcod %v seq %v dpid %v dpseq %v extid %v", p.Opcode, p.VerSeq, p.PartitionID, partition.verSeq, p.ExtentID)
-		if p.Opcode == proto.OpSyncRandomWrite || p.Opcode == proto.OpRandomWrite {
-			err = fmt.Errorf("volume enable mulit version")
-			log.LogErrorf("action[handleRandomWritePacket] error %v", err)
-			return
-		}
-		if p.VerSeq < partition.verSeq && (p.Opcode == proto.OpRandomWriteVer || p.Opcode == proto.OpSyncRandomWriteVer) {
-			p.ExtentType |= proto.MultiVersionFlag
-			err = storage.VerNotConsistentError
-			log.LogErrorf("action[handleRandomWritePacket] dp %v client verSeq[%v] small than dataPartiton ver[%v]",
-				partition.config.PartitionID, p.VerSeq, partition.verSeq)
-			p.VerSeq = partition.verSeq
-			return
-		} else if p.VerSeq > partition.verSeq {
-			log.LogDebugf("action[handleRandomWritePacket] dp %v client verSeq[%v] and update dp Seq[%v]", partition.config.PartitionID, p.VerSeq, partition.verSeq)
-			partition.verSeq = p.VerSeq
-		}
 	}
 
 	err = partition.RandomWriteSubmit(p)
@@ -1001,7 +969,7 @@ func (s *DataNode) handlePacketToGetAllWatermarks(p *repl.Packet) {
 	)
 	partition := p.Object.(*DataPartition)
 	store := partition.ExtentStore()
-	if p.ExtentType == proto.NormalExtentType {
+	if proto.IsNormalExtentType(p.ExtentType) {
 		fInfoList, _, err = store.GetAllWatermarks(storage.NormalExtentFilter())
 	} else {
 		extents := make([]uint64, 0)

--- a/datanode/wrap_post.go
+++ b/datanode/wrap_post.go
@@ -15,6 +15,7 @@
 package datanode
 
 import (
+	"github.com/cubefs/cubefs/proto"
 	"sync/atomic"
 
 	"github.com/cubefs/cubefs/repl"
@@ -47,7 +48,7 @@ func (s *DataNode) releaseExtent(p *repl.Packet) {
 	if p == nil || !storage.IsTinyExtent(p.ExtentID) || p.ExtentID <= 0 || atomic.LoadInt32(&p.IsReleased) == IsReleased {
 		return
 	}
-	if !p.IsTinyExtentType() || !p.IsLeaderPacket() || !p.IsWriteOperation() || !p.IsForwardPkt() {
+	if !proto.IsTinyExtentType(p.ExtentType) || !p.IsLeaderPacket() || !p.IsWriteOperation() || !p.IsForwardPkt() {
 		return
 	}
 	if p.Object == nil {

--- a/datanode/wrap_prepare.go
+++ b/datanode/wrap_prepare.go
@@ -67,7 +67,7 @@ func (s *DataNode) checkStoreMode(p *repl.Packet) (err error) {
 	if proto.IsTinyExtentType(p.ExtentType) || proto.IsNormalExtentType(p.ExtentType) {
 		return
 	}
-	log.LogErrorf("action[checkStoreMode] extent type11111 %v, %v, %v", p.ExtentType, proto.IsTinyExtentType(p.ExtentType), proto.IsNormalExtentType(p.ExtentType))
+	log.LogErrorf("action[checkStoreMode] dp [%v] reqId [%v] extent type %v", p.PartitionID, p.ReqID, p.ExtentType)
 	return ErrIncorrectStoreType
 }
 

--- a/datanode/wrap_prepare.go
+++ b/datanode/wrap_prepare.go
@@ -145,6 +145,7 @@ func (s *DataNode) addExtentInfo(p *repl.Packet) error {
 				p.PartitionID, p.ExtentOffset, p.KernelOffset)
 			return err
 		}
+
 		p.ExtentOffset, err = store.GetExtentSnapshotModOffset(p.ExtentID, p.Size)
 		log.LogDebugf("action[prepare.addExtentInfo] pack (%v) partition %v %v", p, p.PartitionID, extentID)
 		if err != nil {

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2425,7 +2425,6 @@ func newSimpleView(vol *Vol) (view *proto.SimpleVolView) {
 		DeleteLockTime:          vol.DeleteLockTime,
 		Description:             vol.description,
 		DpSelectorName:          vol.dpSelectorName,
-		DpSelectorParm:          vol.dpSelectorParm,
 		DpReadOnlyWhenVolFull:   vol.DpReadOnlyWhenVolFull,
 		VolType:                 vol.VolType,
 		ObjBlockSize:            vol.EbsBlkSize,

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2425,7 +2425,7 @@ func newSimpleView(vol *Vol) (view *proto.SimpleVolView) {
 		DeleteLockTime:          vol.DeleteLockTime,
 		Description:             vol.description,
 		DpSelectorName:          vol.dpSelectorName,
-		DpSelectorParm: 		 vol.dpSelectorParm,
+		DpSelectorParm:          vol.dpSelectorParm,
 		DpReadOnlyWhenVolFull:   vol.DpReadOnlyWhenVolFull,
 		VolType:                 vol.VolType,
 		ObjBlockSize:            vol.EbsBlkSize,

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2425,6 +2425,7 @@ func newSimpleView(vol *Vol) (view *proto.SimpleVolView) {
 		DeleteLockTime:          vol.DeleteLockTime,
 		Description:             vol.description,
 		DpSelectorName:          vol.dpSelectorName,
+		DpSelectorParm: 		 vol.dpSelectorParm,
 		DpReadOnlyWhenVolFull:   vol.DpReadOnlyWhenVolFull,
 		VolType:                 vol.VolType,
 		ObjBlockSize:            vol.EbsBlkSize,

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -1582,7 +1582,7 @@ func (i *Inode) AppendExtentWithCheck(
 	volType int) (delExtents []proto.ExtentKey, status uint8) {
 
 	ek.SetSeq(mpVer)
-	log.LogDebugf("action[AppendExtentWithCheck] mpVer %v inode %v and ver %v,req ver %v,ek %v,hist len %v",
+	log.LogDebugf("action[AppendExtentWithCheck] mpVer %v inode %v and fsm ver %v,req ver %v,ek %v,hist len %v",
 		mpVer, i.Inode, i.getVer(), reqVer, ek, i.getLayerLen())
 
 	if mpVer != i.getVer() {

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -127,14 +127,14 @@ func (i *Inode) setVer(seq uint64) {
 	}
 }
 
-func (i *Inode) insertEkRefMap(ek *proto.ExtentKey) {
+func (i *Inode) insertEkRefMap(mpId uint64, ek *proto.ExtentKey) {
 	if i.multiSnap == nil {
 		i.multiSnap = NewMultiSnap(i.getVer())
 	}
 	if i.multiSnap.ekRefMap == nil {
 		i.multiSnap.ekRefMap = new(sync.Map)
 	}
-	storeEkSplit(i.Inode, i.multiSnap.ekRefMap, ek)
+	storeEkSplit(mpId, i.Inode, i.multiSnap.ekRefMap, ek)
 }
 
 func (i *Inode) getEkRefMap() *sync.Map {
@@ -216,7 +216,8 @@ func (inode *Inode) GetAllExtsOfflineInode(mpID uint64) (extInfo map[uint64][]*p
 					dOK  bool
 					last bool
 				)
-				if dOK, last = dIno.DecSplitEk(ext); !dOK {
+				log.LogDebugf("deleteMarkedInodes DecSplitEk mpID %v inode [%v]", mpID, inode.Inode)
+				if dOK, last = dIno.DecSplitEk(mpID, ext); !dOK {
 					return false
 				}
 				if !last {
@@ -936,7 +937,7 @@ func (i *Inode) MultiLayerClearExtByVer(layer int, dVerSeq uint64) (delExtents [
 	return
 }
 
-func (i *Inode) mergeExtentArr(extentKeysLeft []proto.ExtentKey, extentKeysRight []proto.ExtentKey) []proto.ExtentKey {
+func (i *Inode) mergeExtentArr(mpId uint64, extentKeysLeft []proto.ExtentKey, extentKeysRight []proto.ExtentKey) []proto.ExtentKey {
 	lCnt := len(extentKeysLeft)
 	rCnt := len(extentKeysRight)
 	sortMergedExts := make([]proto.ExtentKey, 0, lCnt+rCnt)
@@ -946,11 +947,11 @@ func (i *Inode) mergeExtentArr(extentKeysLeft []proto.ExtentKey, extentKeysRight
 		mLen := len(sortMergedExts)
 		if mLen > 0 && sortMergedExts[mLen-1].IsSequence(&(*keyArr)[pos]) {
 			sortMergedExts[mLen-1].Size += (*keyArr)[pos].Size
-			log.LogDebugf("mergeExtentArr. ek left %v right %v", sortMergedExts[mLen-1], (*keyArr)[pos])
+			log.LogDebugf("[mergeExtentArr] mpId[%v]. ek left %v right %v", mpId, sortMergedExts[mLen-1], (*keyArr)[pos])
 			if !sortMergedExts[mLen-1].IsSplit() || !(*keyArr)[pos].IsSplit() {
-				log.LogErrorf("ino %v ek merge left %v right %v not all split", i.Inode, sortMergedExts[mLen-1], (*keyArr)[pos])
+				log.LogErrorf("[mergeExtentArr] mpId[%v] ino %v ek merge left %v right %v not all split", mpId, i.Inode, sortMergedExts[mLen-1], (*keyArr)[pos])
 			}
-			i.DecSplitEk(&(*keyArr)[pos])
+			i.DecSplitEk(mpId, &(*keyArr)[pos])
 		} else {
 			sortMergedExts = append(sortMergedExts, (*keyArr)[pos])
 		}
@@ -981,11 +982,11 @@ func (i *Inode) mergeExtentArr(extentKeysLeft []proto.ExtentKey, extentKeysRight
 // Restore ext info to older version or deleted if no right version
 // The list(multiSnap.multiVersions) contains all point of modification on inode, each ext must belong to one layer.
 // Once the layer be deleted is top layer ver be changed to upper layer, or else the ext belongs is exclusive and can be dropped
-func (i *Inode) RestoreExts2NextLayer(delExtentsOrigin []proto.ExtentKey, curVer uint64, idx int) (delExtents []proto.ExtentKey, err error) {
-	log.LogInfof("action[RestoreMultiSnapExts] curVer [%v] delExtents size [%v] hist len [%v]", curVer, len(delExtentsOrigin), i.getLayerLen())
+func (i *Inode) RestoreExts2NextLayer(mpId uint64, delExtentsOrigin []proto.ExtentKey, curVer uint64, idx int) (delExtents []proto.ExtentKey, err error) {
+	log.LogInfof("action[RestoreMultiSnapExts] mpId [%v] curVer [%v] delExtents size [%v] hist len [%v]", mpId, curVer, len(delExtentsOrigin), i.getLayerLen())
 	// no version left.all old versions be deleted
 	if i.isEmptyVerList() {
-		log.LogWarnf("action[RestoreMultiSnapExts] restore have no old version left")
+		log.LogWarnf("action[RestoreMultiSnapExts] mpId [%v] inode [%v] restore have no old version left", mpId, i.Inode)
 		return delExtentsOrigin, nil
 	}
 	lastSeq := i.multiSnap.multiVersions[idx].getVer()
@@ -994,37 +995,37 @@ func (i *Inode) RestoreExts2NextLayer(delExtentsOrigin []proto.ExtentKey, curVer
 	for _, delExt := range delExtentsOrigin {
 		// curr deleting delExt with a seq larger than the next version's seq, it doesn't belong to any
 		// versions,so try to delete it
-		log.LogDebugf("action[RestoreMultiSnapExts] ext split [%v] with seq[%v] gSeq[%v] try to del.the last seq [%v], ek details[%v]",
-			delExt.IsSplit(), delExt.GetSeq(), curVer, lastSeq, delExt)
+		log.LogDebugf("action[RestoreMultiSnapExts] mpId [%v] inode [%v] ext split [%v] with seq[%v] gSeq[%v] try to del.the last seq [%v], ek details[%v]",
+			mpId, i.Inode, delExt.IsSplit(), delExt.GetSeq(), curVer, lastSeq, delExt)
 		if delExt.GetSeq() > lastSeq {
 			delExtents = append(delExtents, delExt)
 		} else {
-			log.LogInfof("action[RestoreMultiSnapExts] move to level 1 delExt [%v] specSnapExtent size [%v]", delExt, len(specSnapExtent))
+			log.LogInfof("action[RestoreMultiSnapExts] mpId [%v] inode [%v] move to level 1 delExt [%v] specSnapExtent size [%v]", mpId, i.Inode, delExt, len(specSnapExtent))
 			specSnapExtent = append(specSnapExtent, delExt)
 		}
 	}
 	if len(specSnapExtent) == 0 {
-		log.LogInfof("action[RestoreMultiSnapExts] no need to move to level 1")
+		log.LogInfof("action[RestoreMultiSnapExts] mpId [%v] inode [%v] no need to move to level 1", mpId, i.Inode)
 		return
 	}
 	if len(specSnapExtent) > 0 && i.isEmptyVerList() {
-		err = fmt.Errorf("inode %v error not found prev snapshot index", i.Inode)
-		log.LogErrorf("action[RestoreMultiSnapExts] %v", err)
+		err = fmt.Errorf("mpId [%v] inode %v error not found prev snapshot index", mpId, i.Inode)
+		log.LogErrorf("action[RestoreMultiSnapExts] mpId [%v] inode [%v] %v", mpId, i.Inode, err)
 		return
 	}
 
 	i.multiSnap.multiVersions[idx].Extents.Lock()
-	i.multiSnap.multiVersions[idx].Extents.eks = i.mergeExtentArr(i.multiSnap.multiVersions[idx].Extents.eks, specSnapExtent)
+	i.multiSnap.multiVersions[idx].Extents.eks = i.mergeExtentArr(mpId, i.multiSnap.multiVersions[idx].Extents.eks, specSnapExtent)
 	i.multiSnap.multiVersions[idx].Extents.Unlock()
 
 	return
 }
 
-func (inode *Inode) unlinkTopLayer(ino *Inode, mpVer uint64, verlist *proto.VolVersionInfoList) (ext2Del []proto.ExtentKey, doMore bool, status uint8) {
+func (inode *Inode) unlinkTopLayer(mpId uint64, ino *Inode, mpVer uint64, verlist *proto.VolVersionInfoList) (ext2Del []proto.ExtentKey, doMore bool, status uint8) {
 	// if there's no snapshot itself, nor have snapshot after inode's ver then need unlink directly and make no snapshot
 	// just move to upper layer, the behavior looks like that the snapshot be dropped
-	log.LogDebugf("action[unlinkTopLayer] mpVer %v check if have snapshot depends on the deleitng ino %v (with no snapshot itself) found seq %v, verlist %v",
-		mpVer, ino, inode.getVer(), verlist)
+	log.LogDebugf("action[unlinkTopLayer] mpid [%v] mpVer %v check if have snapshot depends on the deleitng ino %v (with no snapshot itself) found seq %v, verlist %v",
+		mpId, mpVer, ino, inode.getVer(), verlist)
 	status = proto.OpOk
 
 	delFunc := func() (done bool) {
@@ -1035,7 +1036,7 @@ func (inode *Inode) unlinkTopLayer(ino *Inode, mpVer uint64, verlist *proto.VolV
 			return true
 		}
 		var dIno *Inode
-		if ext2Del, dIno = inode.getAndDelVer(ino.getVer(), mpVer, verlist); dIno == nil {
+		if ext2Del, dIno = inode.getAndDelVer(mpId, ino.getVer(), mpVer, verlist); dIno == nil {
 			status = proto.OpNotExistErr
 			log.LogDebugf("action[unlinkTopLayer] ino %v", ino)
 			return true
@@ -1165,8 +1166,8 @@ func (inode *Inode) dirUnlinkVerInlist(ino *Inode, mpVer uint64, verlist *proto.
 	return
 }
 
-func (inode *Inode) unlinkVerInList(ino *Inode, mpVer uint64, verlist *proto.VolVersionInfoList) (ext2Del []proto.ExtentKey, doMore bool, status uint8) {
-	log.LogDebugf("action[unlinkVerInList] ino %v try search seq %v isdir %v", ino, ino.getVer(), proto.IsDir(inode.Type))
+func (inode *Inode) unlinkVerInList(mpId uint64, ino *Inode, mpVer uint64, verlist *proto.VolVersionInfoList) (ext2Del []proto.ExtentKey, doMore bool, status uint8) {
+	log.LogDebugf("action[unlinkVerInList] mpId [%v] ino %v try search seq %v isdir %v", mpId, ino, ino.getVer(), proto.IsDir(inode.Type))
 	if proto.IsDir(inode.Type) { // snapshot dir deletion don't take link into consider, but considers the scope of snapshot contrast to verList
 		return inode.dirUnlinkVerInlist(ino, mpVer, verlist)
 	}
@@ -1192,7 +1193,7 @@ func (inode *Inode) unlinkVerInList(ino *Inode, mpVer uint64, verlist *proto.Vol
 		return
 	} else {
 		// don't unlink if no version satisfied
-		if ext2Del, dIno = inode.getAndDelVer(ino.getVer(), mpVer, verlist); dIno == nil {
+		if ext2Del, dIno = inode.getAndDelVer(mpId, ino.getVer(), mpVer, verlist); dIno == nil {
 			status = proto.OpNotExistErr
 			log.LogDebugf("action[unlinkVerInList] ino %v", ino)
 			return
@@ -1322,7 +1323,7 @@ func (ino *Inode) getInoByVer(verSeq uint64, equal bool) (i *Inode, idx int) {
 // 2. if have system layer between dVer and next older inode's layer(not exist is ok), drop dVer related exts and update ver
 // 3. else Restore to next inode's Layer
 
-func (i *Inode) getAndDelVer(dVer uint64, mpVer uint64, verlist *proto.VolVersionInfoList) (delExtents []proto.ExtentKey, ino *Inode) {
+func (i *Inode) getAndDelVer(mpId uint64, dVer uint64, mpVer uint64, verlist *proto.VolVersionInfoList) (delExtents []proto.ExtentKey, ino *Inode) {
 	var err error
 	verlist.RLock()
 	defer verlist.RUnlock()
@@ -1332,7 +1333,7 @@ func (i *Inode) getAndDelVer(dVer uint64, mpVer uint64, verlist *proto.VolVersio
 
 	// first layer need delete
 	if dVer == 0 {
-		if delExtents, err = i.RestoreExts2NextLayer(i.Extents.eks, mpVer, 0); err != nil {
+		if delExtents, err = i.RestoreExts2NextLayer(mpId, i.Extents.eks, mpVer, 0); err != nil {
 			log.LogErrorf("action[getAndDelVer] ino %v RestoreMultiSnapExts split error %v", i.Inode, err)
 			return
 		}
@@ -1405,7 +1406,7 @@ func (i *Inode) getAndDelVer(dVer uint64, mpVer uint64, verlist *proto.VolVersio
 			} else {
 				log.LogDebugf("action[getAndDelVer] ino %v ver %v nextVer %v step 3 ver ", i.Inode, mIno.getVer(), nVerSeq)
 				// 3. next layer exist. the deleted version and  next version are neighbor in verlist, thus need restore and delete
-				if delExtents, err = i.RestoreExts2NextLayer(mIno.Extents.eks, dVer, id+1); err != nil {
+				if delExtents, err = i.RestoreExts2NextLayer(mpId, mIno.Extents.eks, dVer, id+1); err != nil {
 					log.LogDebugf("action[getAndDelVer] ino %v RestoreMultiSnapExts split error %v", i.Inode, err)
 					return
 				}
@@ -1491,22 +1492,21 @@ func (i *Inode) buildMultiSnap() {
 	}
 }
 
-func (i *Inode) SplitExtentWithCheck(mpVer uint64, multiVersionList *proto.VolVersionInfoList,
-	reqVer uint64, ek proto.ExtentKey, ct int64, volType int) (delExtents []proto.ExtentKey, status uint8) {
+func (i *Inode) SplitExtentWithCheck(param *AppendExtParam) (delExtents []proto.ExtentKey, status uint8) {
 
 	var err error
-	ek.SetSeq(reqVer)
-	log.LogDebugf("action[SplitExtentWithCheck] inode %v,ver %v,ek %v,hist len %v", i.Inode, reqVer, ek, i.getLayerLen())
+	param.ek.SetSeq(param.reqVer)
+	log.LogDebugf("action[SplitExtentWithCheck] inode %v,ver %v,ek %v,hist len %v", i.Inode, param.reqVer, param.ek, i.getLayerLen())
 
-	if reqVer != i.getVer() {
-		log.LogDebugf("action[SplitExtentWithCheck] CreateVer ver %v", reqVer)
-		i.CreateVer(reqVer)
+	if param.reqVer != i.getVer() {
+		log.LogDebugf("action[SplitExtentWithCheck] CreateVer ver %v", param.reqVer)
+		i.CreateVer(param.reqVer)
 	}
 	i.Lock()
 	defer i.Unlock()
 
 	i.buildMultiSnap()
-	delExtents, status = i.Extents.SplitWithCheck(i.Inode, ek, i.multiSnap.ekRefMap)
+	delExtents, status = i.Extents.SplitWithCheck(param.mpId, i.Inode, param.ek, i.multiSnap.ekRefMap)
 	if status != proto.OpOk {
 		log.LogErrorf("action[SplitExtentWithCheck] status %v", status)
 		return
@@ -1515,17 +1515,17 @@ func (i *Inode) SplitExtentWithCheck(mpVer uint64, multiVersionList *proto.VolVe
 		return
 	}
 
-	if err = i.CreateLowerVersion(i.getVer(), multiVersionList); err != nil {
+	if err = i.CreateLowerVersion(i.getVer(), param.multiVersionList); err != nil {
 		return
 	}
 
-	if delExtents, err = i.RestoreExts2NextLayer(delExtents, mpVer, 0); err != nil {
+	if delExtents, err = i.RestoreExts2NextLayer(param.mpId, delExtents, param.mpVer, 0); err != nil {
 		log.LogErrorf("action[fsmAppendExtentWithCheck] ino %v RestoreMultiSnapExts split error %v", i.Inode, err)
 		return
 	}
-	if proto.IsHot(volType) {
+	if proto.IsHot(param.volType) {
 		i.Generation++
-		i.ModifyTime = ct
+		i.ModifyTime = param.ct
 	}
 
 	return
@@ -1572,29 +1572,33 @@ func (i *Inode) CreateLowerVersion(curVer uint64, verlist *proto.VolVersionInfoL
 	return
 }
 
-func (i *Inode) AppendExtentWithCheck(
-	mpVer uint64,
-	multiVersionList *proto.VolVersionInfoList,
-	reqVer uint64,
-	ek proto.ExtentKey,
-	ct int64,
-	discardExtents []proto.ExtentKey,
-	volType int) (delExtents []proto.ExtentKey, status uint8) {
+type AppendExtParam struct {
+	mpId             uint64
+	mpVer            uint64
+	multiVersionList *proto.VolVersionInfoList
+	reqVer           uint64
+	ek               proto.ExtentKey
+	ct               int64
+	discardExtents   []proto.ExtentKey
+	volType          int
+}
 
-	ek.SetSeq(mpVer)
+func (i *Inode) AppendExtentWithCheck(param *AppendExtParam) (delExtents []proto.ExtentKey, status uint8) {
+
+	param.ek.SetSeq(param.mpVer)
 	log.LogDebugf("action[AppendExtentWithCheck] mpVer %v inode %v and fsm ver %v,req ver %v,ek %v,hist len %v",
-		mpVer, i.Inode, i.getVer(), reqVer, ek, i.getLayerLen())
+		param.mpVer, i.Inode, i.getVer(), param.reqVer, param.ek, i.getLayerLen())
 
-	if mpVer != i.getVer() {
-		log.LogDebugf("action[AppendExtentWithCheck] ver %v inode ver %v", reqVer, i.getVer())
-		i.CreateVer(mpVer)
+	if param.mpVer != i.getVer() {
+		log.LogDebugf("action[AppendExtentWithCheck] ver %v inode ver %v", param.reqVer, i.getVer())
+		i.CreateVer(param.mpVer)
 	}
 
 	i.Lock()
 	defer i.Unlock()
 
-	refFunc := func(key *proto.ExtentKey) { i.insertEkRefMap(key) }
-	delExtents, status = i.Extents.AppendWithCheck(i.Inode, ek, refFunc, discardExtents)
+	refFunc := func(key *proto.ExtentKey) { i.insertEkRefMap(param.mpId, key) }
+	delExtents, status = i.Extents.AppendWithCheck(i.Inode, param.ek, refFunc, param.discardExtents)
 	if status != proto.OpOk {
 		log.LogErrorf("action[AppendExtentWithCheck] status %v", status)
 		return
@@ -1603,22 +1607,22 @@ func (i *Inode) AppendExtentWithCheck(
 	// multi version take effect
 	if i.getVer() > 0 && len(delExtents) > 0 {
 		var err error
-		if err = i.CreateLowerVersion(i.getVer(), multiVersionList); err != nil {
+		if err = i.CreateLowerVersion(i.getVer(), param.multiVersionList); err != nil {
 			return
 		}
-		if delExtents, err = i.RestoreExts2NextLayer(delExtents, mpVer, 0); err != nil {
+		if delExtents, err = i.RestoreExts2NextLayer(param.mpId, delExtents, param.mpVer, 0); err != nil {
 			log.LogErrorf("action[AppendExtentWithCheck] RestoreMultiSnapExts err %v", err)
 			return nil, proto.OpErr
 		}
 	}
 
-	if proto.IsHot(volType) {
+	if proto.IsHot(param.volType) {
 		size := i.Extents.Size()
 		if i.Size < size {
 			i.Size = size
 		}
 		i.Generation++
-		i.ModifyTime = ct
+		i.ModifyTime = param.ct
 	}
 	return
 }
@@ -1661,29 +1665,34 @@ func (i *Inode) DecNLinkByVer(verSeq uint64) {
 	i.DecNLink()
 }
 
-func (i *Inode) DecSplitExts(delExtents interface{}) {
-	log.LogDebugf("DecSplitExts inode %v", i.Inode)
+func (i *Inode) DecSplitExts(mpId uint64, delExtents interface{}) {
+	log.LogDebugf("[DecSplitExts] mpId [%v] inode %v", mpId, i.Inode)
 	cnt := len(delExtents.([]proto.ExtentKey))
 	for id := 0; id < cnt; id++ {
 		ek := &delExtents.([]proto.ExtentKey)[id]
 		if !ek.IsSplit() {
-			log.LogDebugf("DecSplitExts ek not split %v", ek)
+			log.LogDebugf("[DecSplitExts] mpId [%v]  ek not split %v", mpId, ek)
 			continue
 		}
-		ok, last := i.DecSplitEk(ek)
+		if i.multiSnap.ekRefMap == nil {
+			log.LogErrorf("[DecSplitExts] mpid [%v]. multiSnap.ekRefMap is nil", mpId)
+			return
+		}
+
+		ok, last := i.DecSplitEk(mpId, ek)
 		if !ok {
-			log.LogErrorf("DecSplitExts. ek %v not found!", ek)
+			log.LogErrorf("[DecSplitExts] mpid [%v]. ek %v not found!", mpId, ek)
 			continue
 		}
 		if last {
-			log.LogDebugf("DecSplitExts ek %v split flag be unset to remove all content", ek)
+			log.LogDebugf("[DecSplitExts] mpid [%v] ek %v split flag be unset to remove all content", mpId, ek)
 			ek.SetSplit(false)
 		}
 	}
 }
 
-func (i *Inode) DecSplitEk(ext *proto.ExtentKey) (ok bool, last bool) {
-	log.LogDebugf("DecSplitEk inode %v dp %v extent id %v.key %v ext %v", i.Inode, ext.PartitionId, ext.ExtentId,
+func (i *Inode) DecSplitEk(mpId uint64, ext *proto.ExtentKey) (ok bool, last bool) {
+	log.LogDebugf("[DecSplitEk] mpId[%v] inode %v dp %v extent id %v.key %v ext %v", mpId, i.Inode, ext.PartitionId, ext.ExtentId,
 		ext.PartitionId<<32|ext.ExtentId, ext)
 
 	if i.multiSnap == nil || i.multiSnap.ekRefMap == nil {
@@ -1691,21 +1700,21 @@ func (i *Inode) DecSplitEk(ext *proto.ExtentKey) (ok bool, last bool) {
 		return
 	}
 	if val, ok := i.multiSnap.ekRefMap.Load(ext.PartitionId<<32 | ext.ExtentId); !ok {
-		log.LogErrorf("DecSplitEk. dp %v inode [%v] ext not found", ext.PartitionId, i.Inode)
+		log.LogErrorf("[DecSplitEk] mpId[%v]. dp %v inode [%v] ext not found", mpId, ext.PartitionId, i.Inode)
 		return false, false
 	} else {
 		if val.(uint32) == 0 {
-			log.LogErrorf("DecSplitEk. dp %v inode [%v] ek ref is zero!", ext.PartitionId, i.Inode)
+			log.LogErrorf("[DecSplitEk] mpId[%v]. dp %v inode [%v] ek ref is zero!", mpId, ext.PartitionId, i.Inode)
 			return false, false
 		}
 		if val.(uint32) == 1 {
-			log.LogDebugf("DecSplitEk inode %v dp %v extent id %v.key %v", i.Inode, ext.PartitionId, ext.ExtentId,
+			log.LogDebugf("[DecSplitEk] mpId[%v] inode %v dp %v extent id %v.key %v", mpId, i.Inode, ext.PartitionId, ext.ExtentId,
 				ext.PartitionId<<32|ext.ExtentId)
 			i.multiSnap.ekRefMap.Delete(ext.PartitionId<<32 | ext.ExtentId)
 			return true, true
 		}
 		i.multiSnap.ekRefMap.Store(ext.PartitionId<<32|ext.ExtentId, val.(uint32)-1)
-		log.LogDebugf("DecSplitEk. mp %v inode [%v] ek %v val %v", ext.PartitionId, i.Inode, ext, val.(uint32)-1)
+		log.LogDebugf("[DecSplitEk] mpId[%v]. mp %v inode [%v] ek %v val %v", mpId, ext.PartitionId, i.Inode, ext, val.(uint32)-1)
 		return true, false
 	}
 }

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -603,9 +603,11 @@ func (m *metadataManager) deletePartition(id uint64) (err error) {
 }
 
 // Range scans all the meta partitions.
-func (m *metadataManager) Range(f func(i uint64, p MetaPartition) bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+func (m *metadataManager) Range(needLock bool, f func(i uint64, p MetaPartition) bool) {
+	if needLock {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+	}
 	for k, v := range m.partitions {
 		if !f(k, v) {
 			return

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -244,12 +244,12 @@ func TestEkMarshal(t *testing.T) {
 			VerSeq: 123444,
 		},
 	}
-	id := storeEkSplit(0, ino.multiSnap.ekRefMap, ek)
+	id := storeEkSplit(0, 0, ino.multiSnap.ekRefMap, ek)
 	dpID, extID := proto.ParseFromId(id)
 	assert.True(t, dpID == ek.PartitionId)
 	assert.True(t, extID == ek.ExtentId)
 
-	ok, _ := ino.DecSplitEk(ek)
+	ok, _ := ino.DecSplitEk(mp.config.PartitionId, ek)
 	assert.True(t, ok == true)
 	log.LogDebugf("TestEkMarshal close")
 }

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var partitionId uint64 = 10
-var manager = &metadataManager{}
+var manager = &metadataManager{partitions: make(map[uint64]MetaPartition), volUpdating: new(sync.Map)}
 var mp *metaPartition
 
 //PartitionId   uint64              `json:"partition_id"`
@@ -1213,6 +1213,11 @@ func mockPartitionRaftForTest(ctrl *gomock.Controller) *metaPartition {
 		idx++
 		return partition.Apply(cmd, idx)
 	}).AnyTimes()
+
+	raft.EXPECT().IsRaftLeader().DoAndReturn(func(cmd []byte) (resp interface{}, err error) {
+		return true, nil
+	}).AnyTimes()
+
 	raft.EXPECT().LeaderTerm().Return(uint64(1), uint64(1)).AnyTimes()
 	partition.raftPartition = raft
 
@@ -1259,6 +1264,7 @@ func TestCheckVerList(t *testing.T) {
 	assert.True(t, len(mp.multiVersionList.VerList) == 2)
 	mp.stop()
 }
+
 func checkStoreMode(t *testing.T, ExtentType uint8) (err error) {
 	if proto.IsTinyExtentType(ExtentType) || proto.IsNormalExtentType(ExtentType) {
 		return
@@ -1266,8 +1272,73 @@ func checkStoreMode(t *testing.T, ExtentType uint8) (err error) {
 	t.Logf("action[checkStoreMode] extent type %v", ExtentType)
 	return fmt.Errorf("error")
 }
+
 func TestCheckMod(t *testing.T) {
 	var tp uint8 = 192
 	err := checkStoreMode(t, tp)
 	assert.True(t, err == nil)
+}
+
+func managerVersionPrepare(req *proto.MultiVersionOpRequest) (err error) {
+	if err, _ = manager.prepareCreateVersion(req); err != nil {
+		return
+	}
+	return manager.commitCreateVersion(req.VolumeID, req.VerSeq, req.Op, true)
+}
+
+func TestOpCommitVersion(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	for i := 1; i < 5; i++ {
+		mp = mockPartitionRaftForTest(mockCtrl)
+		mp.config.PartitionId = uint64(i)
+		mp.manager = manager
+		mp.manager.partitions[mp.config.PartitionId] = mp
+		mp.config.NodeId = 1
+	}
+
+	err := managerVersionPrepare(&proto.MultiVersionOpRequest{VolumeID: VolNameForTest, Op: proto.CreateVersionPrepare, VerSeq: 10000})
+	assert.True(t, err == nil)
+	for _, m := range manager.partitions {
+		mList := m.GetVerList()
+		assert.True(t, len(mList) == 1)
+		assert.True(t, mList[0].Ver == 10000)
+		assert.True(t, mList[0].Status == proto.VersionPrepare)
+	}
+	err = manager.commitCreateVersion(VolNameForTest, 10000, proto.CreateVersionPrepare, true)
+	assert.True(t, err == nil)
+	for _, m := range manager.partitions {
+		mList := m.GetVerList()
+		assert.True(t, len(mList) == 1)
+		assert.True(t, mList[0].Ver == 10000)
+		assert.True(t, mList[0].Status == proto.VersionPrepare)
+	}
+	err = managerVersionPrepare(&proto.MultiVersionOpRequest{VolumeID: VolNameForTest, Op: proto.CreateVersionPrepare, VerSeq: 5000})
+	assert.True(t, err != nil)
+	for _, m := range manager.partitions {
+		mList := m.GetVerList()
+		assert.True(t, len(mList) == 1)
+		assert.True(t, mList[0].Ver == 10000)
+		assert.True(t, mList[0].Status == proto.VersionPrepare)
+	}
+	err = managerVersionPrepare(&proto.MultiVersionOpRequest{VolumeID: VolNameForTest, Op: proto.CreateVersionPrepare, VerSeq: 20000})
+	assert.True(t, err == nil)
+	for _, m := range manager.partitions {
+		mList := m.GetVerList()
+		assert.True(t, len(mList) == 2)
+		assert.True(t, mList[0].Ver == 10000)
+		assert.True(t, mList[0].Status == proto.VersionPrepare)
+		assert.True(t, mList[1].Ver == 20000)
+		assert.True(t, mList[1].Status == proto.VersionPrepare)
+	}
+	err = manager.commitCreateVersion(VolNameForTest, 20000, proto.CreateVersionCommit, true)
+	assert.True(t, err == nil)
+	for _, m := range manager.partitions {
+		mList := m.GetVerList()
+		assert.True(t, len(mList) == 2)
+		assert.True(t, mList[0].Ver == 10000)
+		assert.True(t, mList[0].Status == proto.VersionPrepare)
+		assert.True(t, mList[1].Ver == 20000)
+		assert.True(t, mList[1].Status == proto.VersionNormal)
+	}
 }

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -1238,7 +1238,7 @@ func TestCheckVerList(t *testing.T) {
 			{Ver: 50, Status: proto.VersionNormal}},
 	}
 
-	mp.checkVerList(masterList)
+	mp.checkVerList(masterList, false)
 	verData := <-mp.verUpdateChan
 	mp.submit(opFSMVersionOp, verData)
 
@@ -1251,11 +1251,23 @@ func TestCheckVerList(t *testing.T) {
 			{Ver: 40, Status: proto.VersionNormal}},
 	}
 
-	mp.checkVerList(masterList)
+	mp.checkVerList(masterList, false)
 	verData = <-mp.verUpdateChan
 	mp.submit(opFSMVersionOp, verData)
 
 	assert.True(t, mp.verSeq == 40)
 	assert.True(t, len(mp.multiVersionList.VerList) == 2)
 	mp.stop()
+}
+func checkStoreMode(t *testing.T, ExtentType uint8) (err error) {
+	if proto.IsTinyExtentType(ExtentType) || proto.IsNormalExtentType(ExtentType) {
+		return
+	}
+	t.Logf("action[checkStoreMode] extent type %v", ExtentType)
+	return fmt.Errorf("error")
+}
+func TestCheckMod(t *testing.T) {
+	var tp uint8 = 192
+	err := checkStoreMode(t, tp)
+	assert.True(t, err == nil)
 }

--- a/metanode/packet.go
+++ b/metanode/packet.go
@@ -32,7 +32,7 @@ func NewPacketToDeleteExtent(dp *DataPartition, ext *proto.ExtentKey) (p *Packet
 	p.Magic = proto.ProtoMagic
 	p.Opcode = proto.OpMarkDelete
 	p.ExtentType = proto.NormalExtentType
-	p.PartitionID = uint64(dp.PartitionID)
+	p.PartitionID = dp.PartitionID
 	if storage.IsTinyExtent(ext.ExtentId) {
 		p.ExtentType = proto.TinyExtentType
 	}

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -690,7 +690,6 @@ func (mp *metaPartition) onStart(isCreate bool) (err error) {
 		}
 		mp.onStop()
 	}()
-	mp.multiVersionList = &proto.VolVersionInfoList{}
 	if err = mp.load(isCreate); err != nil {
 		err = errors.NewErrorf("[onStart] load partition id=%d: %s",
 			mp.config.PartitionId, err.Error())
@@ -862,20 +861,21 @@ func (mp *metaPartition) getRaftPort() (heartbeat, replica int, err error) {
 // NewMetaPartition creates a new meta partition with the specified configuration.
 func NewMetaPartition(conf *MetaPartitionConfig, manager *metadataManager) MetaPartition {
 	mp := &metaPartition{
-		config:        conf,
-		dentryTree:    NewBtree(),
-		inodeTree:     NewBtree(),
-		extendTree:    NewBtree(),
-		multipartTree: NewBtree(),
-		stopC:         make(chan bool),
-		storeChan:     make(chan *storeMsg, 100),
-		freeList:      newFreeList(),
-		extDelCh:      make(chan []proto.ExtentKey, defaultDelExtentsCnt),
-		extReset:      make(chan struct{}),
-		vol:           NewVol(),
-		manager:       manager,
-		uniqChecker:   newUniqChecker(),
-		verSeq:        conf.VerSeq,
+		config:           conf,
+		dentryTree:       NewBtree(),
+		inodeTree:        NewBtree(),
+		extendTree:       NewBtree(),
+		multipartTree:    NewBtree(),
+		stopC:            make(chan bool),
+		storeChan:        make(chan *storeMsg, 100),
+		freeList:         newFreeList(),
+		extDelCh:         make(chan []proto.ExtentKey, defaultDelExtentsCnt),
+		extReset:         make(chan struct{}),
+		vol:              NewVol(),
+		manager:          manager,
+		uniqChecker:      newUniqChecker(),
+		verSeq:           conf.VerSeq,
+		multiVersionList: &proto.VolVersionInfoList{},
 	}
 	mp.txProcessor = NewTransactionProcessor(mp)
 	return mp

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -211,12 +211,12 @@ type OpMultipart interface {
 
 // MultiVersion operation from master or client
 type OpMultiVersion interface {
-	HandleVersionOp(op uint8, verSeq uint64, verList []*proto.VolVersionInfo) (err error)
+	HandleVersionOp(op uint8, verSeq uint64, verList []*proto.VolVersionInfo, sync bool) (err error)
 	fsmVersionOp(reqData []byte) (err error)
 	GetAllVersionInfo(req *proto.MultiVersionOpRequest, p *Packet) (err error)
 	GetSpecVersionInfo(req *proto.MultiVersionOpRequest, p *Packet) (err error)
 	GetExtentByVer(ino *Inode, req *proto.GetExtentsRequest, rsp *proto.GetExtentsResponse)
-	checkVerList(info *proto.VolVersionInfoList) (err error)
+	checkVerList(info *proto.VolVersionInfoList, sync bool) (err error)
 }
 
 // OpMeta defines the interface for the metadata operations.
@@ -236,6 +236,7 @@ type OpMeta interface {
 type OpPartition interface {
 	GetVolName() (volName string)
 	GetVerSeq() uint64
+	GetVerList() []*proto.VolVersionInfo
 	IsLeader() (leaderAddr string, isLeader bool)
 	LeaderTerm() (leaderID, term uint64)
 	IsFollowerRead() bool
@@ -529,7 +530,7 @@ func (mp *metaPartition) acucumUidSizeByLoad(ino *Inode) {
 	mp.uidManager.accumInoUidSize(ino, mp.uidManager.accumBase)
 }
 
-func (mp *metaPartition) getVerList() []*proto.VolVersionInfo {
+func (mp *metaPartition) GetVerList() []*proto.VolVersionInfo {
 	mp.multiVersionList.RLock()
 	defer mp.multiVersionList.RUnlock()
 	return mp.multiVersionList.VerList

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -442,7 +442,7 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 		}
 		err = mp.fsmUniqCheckerEvict(req)
 	case opFSMVersionOp:
-		resp = mp.fsmVersionOp(msg.V)
+		err = mp.fsmVersionOp(msg.V)
 	}
 
 	return
@@ -467,17 +467,49 @@ func (mp *metaPartition) fsmVersionOp(reqData []byte) (err error) {
 
 	var opData VerOpData
 	if err = json.Unmarshal(reqData, &opData); err != nil {
-		log.LogErrorf("action[fsmVersionOp] unmarshal error %v", err)
+		log.LogErrorf("action[fsmVersionOp] mp[%v] unmarshal error %v", mp.config.PartitionId, err)
 		return
 	}
 
 	log.LogInfof("action[fsmVersionOp] mp[%v] seq %v, op %v", mp.config.PartitionId, opData.VerSeq, opData.Op)
-	if opData.Op == proto.CreateVersionCommit {
+	if opData.Op == proto.CreateVersionPrepare {
 		cnt := len(mp.multiVersionList.VerList)
-		if cnt > 0 && mp.multiVersionList.VerList[cnt-1].Ver >= opData.VerSeq {
-			log.LogErrorf("action[HandleVersionOp] reqeust seq %v lessOrEqual last exist snapshot seq %v",
-				mp.multiVersionList.VerList[cnt-1].Ver, opData.VerSeq)
-			return
+		if cnt > 0 {
+			lastVersion := mp.multiVersionList.VerList[cnt-1]
+			if lastVersion.Ver > opData.VerSeq {
+				err = fmt.Errorf("reqeust seq %v less than last exist snapshot seq %v",
+					opData.VerSeq, lastVersion.Ver)
+				log.LogErrorf("action[HandleVersionOp] createVersionPrepare err %v", err)
+				return
+			} else if lastVersion.Ver == opData.VerSeq {
+				log.LogWarnf("action[HandleVersionOp] CreateVersionPrepare request seq %v already exist status %v", opData.VerSeq, lastVersion.Status)
+				return
+			}
+		}
+		newVer := &proto.VolVersionInfo{
+			Status: proto.VersionPrepare,
+			Ver:    opData.VerSeq,
+		}
+		mp.verSeq = opData.VerSeq
+		mp.multiVersionList.VerList = append(mp.multiVersionList.VerList, newVer)
+
+		log.LogInfof("action[fsmVersionOp] mp[%v] seq %v, op %v, seqArray size %v", mp.config.PartitionId, opData.VerSeq, opData.Op, len(mp.multiVersionList.VerList))
+	} else if opData.Op == proto.CreateVersionCommit {
+		cnt := len(mp.multiVersionList.VerList)
+		if cnt > 0 {
+			if mp.multiVersionList.VerList[cnt-1].Ver > opData.VerSeq {
+				log.LogWarnf("action[HandleVersionOp] mp[%v] reqeust seq %v less than last exist snapshot seq %v", mp.config.PartitionId,
+					mp.multiVersionList.VerList[cnt-1].Ver, opData.VerSeq)
+				return
+			}
+			if mp.multiVersionList.VerList[cnt-1].Ver == opData.VerSeq {
+				if mp.multiVersionList.VerList[cnt-1].Status != proto.VersionPrepare {
+					log.LogWarnf("action[HandleVersionOp] reqeust seq %v Equal last exist snapshot seq %v but with status %v",
+						mp.multiVersionList.VerList[cnt-1].Ver, opData.VerSeq, mp.multiVersionList.VerList[cnt-1].Status)
+				}
+				mp.multiVersionList.VerList[cnt-1].Status = proto.VersionNormal
+				return
+			}
 		}
 		newVer := &proto.VolVersionInfo{
 			Status: proto.VersionNormal,

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -267,7 +267,7 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 			quotaRebuild:   quotaRebuild,
 			uidRebuild:     uidRebuild,
 			uniqChecker:    uniqChecker,
-			multiVerList:   mp.getVerList(),
+			multiVerList:   mp.GetVerList(),
 		}
 		log.LogDebugf("opFSMStoreTick: quotaRebuild [%v] uidRebuild [%v]", quotaRebuild, uidRebuild)
 		mp.storeChan <- msg
@@ -648,7 +648,7 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 				txRbInodeTree:  mp.txProcessor.txResource.txRbInodeTree.GetTree(),
 				txRbDentryTree: mp.txProcessor.txResource.txRbDentryTree.GetTree(),
 				uniqChecker:    uniqChecker.clone(),
-				multiVerList:   mp.getVerList(),
+				multiVerList:   mp.GetVerList(),
 			}
 			select {
 			case mp.extReset <- struct{}{}:

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -250,7 +250,7 @@ func (mp *metaPartition) fsmDeleteDentry(denParm *Dentry, checkInode bool) (resp
 				denFound = den
 				return mp.dentryTree.tree.Delete(den)
 			}
-			denFound, doMore, clean = den.deleteVerSnapshot(denParm.getSeqFiled(), mp.verSeq, mp.getVerList())
+			denFound, doMore, clean = den.deleteVerSnapshot(denParm.getSeqFiled(), mp.verSeq, mp.GetVerList())
 			return den
 		})
 	} else {
@@ -264,7 +264,7 @@ func (mp *metaPartition) fsmDeleteDentry(denParm *Dentry, checkInode bool) (resp
 		} else {
 			item = mp.dentryTree.Get(denParm)
 			if item != nil {
-				denFound, doMore, clean = item.(*Dentry).deleteVerSnapshot(denParm.getSeqFiled(), mp.verSeq, mp.getVerList())
+				denFound, doMore, clean = item.(*Dentry).deleteVerSnapshot(denParm.getSeqFiled(), mp.verSeq, mp.GetVerList())
 			}
 		}
 	}

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -322,7 +322,7 @@ func (mp *metaPartition) fsmUnlinkInode(ino *Inode, uniqID uint64) (resp *InodeR
 	)
 
 	if ino.getVer() == 0 {
-		ext2Del, doMore, status = inode.unlinkTopLayer(ino, mp.verSeq, mp.multiVersionList)
+		ext2Del, doMore, status = inode.unlinkTopLayer(mp.config.PartitionId, ino, mp.verSeq, mp.multiVersionList)
 	} else { // means drop snapshot
 		log.LogDebugf("action[fsmUnlinkInode] req drop assigned snapshot reqseq %v inode seq %v", ino.getVer(), inode.getVer())
 		if ino.getVer() > inode.getVer() && !isInitSnapVer(ino.getVer()) {
@@ -330,7 +330,7 @@ func (mp *metaPartition) fsmUnlinkInode(ino *Inode, uniqID uint64) (resp *InodeR
 				ino.Inode, ino.getVer(), inode.getVer())
 			return
 		} else {
-			ext2Del, doMore, status = inode.unlinkVerInList(ino, mp.verSeq, mp.multiVersionList)
+			ext2Del, doMore, status = inode.unlinkVerInList(mp.config.PartitionId, ino, mp.verSeq, mp.multiVersionList)
 		}
 	}
 	if !doMore {
@@ -368,8 +368,8 @@ func (mp *metaPartition) fsmUnlinkInode(ino *Inode, uniqID uint64) (resp *InodeR
 	}
 
 	if len(ext2Del) > 0 {
-		log.LogDebugf("action[fsmUnlinkInode] ino %v ext2Del %v", ino, ext2Del)
-		inode.DecSplitExts(ext2Del)
+		log.LogDebugf("action[fsmUnlinkInode] mp %v ino %v DecSplitExts ext2Del %v", mp.config.PartitionId, ino, ext2Del)
+		inode.DecSplitExts(mp.config.PartitionId, ext2Del)
 		mp.extDelCh <- ext2Del
 	}
 	log.LogDebugf("action[fsmUnlinkInode] ino %v left", inode)
@@ -462,8 +462,8 @@ func (mp *metaPartition) fsmAppendExtents(ino *Inode) (status uint8) {
 	log.LogInfof("fsmAppendExtents inode(%v) deleteExtents(%v)", ino2.Inode, delExtents)
 	mp.uidManager.minusUidSpace(ino2.Uid, ino2.Inode, delExtents)
 
-	log.LogInfof("fsmAppendExtents inode(%v) deleteExtents(%v)", ino2.Inode, delExtents)
-	ino2.DecSplitExts(delExtents)
+	log.LogInfof("fsmAppendExtents inode(%v) DecSplitExts deleteExtents(%v)", ino2.Inode, delExtents)
+	ino2.DecSplitExts(mp.config.PartitionId, delExtents)
 	mp.extDelCh <- delExtents
 	return
 }
@@ -504,16 +504,28 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 	}
 
 	log.LogDebugf("action[fsmAppendExtentsWithCheck] ino %v isSplit %v ek %v hist len %v", fsmIno.Inode, isSplit, eks[0], fsmIno.getLayerLen())
+
+	appendExtParam := &AppendExtParam{
+		mpId:             mp.config.PartitionId,
+		mpVer:            mp.verSeq,
+		reqVer:           ino.getVer(),
+		ek:               eks[0],
+		ct:               ino.ModifyTime,
+		discardExtents:   discardExtentKey,
+		volType:          mp.volType,
+		multiVersionList: mp.multiVersionList,
+	}
+
 	if !isSplit {
-		delExtents, status = fsmIno.AppendExtentWithCheck(mp.verSeq, mp.multiVersionList, ino.getVer(), eks[0], ino.ModifyTime, discardExtentKey, mp.volType)
+		delExtents, status = fsmIno.AppendExtentWithCheck(appendExtParam)
 		if status == proto.OpOk {
-			log.LogInfof("action[fsmAppendExtentsWithCheck] delExtents [%v]", delExtents)
-			fsmIno.DecSplitExts(delExtents)
+			log.LogInfof("action[fsmAppendExtentsWithCheck] mp %v DecSplitExts delExtents [%v]", mp.config.PartitionId, delExtents)
+			fsmIno.DecSplitExts(appendExtParam.mpId, delExtents)
 			mp.extDelCh <- delExtents
 		}
 		// conflict need delete eks[0], to clear garbage data
 		if status == proto.OpConflictExtentsErr {
-			log.LogInfof("action[fsmAppendExtentsWithCheck] OpConflictExtentsErr [%v]", eks[:1])
+			log.LogInfof("action[fsmAppendExtentsWithCheck] mp %v OpConflictExtentsErr [%v]", mp.config.PartitionId, eks[:1])
 			if !storage.IsTinyExtent(eks[0].ExtentId) && eks[0].ExtentOffset >= util.ExtentSize {
 				eks[0].SetSplit(true)
 			}
@@ -523,8 +535,9 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 		// only the ek itself will be moved to level before
 		// ino verseq be set with mp ver before submit in case other mp be updated while on flight, which will lead to
 		// inconsistent between raft pairs
-		delExtents, status = fsmIno.SplitExtentWithCheck(mp.verSeq, mp.multiVersionList, ino.getVer(), eks[0], ino.ModifyTime, mp.volType)
-		fsmIno.DecSplitExts(delExtents)
+		delExtents, status = fsmIno.SplitExtentWithCheck(appendExtParam)
+		log.LogInfof("action[fsmAppendExtentsWithCheck] mp %v DecSplitExts delExtents [%v]", mp.config.PartitionId, delExtents)
+		fsmIno.DecSplitExts(mp.config.PartitionId, delExtents)
 		mp.extDelCh <- delExtents
 		mp.uidManager.minusUidSpace(fsmIno.Uid, fsmIno.Inode, delExtents)
 	}
@@ -608,14 +621,14 @@ func (mp *metaPartition) fsmExtentsTruncate(ino *Inode) (resp *InodeResponse) {
 		return
 	}
 
-	if delExtents, err = i.RestoreExts2NextLayer(delExtents, mp.verSeq, 0); err != nil {
+	if delExtents, err = i.RestoreExts2NextLayer(mp.config.PartitionId, delExtents, mp.verSeq, 0); err != nil {
 		panic("RestoreExts2NextLayer should not be error")
 	}
 	mp.updateUsedInfo(int64(i.Size)-oldSize, 0, i.Inode)
 
 	// now we should delete the extent
-	log.LogInfof("fsmExtentsTruncate inode(%v) exts(%v)", i.Inode, delExtents)
-	i.DecSplitExts(delExtents)
+	log.LogInfof("fsmExtentsTruncate.mp (%v) inode(%v) DecSplitExts exts(%v)", mp.config.PartitionId, i.Inode, delExtents)
+	i.DecSplitExts(mp.config.PartitionId, delExtents)
 	mp.extDelCh <- delExtents
 	mp.uidManager.minusUidSpace(i.Uid, i.Inode, delExtents)
 	return
@@ -767,9 +780,9 @@ func (mp *metaPartition) fsmClearInodeCache(ino *Inode) (status uint8) {
 		return
 	}
 	delExtents := ino2.EmptyExtents(ino.ModifyTime)
-	log.LogInfof("fsmClearInodeCache inode(%v) delExtents(%v)", ino2.Inode, delExtents)
+	log.LogInfof("fsmClearInodeCache.mp(%v) inode(%v) DecSplitExts delExtents(%v)", mp.config.PartitionId, ino2.Inode, delExtents)
 	if len(delExtents) > 0 {
-		ino2.DecSplitExts(delExtents)
+		ino2.DecSplitExts(mp.config.PartitionId, delExtents)
 		mp.extDelCh <- delExtents
 	}
 	return

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -199,11 +199,15 @@ func (mp *metaPartition) checkVerList(masterListInfo *proto.VolVersionInfoList, 
 		log.LogDebugf("checkVerList. vol %v mp %v ver info %v", mp.config.VolName, mp.config.PartitionId, info2)
 		vms, exist := verMapMaster[info2.Ver]
 		if !exist {
-			warn := fmt.Sprintf("[checkVerList] vol %v mp %v not found %v in master list", mp.config.VolName, mp.config.PartitionId, info2.Ver)
-			exporter.Warning(warn)
-			log.LogWarn(warn)
-			needUpdate = true
-			continue
+			// To mitigate the blocking risk caused by the confirmation of the prepare version and the master version,
+			// a version in the prepare phase is preliminarily considered as a valid version.
+			if info2.Status != proto.VersionPrepare {
+				warn := fmt.Sprintf("[checkVerList] vol %v mp %v not found %v in master list", mp.config.VolName, mp.config.PartitionId, info2.Ver)
+				exporter.Warning(warn)
+				log.LogWarn(warn)
+				needUpdate = true
+				continue
+			}
 		}
 		if info2.Status != proto.VersionNormal && info2.Status != vms.Status {
 			log.LogWarnf("checkVerList. vol %v mp %v ver %v status abnormal %v", mp.config.VolName, mp.config.PartitionId, info2.Ver, info2.Status)

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -424,7 +424,7 @@ func (mp *metaPartition) InodeGetSplitEk(req *InodeGetSplitReq, p *Packet) (err 
 			},
 		}
 		multiSnap := retMsg.Msg.multiSnap
-		if multiSnap.ekRefMap != nil {
+		if multiSnap != nil && multiSnap.ekRefMap != nil {
 			multiSnap.ekRefMap.Range(func(key, value interface{}) bool {
 				dpID, extID := proto.ParseFromId(key.(uint64))
 				resp.Info.SplitArr = append(resp.Info.SplitArr, proto.SimpleExtInfo{

--- a/metanode/sorted_extents.go
+++ b/metanode/sorted_extents.go
@@ -142,17 +142,17 @@ func (se *SortedExtents) Append(ek proto.ExtentKey) (deleteExtents []proto.Exten
 	return
 }
 
-func storeEkSplit(inodeID uint64, ekRef *sync.Map, ek *proto.ExtentKey) (id uint64) {
+func storeEkSplit(mpId uint64, inodeID uint64, ekRef *sync.Map, ek *proto.ExtentKey) (id uint64) {
 	if ekRef == nil {
-		log.LogErrorf("inodeID %v ekRef nil", inodeID)
+		log.LogErrorf("[storeEkSplit] mpId [%v] inodeID %v ekRef nil", mpId, inodeID)
 		return
 	}
-	log.LogDebugf("storeEkSplit inode %v mp %v extent id %v ek %v", inodeID, ek.PartitionId, ek.ExtentId, ek)
+	log.LogDebugf("[storeEkSplit] mpId [%v] inode %v mp %v extent id %v ek %v", mpId, inodeID, ek.PartitionId, ek.ExtentId, ek)
 	id = ek.PartitionId<<32 | ek.ExtentId
 	var v uint32
 	if val, ok := ekRef.Load(id); !ok {
 		if ek.IsSplit() {
-			log.LogErrorf("inode id %v ek %v already be set split", inodeID, ek)
+			log.LogErrorf("[storeEkSplit] mpId [%v]inode id %v ek %v already be set split", mpId, inodeID, ek)
 		}
 		v = 1
 	} else {
@@ -160,34 +160,34 @@ func storeEkSplit(inodeID uint64, ekRef *sync.Map, ek *proto.ExtentKey) (id uint
 	}
 	ek.SetSplit(true)
 	ekRef.Store(id, v)
-	log.LogDebugf("storeEkSplit inode %v mp %v extent id %v.key %v, cnt %v", inodeID, ek.PartitionId, ek.ExtentId,
+	log.LogDebugf("[storeEkSplit] mpId [%v] inode %v mp %v extent id %v.key %v, cnt %v", mpId, inodeID, ek.PartitionId, ek.ExtentId,
 		ek.PartitionId<<32|ek.ExtentId, v)
 	return
 }
 
-func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey, ekRef *sync.Map) (delExtents []proto.ExtentKey, status uint8) {
+func (se *SortedExtents) SplitWithCheck(mpId uint64, inodeID uint64, ekSplit proto.ExtentKey, ekRef *sync.Map) (delExtents []proto.ExtentKey, status uint8) {
 	status = proto.OpOk
 	endOffset := ekSplit.FileOffset + uint64(ekSplit.Size)
-	log.LogDebugf("SplitWithCheck. inode %v  ekSplit ek %v", inodeID, ekSplit)
+	log.LogDebugf("[SplitWithCheck] mpId [%v]. inode %v  ekSplit ek %v", mpId, inodeID, ekSplit)
 	se.Lock()
 	defer se.Unlock()
 
 	if len(se.eks) <= 0 {
-		log.LogErrorf("SplitWithCheck. inode %v eks empty cann't find ek [%v]", inodeID, ekSplit)
+		log.LogErrorf("[SplitWithCheck] mpId [%v]. inode %v eks empty cann't find ek [%v]", mpId, inodeID, ekSplit)
 		status = proto.OpArgMismatchErr
 		return
 	}
 	ekSplit.SetSplit(true)
 	lastKey := se.eks[len(se.eks)-1]
 	if lastKey.FileOffset+uint64(lastKey.Size) <= ekSplit.FileOffset {
-		log.LogErrorf("SplitWithCheck. inode %v eks do split not found", inodeID)
+		log.LogErrorf("[SplitWithCheck] mpId [%v]. inode %v eks do split not found", mpId, inodeID)
 		status = proto.OpArgMismatchErr
 		return
 	}
 
 	firstKey := se.eks[0]
 	if firstKey.FileOffset >= endOffset {
-		log.LogErrorf("SplitWithCheck. inode %v eks do split not found", inodeID)
+		log.LogErrorf("[SplitWithCheck] mpId [%v]. inode %v eks do split not found", mpId, inodeID)
 		status = proto.OpArgMismatchErr
 		return
 	}
@@ -206,7 +206,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 
 	if startIndex == 0 {
 		status = proto.OpArgMismatchErr
-		log.LogErrorf("SplitWithCheck. inode %v should have no valid extent request [%v]", inodeID, ekSplit)
+		log.LogErrorf("[SplitWithCheck] mpId [%v]. inode %v should have no valid extent request [%v]", mpId, inodeID, ekSplit)
 		return
 	}
 
@@ -220,7 +220,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 	keySize := key.Size
 	key.AddModGen()
 	if !key.IsSplit() {
-		storeEkSplit(inodeID, ekRef, key)
+		storeEkSplit(mpId, inodeID, ekRef, key)
 	}
 
 	if ekSplit.FileOffset+uint64(ekSplit.Size) > key.FileOffset+uint64(key.Size) {
@@ -237,7 +237,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 	delKey := *key
 	delKey.ExtentOffset = key.ExtentOffset + (ekSplit.FileOffset - key.FileOffset)
 	delKey.Size = ekSplit.Size
-	storeEkSplit(inodeID, ekRef, &delKey)
+	storeEkSplit(mpId, inodeID, ekRef, &delKey)
 
 	if ekSplit.Size == 0 {
 		log.LogErrorf("SplitWithCheck. inode %v delKey %v,key %v, eksplit %v", inodeID, delKey, key, ekSplit)
@@ -265,7 +265,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 			keyBefore.Size += ekSplit.Size
 		} else {
 			se.eks = append(se.eks, ekSplit)
-			storeEkSplit(inodeID, ekRef, &ekSplit)
+			storeEkSplit(mpId, inodeID, ekRef, &ekSplit)
 		}
 
 		keyDup.FileOffset = keyDup.FileOffset + uint64(ekSplit.Size)
@@ -292,7 +292,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 			eks[0].Size += ekSplit.Size
 		} else {
 			se.eks = append(se.eks, ekSplit)
-			storeEkSplit(inodeID, ekRef, &ekSplit)
+			storeEkSplit(mpId, inodeID, ekRef, &ekSplit)
 		}
 
 		se.eks = append(se.eks, eks...)
@@ -306,7 +306,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 
 		se.eks = se.eks[:startIndex]
 		se.eks = append(se.eks, ekSplit)
-		storeEkSplit(inodeID, ekRef, &ekSplit)
+		storeEkSplit(mpId, inodeID, ekRef, &ekSplit)
 		mKey := &proto.ExtentKey{
 			FileOffset:   ekSplit.FileOffset + uint64(ekSplit.Size),
 			PartitionId:  key.PartitionId,
@@ -321,7 +321,7 @@ func (se *SortedExtents) SplitWithCheck(inodeID uint64, ekSplit proto.ExtentKey,
 			},
 		}
 		se.eks = append(se.eks, *mKey)
-		storeEkSplit(inodeID, ekRef, mKey)
+		storeEkSplit(mpId, inodeID, ekRef, mKey)
 
 		if keySize-key.Size-ekSplit.Size == 0 {
 			log.LogErrorf("SplitWithCheck. inode %v keySize %v,key %v, eksplit %v", inodeID, keySize, key, ekSplit)

--- a/proto/model.go
+++ b/proto/model.go
@@ -359,6 +359,13 @@ type VolVersionInfoList struct {
 	sync.RWMutex
 }
 
+func (v *VolVersionInfoList) GetLastVer() uint64 {
+	if len(v.VerList) == 0 {
+		return 0
+	}
+	return v.VerList[len(v.VerList)-1].Ver
+}
+
 type DecommissionDiskLimitDetail struct {
 	NodeSetId uint64
 	Limit     int

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -15,10 +15,12 @@
 package proto
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cubefs/cubefs/util/log"
 	"io"
 	"net"
 	"strconv"
@@ -202,6 +204,7 @@ const (
 	OpNotEmpty           uint8 = 0xFE
 	OpOk                 uint8 = 0xF0
 	OpTryOtherExtent     uint8 = 0xE0
+	OpAgainVerionList    uint8 = 0xEF
 
 	OpPing                  uint8 = 0xFF
 	OpMetaUpdateXAttr       uint8 = 0x3B
@@ -250,6 +253,7 @@ const (
 	GetAllWatermarksDeadLineTime              = 60
 	DefaultClusterLoadFactor          float64 = 10
 	MultiVersionFlag                          = 0x80
+	VersionListFlag                           = 0x40
 )
 
 // multi version operation
@@ -309,6 +313,15 @@ type Packet struct {
 	mesg               string
 	HasPrepare         bool
 	VerSeq             uint64 // only used in mod request to datanode
+	VerList            []*VolVersionInfo
+}
+
+func IsTinyExtentType(extentType uint8) bool {
+	return extentType&NormalExtentType != NormalExtentType
+}
+
+func IsNormalExtentType(extentType uint8) bool {
+	return extentType&NormalExtentType == NormalExtentType
 }
 
 // NewPacket returns a new packet.
@@ -346,15 +359,13 @@ func (p *Packet) String() string {
 
 // GetStoreType returns the store type.
 func (p *Packet) GetStoreType() (m string) {
-	switch p.ExtentType {
-	case TinyExtentType:
-		m = "TinyExtent"
-	case NormalExtentType:
-		m = "NormalExtent"
-	default:
-		m = "Unknown"
+	if IsNormalExtentType(p.ExtentType) {
+		return "NormalExtent"
+	} else if IsTinyExtentType(p.ExtentType) {
+		return "TinyExtent"
+	} else {
+		return "Unknown"
 	}
-	return
 }
 
 func (p *Packet) GetOpMsgWithReqAndResult() (m string) {
@@ -696,6 +707,13 @@ func (p *Packet) MarshalHeader(out []byte) {
 	return
 }
 
+func (p *Packet) IsVersionList() bool {
+	if p.ExtentType&VersionListFlag == VersionListFlag {
+		return true
+	}
+	return false
+}
+
 // UnmarshalHeader unmarshals the packet header.
 func (p *Packet) UnmarshalHeader(in []byte) error {
 	p.Magic = in[0]
@@ -720,6 +738,56 @@ func (p *Packet) UnmarshalHeader(in []byte) error {
 	// the ver param should read at the higher level directly
 	//if p.Opcode ==OpRandomWriteVer {
 
+	return nil
+}
+
+const verInfoCnt = 17
+
+func (p *Packet) MarshalVersionSlice() (data []byte, err error) {
+	items := p.VerList
+	cnt := len(items)
+	buff := bytes.NewBuffer(make([]byte, 0, 2*cnt*verInfoCnt))
+	if err := binary.Write(buff, binary.BigEndian, uint16(cnt)); err != nil {
+		return nil, err
+	}
+
+	for _, v := range items {
+		if err := binary.Write(buff, binary.BigEndian, v.Ver); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buff, binary.BigEndian, v.DelTime); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buff, binary.BigEndian, v.Status); err != nil {
+			return nil, err
+		}
+	}
+
+	return buff.Bytes(), nil
+}
+
+func (p *Packet) UnmarshalVersionSlice(cnt int, d []byte) error {
+	items := make([]*VolVersionInfo, 0)
+	buf := bytes.NewBuffer(d)
+	var err error
+
+	for idx := 0; idx < cnt; idx++ {
+		e := &VolVersionInfo{}
+		err = binary.Read(buf, binary.BigEndian, &e.Ver)
+		if err != nil {
+			return err
+		}
+		err = binary.Read(buf, binary.BigEndian, &e.DelTime)
+		if err != nil {
+			return err
+		}
+		err = binary.Read(buf, binary.BigEndian, &e.Status)
+		if err != nil {
+			return err
+		}
+		items = append(items, e)
+	}
+	p.VerList = items
 	return nil
 }
 
@@ -774,6 +842,19 @@ func (p *Packet) WriteToConn(c net.Conn) (err error) {
 	c.SetWriteDeadline(time.Now().Add(WriteDeadlineTime * time.Second))
 	p.MarshalHeader(header)
 	if _, err = c.Write(header); err == nil {
+		// write dir version info.
+		if p.IsVersionList() {
+			d, err1 := p.MarshalVersionSlice()
+			if err1 != nil {
+				log.LogErrorf("MarshalVersionSlice: marshal version ifo failed, err %s", err1.Error())
+				return err1
+			}
+
+			_, err = c.Write(d)
+			if err != nil {
+				return err
+			}
+		}
 		if _, err = c.Write(p.Arg[:int(p.ArgLen)]); err == nil {
 			if p.Data != nil && p.Size != 0 {
 				_, err = c.Write(p.Data[:p.Size])
@@ -823,6 +904,27 @@ func (p *Packet) ReadFromConnWithVer(c net.Conn, timeoutSec int) (err error) {
 			return
 		}
 		p.VerSeq = binary.BigEndian.Uint64(ver)
+	}
+
+	if p.IsVersionList() {
+		cntByte := make([]byte, 2)
+		if _, err = io.ReadFull(c, cntByte); err != nil {
+			return err
+		}
+		cnt := binary.BigEndian.Uint16(cntByte)
+		log.LogDebugf("action[ReadFromConnWithVer] op %s verseq %v, extType %d, cnt %d",
+			p.GetOpMsg(), p.VerSeq, p.ExtentType, cnt)
+		verData := make([]byte, cnt*verInfoCnt)
+		if _, err = io.ReadFull(c, verData); err != nil {
+			log.LogWarnf("ReadFromConnWithVer: read ver slice from conn failed, err %s", err.Error())
+			return err
+		}
+
+		err = p.UnmarshalVersionSlice(int(cnt), verData)
+		if err != nil {
+			log.LogWarnf("ReadFromConnWithVer: unmarshal ver slice failed, err %s", err.Error())
+			return err
+		}
 	}
 
 	if p.ArgLen > 0 {
@@ -953,7 +1055,7 @@ func (p *Packet) GetUniqueLogId() (m string) {
 		return
 	}
 	m = fmt.Sprintf("Req(%v)_Partition(%v)_", p.ReqID, p.PartitionID)
-	if (p.Opcode == OpSplitMarkDelete || (p.ExtentType == TinyExtentType && p.Opcode == OpMarkDelete)) && len(p.Data) > 0 {
+	if p.Opcode == OpSplitMarkDelete || (IsTinyExtentType(p.ExtentType) && p.Opcode == OpMarkDelete) && len(p.Data) > 0 {
 		ext := new(TinyExtentDeleteRecord)
 		err := json.Unmarshal(p.Data, ext)
 		if err == nil {
@@ -984,7 +1086,7 @@ func (p *Packet) GetUniqueLogId() (m string) {
 
 func (p *Packet) setPacketPrefix() {
 	p.mesg = fmt.Sprintf("Req(%v)_Partition(%v)_", p.ReqID, p.PartitionID)
-	if (p.Opcode == OpSplitMarkDelete || (p.ExtentType == TinyExtentType && p.Opcode == OpMarkDelete)) && len(p.Data) > 0 {
+	if (p.Opcode == OpSplitMarkDelete || (IsTinyExtentType(p.ExtentType) && p.Opcode == OpMarkDelete)) && len(p.Data) > 0 {
 		ext := new(TinyExtentDeleteRecord)
 		err := json.Unmarshal(p.Data, ext)
 		if err == nil {
@@ -1029,6 +1131,11 @@ func (p *Packet) LogMessage(action, remote string, start int64, err error) (m st
 	}
 
 	return
+}
+
+// ShallRetry returns if we should retry the packet.
+func (p *Packet) ShouldRetryWithVersionList() bool {
+	return p.ResultCode == OpAgainVerionList
 }
 
 // ShallRetry returns if we should retry the packet.

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -280,6 +280,7 @@ const (
 	VersionDeleted        = 2
 	VersionDeleting       = 3
 	VersionDeleteAbnormal = 4
+	VersionPrepare        = 5
 )
 
 const (

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cubefs/cubefs/util/log"
 	"io"
 	"net"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -296,11 +295,10 @@ var (
 )
 
 func (p *Packet) identificationErrorResultCode(errLog string, errMsg string) {
-	log.LogErrorf("action[identificationErrorResultCode] error %v, errmsg %v", errLog, errMsg)
+	log.LogDebugf("action[identificationErrorResultCode] error %v, errmsg %v", errLog, errMsg)
 	if strings.Contains(errLog, ActionReceiveFromFollower) || strings.Contains(errLog, ActionSendToFollowers) ||
 		strings.Contains(errLog, ConnIsNullErr) {
 		p.ResultCode = proto.OpIntraGroupNetErr
-		log.LogErrorf("action[identificationErrorResultCode] error %v, errmsg %v", errLog, errMsg)
 	} else if strings.Contains(errMsg, storage.ParameterMismatchError.Error()) ||
 		strings.Contains(errMsg, ErrorUnknownOp.Error()) {
 		p.ResultCode = proto.OpArgMismatchErr
@@ -319,7 +317,7 @@ func (p *Packet) identificationErrorResultCode(errLog string, errMsg string) {
 		p.ResultCode = proto.OpTryOtherAddr
 	} else if strings.Contains(errMsg, storage.VerNotConsistentError.Error()) {
 		p.ResultCode = proto.ErrCodeVersionOpError
-		log.LogErrorf("action[identificationErrorResultCode] not change ver erro code, (%v)", string(debug.Stack()))
+		// log.LogDebugf("action[identificationErrorResultCode] not change ver erro code, (%v)", string(debug.Stack()))
 	} else {
 		log.LogErrorf("action[identificationErrorResultCode] error %v, errmsg %v", errLog, errMsg)
 		p.ResultCode = proto.OpIntraGroupNetErr

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -269,7 +269,7 @@ retry:
 	client.volumeName = config.Volume
 	client.bcacheEnable = config.BcacheEnable
 	client.bcacheDir = config.BcacheDir
-	client.multiVerMgr.verReadSeq = config.VerReadSeq
+	client.multiVerMgr.verReadSeq = client.dataWrapper.GetReadVerSeq()
 	client.BcacheHealth = true
 	client.preload = config.Preload
 	client.disableMetaCache = config.DisableMetaCache

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -124,6 +124,7 @@ type ExtentConfig struct {
 type MultiVerMgr struct {
 	verReadSeq   uint64 // verSeq in config used as snapshot read
 	latestVerSeq uint64 // newest verSeq from master for datanode write to check
+	verList      *proto.VolVersionInfoList
 	sync.RWMutex
 }
 
@@ -252,7 +253,7 @@ retry:
 	}
 
 	client.streamers = make(map[uint64]*Streamer)
-	client.multiVerMgr = &MultiVerMgr{}
+	client.multiVerMgr = &MultiVerMgr{verList: &proto.VolVersionInfoList{}}
 
 	client.appendExtentKey = config.OnAppendExtentKey
 	client.splitExtentKey = config.OnSplitExtentKey
@@ -339,7 +340,11 @@ func (client *ExtentClient) GetLatestVer() uint64 {
 func (client *ExtentClient) GetReadVer() uint64 {
 	return atomic.LoadUint64(&client.multiVerMgr.verReadSeq)
 }
-func (client *ExtentClient) UpdateLatestVer(verSeq uint64) (err error) {
+func (client *ExtentClient) GetVerMgr() *proto.VolVersionInfoList {
+	return client.multiVerMgr.verList
+}
+func (client *ExtentClient) UpdateLatestVer(verList *proto.VolVersionInfoList) (err error) {
+	verSeq := verList.GetLastVer()
 	if verSeq == 0 || verSeq <= atomic.LoadUint64(&client.multiVerMgr.latestVerSeq) {
 		return
 	}
@@ -351,6 +356,7 @@ func (client *ExtentClient) UpdateLatestVer(verSeq uint64) (err error) {
 
 	log.LogInfof("action[UpdateLatestVer] update verseq [%v] to [%v]", client.multiVerMgr.latestVerSeq, verSeq)
 	atomic.StoreUint64(&client.multiVerMgr.latestVerSeq, verSeq)
+	client.multiVerMgr.verList = verList
 
 	client.streamerLock.Lock()
 	defer client.streamerLock.Unlock()

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -613,6 +613,11 @@ func (s *Streamer) doOverwrite(req *ExtentRequest, direct bool) (total int, err 
 
 	for total < size {
 		reqPacket := NewOverwritePacket(dp, req.ExtentKey.ExtentId, offset-ekFileOffset+total+ekExtOffset, s.inode, offset)
+		reqPacket.VerSeq = s.client.multiVerMgr.latestVerSeq
+		reqPacket.VerList = s.client.multiVerMgr.verList.VerList
+		reqPacket.ExtentType |= proto.MultiVersionFlag
+		reqPacket.ExtentType |= proto.VersionListFlag
+
 		log.LogDebugf("action[doOverwrite] inode %v extentid %v,extentOffset %v(%v,%v,%v,%v) offset %v, streamer seq %v", s.inode, req.ExtentKey.ExtentId, reqPacket.ExtentOffset,
 			offset, ekFileOffset, total, ekExtOffset, offset, s.verSeq)
 		if direct {
@@ -646,7 +651,7 @@ func (s *Streamer) doOverwrite(req *ExtentRequest, direct bool) (total int, err 
 				log.LogWarnf("action[doOverwrite] verseq (%v) be updated to (%v) by datanode rsp", s.verSeq, replyPacket.VerSeq)
 				s.verSeq = replyPacket.VerSeq
 				s.extents.verSeq = s.verSeq
-				s.client.UpdateLatestVer(s.verSeq)
+				s.client.UpdateLatestVer(&proto.VolVersionInfoList{VerList: replyPacket.VerList})
 				return e, false
 			}
 

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -146,7 +146,7 @@ func NewDataPartitionWrapper(client SimpleClientInfo, volName string, masters []
 		}
 	}
 	go w.uploadFlowInfoByTick(client)
-	go w.update()
+	go w.update(client)
 	return
 }
 
@@ -239,7 +239,7 @@ func (w *Wrapper) uploadFlowInfoByTick(clientInfo SimpleClientInfo) {
 	}
 }
 
-func (w *Wrapper) update() {
+func (w *Wrapper) update(clientInfo SimpleClientInfo) {
 	ticker := time.NewTicker(time.Minute)
 	for {
 		select {
@@ -248,6 +248,7 @@ func (w *Wrapper) update() {
 			w.updateDataPartition(false)
 			w.updateDataNodeStatus()
 			w.CheckPermission()
+			w.updateVerlist(clientInfo)
 		case <-w.stopC:
 			return
 		}

--- a/sdk/meta/operation.go
+++ b/sdk/meta/operation.go
@@ -2876,5 +2876,5 @@ func (mw *MetaWrapper) checkVerFromMeta(packet *proto.Packet) {
 	}
 
 	log.LogDebugf("checkVerFromMeta.try update meta wrapper verSeq from %v to %v", mw.Client.GetLatestVer(), packet.VerSeq)
-	mw.Client.UpdateLatestVer(packet.VerSeq)
+	mw.Client.UpdateLatestVer(&proto.VolVersionInfoList{VerList: packet.VerList})
 }

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -325,6 +325,9 @@ func (e *Extent) Write(data []byte, offset, size int64, crc uint32, writeType in
 		} else if IsAppendRandomWrite(writeType) {
 			atomic.StoreInt64(&e.modifyTime, time.Now().Unix())
 			index := int64(math.Max(float64(e.snapshotDataOff), float64(offset+size)))
+			if index%util.PageSize != 0 {
+				index = index + (util.PageSize - index%util.PageSize)
+			}
 			e.snapshotDataOff = uint64(index)
 		}
 		log.LogDebugf("action[Extent.Write] offset %v size %v writeType %v dataSize %v snapshotDataOff %v",


### PR DESCRIPTION
…lity of split

current senario
1) seq update: updated as the volume information is fetched, and later it is updated based on changes in the verlist of data and meta. However, it does not have real-time capability. 2) The dirty flag of ExtentHandler is written back to the datanode, which means it is prepared for flushing to the metanode. 3) For appending ek, find the previous appendable ek. If ExtentHandler is not closed, the ek will include the previous ek (Note that it is difficult to control here as the previous ek might have already been asynchronously written to the meta or it may be in transit. After data is returned and before meta is returned, dirty is true). To append as a whole, where meta and data have changed but the client may not perceive it in a timely manner, the range of the appended ek is larger, including the previous ek (an extent). When meta is processed, it is used directly.

Improvements:
Approach 1: Without modifying the client, append the ek to the meta. The meta will differentiate the range based on the existing ke conditions, for example, if the new ek range overlaps with the old one, it will proactively split into two sets and assign a new version number to the newly added ek. Approach 2: If the meta detects that the client's requested seq is outdated and its own seq has advanced beyond the client's request, it will return to the client. The client can then modify its ek to be appended based on the current version information returned by the meta and the current state of eks in the meta.

conclusion:
Option 1 is relatively simple and covers more scenes.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
