### PR TITLE
fix(master): in creating vol procedure, clean vol info if initDataPartitions() failed

### DIFF
--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -118,17 +118,19 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 			}
 			mpr.TxCnt, mpr.TxRbInoCnt, mpr.TxRbDenCnt = partition.TxGetCnt()
 
-			addr, isLeader := partition.IsLeader()
-			if addr == "" {
-				mpr.Status = proto.Unavailable
-			}
-			mpr.IsLeader = isLeader
 			if mConf.Cursor >= mConf.End {
 				mpr.Status = proto.ReadOnly
 			}
 			if resp.MemUsed > uint64(float64(resp.Total)*MaxUsedMemFactor) {
 				mpr.Status = proto.ReadOnly
 			}
+
+			addr, isLeader := partition.IsLeader()
+			if addr == "" {
+				mpr.Status = proto.Unavailable
+			}
+			mpr.IsLeader = isLeader
+
 			resp.MetaPartitionReports = append(resp.MetaPartitionReports, mpr)
 			return true
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
currently, if initDataPartitions() failed in the creating vol procedure, the vol info is not cleaned, so it can be found in the master but can't be used.
should clean the vol info if initDataPartitions() failed when creating.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2019