### PR TITLE
feat(blobstore): to support objectnode auditlog

### DIFF
--- a/blobstore/common/rpc/auditlog/auditlog.go
+++ b/blobstore/common/rpc/auditlog/auditlog.go
@@ -171,6 +171,7 @@ func (j *jsonAuditlog) Handler(w http.ResponseWriter, req *http.Request, f func(
 		module:         j.module,
 		body:           j.bodyPool.Get().([]byte),
 		bodyLimit:      j.cfg.BodyLimit,
+		no2xxBody:      j.cfg.No2xxBody,
 		span:           span,
 		startTime:      time.Now(),
 		ResponseWriter: w,
@@ -272,4 +273,14 @@ func defaultLogFilter(r *http.Request, words []string) bool {
 		}
 	}
 	return false
+}
+
+// ExtraHeader provides extra response header writes to the ResponseWriter.
+func ExtraHeader(w http.ResponseWriter) http.Header {
+	h := make(http.Header)
+	if eh, ok := w.(ResponseExtraHeader); ok {
+		h = eh.ExtraHeader()
+	}
+
+	return h
 }

--- a/blobstore/common/rpc/auditlog/proto.go
+++ b/blobstore/common/rpc/auditlog/proto.go
@@ -29,6 +29,8 @@ type Config struct {
 	ChunkBits uint `json:"chunkbits"`
 	// BodyLimit negative means no body-cache, 0 means default buffer size.
 	BodyLimit int `json:"bodylimit"`
+	// No2xxBody means that the response body of 2xx will not be logged.
+	No2xxBody bool `json:"no_2xx_body"`
 	// rotate new audit log file every start time
 	RotateNew     bool   `json:"rotate_new"`
 	LogFileSuffix string `json:"log_file_suffix"`
@@ -63,4 +65,8 @@ type MetricSender interface {
 
 type Decoder interface {
 	DecodeReq(req *http.Request) *DecodedReq
+}
+
+type ResponseExtraHeader interface {
+	ExtraHeader() http.Header
 }

--- a/blobstore/common/trace/tracer.go
+++ b/blobstore/common/trace/tracer.go
@@ -236,9 +236,9 @@ func StartSpanFromHTTPHeaderSafe(r *http.Request, operationName string) (Span, c
 	spanCtx, _ := Extract(HTTPHeaders, HTTPHeadersCarrier(r.Header))
 	traceID := r.Header.Get(RequestIDKey)
 	if traceID == "" {
-		return StartSpanFromContext(context.Background(), operationName, ext.RPCServerOption(spanCtx))
+		return StartSpanFromContext(r.Context(), operationName, ext.RPCServerOption(spanCtx))
 	}
-	return StartSpanFromContextWithTraceID(context.Background(), operationName, traceID, ext.RPCServerOption(spanCtx))
+	return StartSpanFromContextWithTraceID(r.Context(), operationName, traceID, ext.RPCServerOption(spanCtx))
 }
 
 // ContextWithSpan returns a new `context.Context` that holds a reference to


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In order to support the audit log of objectnode, certain modifications need to be made to the audit log of blobstore. For example:
1. Additional information needs to be printed in the audit log, but these fields cannot be passed to the user.
2. For the successful response of 2xx, it is completely unnecessary to print the data read by the user. Here, add a configuration item to disable body printing.
3. Fix the problem that the original context cannot be assigned by kv.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #
