### PR TITLE
fix(master): fix the bug of not validating the cluster name when call…

### DIFF
--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -1035,6 +1035,11 @@ func (c *Cluster) loadClusterValue() (err error) {
 			return err
 		}
 
+		if cv.Name != c.Name {
+			log.LogErrorf("action[loadClusterValue] loaded cluster value: %+v", cv)
+			continue
+		}
+
 		log.LogDebugf("action[loadClusterValue] loaded cluster value: %+v", cv)
 		c.CreateTime = cv.CreateTime
 


### PR DESCRIPTION
…ing loadClusterValue.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
If the cluster name has been changed and the records in rocksdb have not been cleaned up, the cluster configuration that has not been cleaned up may be saved to the current cluster configuration when loadClusterValue is called, so  it is necessary to determine whether the cluster name matches or not when loadClusterValue is called.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2639 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
