### PR TITLE
[Feature]: Support back-end audit log

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -527,7 +527,7 @@ func (s *Super) EnableAuditLog(w http.ResponseWriter, r *http.Request) {
 		logSize = auditlog.DefaultAuditLogSize
 	}
 
-	err, dir, logModule, logMaxSize := auditlog.GetAuditLogInfo()
+	dir, logModule, logMaxSize, err := auditlog.GetAuditLogInfo()
 	if err != nil {
 
 		_, err = auditlog.InitAuditWithPrefix(logPath, prefix, int64(auditlog.DefaultAuditLogSize),

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/errors"
 	sysutil "github.com/cubefs/cubefs/util/sys"
 
@@ -169,7 +170,6 @@ func main() {
 		log.LogErrorf("logLeftSpaceLimit is not a legal int value: %v", err.Error())
 		logLeftSpaceLimit = log.DefaultLogLeftSpaceLimit
 	}
-
 	// Init server instance with specified role configuration.
 	var (
 		server common.Server
@@ -231,6 +231,15 @@ func main() {
 		os.Exit(1)
 	}
 	defer log.LogFlush()
+
+	_, err = auditlog.InitAudit(logDir, module, auditlog.DefaultAuditLogSize)
+	if err != nil {
+		err = errors.NewErrorf("Fatal: failed to init audit log - %v", err)
+		fmt.Println(err)
+		daemonize.SignalOutcome(err)
+		os.Exit(1)
+	}
+	defer auditlog.StopAudit()
 
 	if *redirectSTD {
 		// Init output file

--- a/fsck/cmd/clean.go
+++ b/fsck/cmd/clean.go
@@ -217,7 +217,7 @@ func doEvictInode(inode *Inode) error {
 	if inode.NLink != 0 || time.Since(time.Unix(inode.ModifyTime, 0)) < 24*time.Hour || !proto.IsRegular(inode.Type) {
 		return nil
 	}
-	err := gMetaWrapper.Evict(inode.Inode)
+	err := gMetaWrapper.Evict(inode.Inode, inode.Path)
 	if err != nil {
 		if err != syscall.ENOENT {
 			return err

--- a/lcnode/meta.go
+++ b/lcnode/meta.go
@@ -18,10 +18,10 @@ import "github.com/cubefs/cubefs/proto"
 
 type MetaWrapper interface {
 	ReadDirLimitForSnapShotClean(parentID uint64, from string, limit uint64, verSeq uint64, isDir bool) ([]proto.Dentry, error)
-	Delete_Ver_ll(parentID uint64, name string, isDir bool, verSeq uint64) (*proto.InodeInfo, error)
+	Delete_Ver_ll(parentID uint64, name string, isDir bool, verSeq uint64, fullPath string) (*proto.InodeInfo, error)
 	Lookup_ll(parentID uint64, name string) (inode uint64, mode uint32, err error)
 	BatchInodeGet(inodes []uint64) []*proto.InodeInfo
-	DeleteWithCond_ll(parentID, cond uint64, name string, isDir bool) (*proto.InodeInfo, error)
-	Evict(inode uint64) error
+	DeleteWithCond_ll(parentID, cond uint64, name string, isDir bool, fullPath string) (inode *proto.InodeInfo, err error)
+	Evict(inode uint64, fullPath string) error
 	ReadDirLimit_ll(parentID uint64, from string, limit uint64) ([]proto.Dentry, error)
 }

--- a/lcnode/meta_test.go
+++ b/lcnode/meta_test.go
@@ -26,7 +26,7 @@ func (*MockMetaWrapper) ReadDirLimitForSnapShotClean(parentID uint64, from strin
 	return nil, nil
 }
 
-func (*MockMetaWrapper) Delete_Ver_ll(parentID uint64, name string, isDir bool, verSeq uint64) (*proto.InodeInfo, error) {
+func (*MockMetaWrapper) Delete_Ver_ll(parentID uint64, name string, isDir bool, verSeq uint64, fullPath string) (*proto.InodeInfo, error) {
 	return nil, nil
 }
 
@@ -38,11 +38,11 @@ func (*MockMetaWrapper) BatchInodeGet(inodes []uint64) []*proto.InodeInfo {
 	return nil
 }
 
-func (*MockMetaWrapper) DeleteWithCond_ll(parentID, cond uint64, name string, isDir bool) (*proto.InodeInfo, error) {
+func (*MockMetaWrapper) DeleteWithCond_ll(parentID, cond uint64, name string, isDir bool, fullPath string) (*proto.InodeInfo, error) {
 	return nil, nil
 }
 
-func (*MockMetaWrapper) Evict(inode uint64) error {
+func (*MockMetaWrapper) Evict(inode uint64, fullPath string) error {
 	return nil
 }
 

--- a/lcnode/snapshot_scanner.go
+++ b/lcnode/snapshot_scanner.go
@@ -253,7 +253,7 @@ func (s *SnapshotScanner) handlVerDelDepthFirst(dentry *proto.ScanDentry) {
 			}
 
 			for _, file := range files {
-				if ino, err = s.mw.Delete_Ver_ll(file.ParentId, file.Name, false, s.getTaskVerSeq()); err != nil {
+				if ino, err = s.mw.Delete_Ver_ll(file.ParentId, file.Name, false, s.getTaskVerSeq(), file.Path); err != nil {
 					log.LogErrorf("action[handlVerDelDepthFirst] Delete_Ver_ll failed, file(parent[%v] child name[%v]) verSeq[%v] err[%v]",
 						file.ParentId, file.Name, s.getTaskVerSeq(), err)
 					atomic.AddInt64(&s.currentStat.ErrorSkippedNum, 1)
@@ -283,7 +283,7 @@ func (s *SnapshotScanner) handlVerDelDepthFirst(dentry *proto.ScanDentry) {
 	}
 
 	if onlyDir {
-		if ino, err = s.mw.Delete_Ver_ll(dentry.ParentId, dentry.Name, os.FileMode(dentry.Type).IsDir(), s.getTaskVerSeq()); err != nil {
+		if ino, err = s.mw.Delete_Ver_ll(dentry.ParentId, dentry.Name, os.FileMode(dentry.Type).IsDir(), s.getTaskVerSeq(), dentry.Path); err != nil {
 			if dentry.ParentId >= 1 {
 				log.LogErrorf("action[handlVerDelDepthFirst] Delete_Ver_ll failed, dir(parent[%v] child name[%v]) verSeq[%v] err[%v]",
 					dentry.ParentId, dentry.Name, s.getTaskVerSeq(), err)
@@ -367,7 +367,7 @@ func (s *SnapshotScanner) handlVerDelBreadthFirst(dentry *proto.ScanDentry) {
 		}
 
 		for _, file := range scanDentries {
-			if ino, err = s.mw.Delete_Ver_ll(file.ParentId, file.Name, false, s.getTaskVerSeq()); err != nil {
+			if ino, err = s.mw.Delete_Ver_ll(file.ParentId, file.Name, false, s.getTaskVerSeq(), dentry.Path); err != nil {
 				log.LogErrorf("action[handlVerDelBreadthFirst] Delete_Ver_ll failed, file(parent[%v] child name[%v]) verSeq[%v] err[%v]",
 					file.ParentId, file.Name, s.getTaskVerSeq(), err)
 				atomic.AddInt64(&s.currentStat.ErrorSkippedNum, 1)

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -212,7 +212,7 @@ func (m *metadataManager) opCreateInode(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.CreateInode(req, p)
+	err = mp.CreateInode(req, p, remoteAddr)
 	// reply the operation result to the client through TCP
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opCreateInode] req: %d - %v, resp: %v, body: %s",
@@ -242,7 +242,7 @@ func (m *metadataManager) opQuotaCreateInode(conn net.Conn, p *Packet, remoteAdd
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.QuotaCreateInode(req, p)
+	err = mp.QuotaCreateInode(req, p, remoteAddr)
 	// reply the operation result to the client through TCP
 	m.respondToClient(conn, p)
 	log.LogDebugf("%s [opQuotaCreateInode] req: %d - %v, resp: %v, body: %s",
@@ -272,7 +272,7 @@ func (m *metadataManager) opTxMetaLinkInode(conn net.Conn, p *Packet, remoteAddr
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.TxCreateInodeLink(req, p)
+	err = mp.TxCreateInodeLink(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 	log.LogDebugf("%s [opTxMetaLinkInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -302,7 +302,7 @@ func (m *metadataManager) opMetaLinkInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.CreateInodeLink(req, p)
+	err = mp.CreateInodeLink(req, p, remoteAddr)
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opMetaLinkInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -352,7 +352,7 @@ func (m *metadataManager) opTxCreateDentry(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.TxCreateDentry(req, p)
+	err = mp.TxCreateDentry(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 
 	log.LogDebugf("%s [opTxCreateDentry] req: %d - %v, resp: %v, body: %s",
@@ -504,7 +504,7 @@ func (m *metadataManager) opTxCommit(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.TxCommit(req, p)
+	err = mp.TxCommit(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 
 	log.LogDebugf("%s [opTxCommit] req: %d - %v, resp: %v, body: %s",
@@ -534,7 +534,7 @@ func (m *metadataManager) opTxRollback(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.TxRollback(req, p)
+	err = mp.TxRollback(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 
 	log.LogDebugf("%s [opTxRollback] req: %d - %v, resp: %v, body: %s",
@@ -566,7 +566,7 @@ func (m *metadataManager) opCreateDentry(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.CreateDentry(req, p)
+	err = mp.CreateDentry(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 
 	log.LogDebugf("%s [opCreateDentry] req: %d - %v, resp: %v, body: %s",
@@ -597,7 +597,7 @@ func (m *metadataManager) opQuotaCreateDentry(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.QuotaCreateDentry(req, p)
+	err = mp.QuotaCreateDentry(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 
 	log.LogDebugf("%s [opQuotaCreateDentry] req: %d - %v, resp: %v, body: %s",
@@ -627,7 +627,7 @@ func (m *metadataManager) opTxDeleteDentry(conn net.Conn, p *Packet,
 	if !m.serveProxy(conn, mp, p) {
 		return
 	}
-	err = mp.TxDeleteDentry(req, p)
+	err = mp.TxDeleteDentry(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 	if log.EnableDebug() {
 		log.LogDebugf("%s [opTxDeleteDentry] req: %d - %v, resp: %v, body: %s",
@@ -662,7 +662,7 @@ func (m *metadataManager) opDeleteDentry(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.DeleteDentry(req, p)
+	err = mp.DeleteDentry(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 	log.LogDebugf("%s [opDeleteDentry] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -695,7 +695,7 @@ func (m *metadataManager) opBatchDeleteDentry(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.DeleteDentryBatch(req, p)
+	err = mp.DeleteDentryBatch(req, p, remoteAddr)
 
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opDeleteDentry] req: %d - %v, resp: %v, body: %s",
@@ -726,7 +726,7 @@ func (m *metadataManager) opTxUpdateDentry(conn net.Conn, p *Packet, remoteAddr 
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.TxUpdateDentry(req, p)
+	err = mp.TxUpdateDentry(req, p, remoteAddr)
 
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opTxUpdateDentry] req: %d - %v; resp: %v, body: %s",
@@ -759,7 +759,7 @@ func (m *metadataManager) opUpdateDentry(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.UpdateDentry(req, p)
+	err = mp.UpdateDentry(req, p, remoteAddr)
 
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opUpdateDentry] req: %d - %v; resp: %v, body: %s",
@@ -791,7 +791,7 @@ func (m *metadataManager) opTxMetaUnlinkInode(conn net.Conn, p *Packet, remoteAd
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.TxUnlinkInode(req, p)
+	err = mp.TxUnlinkInode(req, p, remoteAddr)
 
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opDeleteInode] req: %d - %v, resp: %v, body: %s",
@@ -822,7 +822,7 @@ func (m *metadataManager) opMetaUnlinkInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.UnlinkInode(req, p)
+	err = mp.UnlinkInode(req, p, remoteAddr)
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opDeleteInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -852,7 +852,7 @@ func (m *metadataManager) opMetaBatchUnlinkInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	err = mp.UnlinkInodeBatch(req, p)
+	err = mp.UnlinkInodeBatch(req, p, remoteAddr)
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opDeleteInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -1007,7 +1007,7 @@ func (m *metadataManager) opBatchMetaEvictInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	if err = mp.EvictInodeBatch(req, p); err != nil {
+	if err = mp.EvictInodeBatch(req, p, remoteAddr); err != nil {
 		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 	}
 	m.respondToClientWithVer(conn, p)
@@ -1039,7 +1039,7 @@ func (m *metadataManager) opMetaEvictInode(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	if err = mp.EvictInode(req, p); err != nil {
+	if err = mp.EvictInode(req, p, remoteAddr); err != nil {
 		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 	}
 	m.respondToClientWithVer(conn, p)
@@ -1286,7 +1286,7 @@ func (m *metadataManager) opMetaExtentsTruncate(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v],req[%v],err[%v]", p.GetOpMsgWithReqAndResult(), req, string(p.Data))
 		return
 	}
-	mp.ExtentsTruncate(req, p)
+	mp.ExtentsTruncate(req, p, remoteAddr)
 	m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [OpMetaTruncate] req: %d - %v, resp body: %v, "+
 		"resp body: %s", remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -1699,7 +1699,7 @@ func (m *metadataManager) opMetaDeleteInode(conn net.Conn, p *Packet,
 	if !m.serveProxy(conn, mp, p) {
 		return
 	}
-	err = mp.DeleteInode(req, p)
+	err = mp.DeleteInode(req, p, remoteAddr)
 	_ = m.respondToClientWithVer(conn, p)
 	log.LogDebugf("%s [opMetaDeleteInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
@@ -1726,7 +1726,7 @@ func (m *metadataManager) opMetaBatchDeleteInode(conn net.Conn, p *Packet,
 	if !m.serveProxy(conn, mp, p) {
 		return
 	}
-	err = mp.DeleteInodeBatch(req, p)
+	err = mp.DeleteInodeBatch(req, p, remoteAddr)
 	log.LogDebugf("%s [opMetaDeleteInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
 
@@ -2170,7 +2170,7 @@ func (m *metadataManager) opTxCreateInode(conn net.Conn, p *Packet,
 		return
 	}
 
-	err = mp.TxCreateInode(req, p)
+	err = mp.TxCreateInode(req, p, remoteAddr)
 	m.respondToClient(conn, p)
 	log.LogDebugf("%s [opTxCreateInode] req: %d - %v, resp: %v, body: %s",
 		remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -36,9 +36,9 @@ var partitionId uint64 = 10
 var manager = &metadataManager{partitions: make(map[uint64]MetaPartition), volUpdating: new(sync.Map)}
 var mp *metaPartition
 
-//PartitionId   uint64              `json:"partition_id"`
-//VolName       string              `json:"vol_name"`
-//PartitionType int                 `json:"partition_type"`
+// PartitionId   uint64              `json:"partition_id"`
+// VolName       string              `json:"vol_name"`
+// PartitionType int                 `json:"partition_type"`
 var metaConf = &MetaPartitionConfig{
 	PartitionId:   10001,
 	VolName:       VolNameForTest,
@@ -1489,7 +1489,7 @@ func TestDelPartitionVersion(t *testing.T) {
 	ino := testCreateInode(t, FileModeType)
 	assert.True(t, ino.getVer() == 10)
 	mp.SetXAttr(&proto.SetXAttrRequest{Inode: ino.Inode, Key: "key1", Value: "0000"}, &Packet{})
-	mp.CreateDentry(&CreateDentryReq{Inode: ino.Inode, Name: "dentryName"}, &Packet{})
+	mp.CreateDentry(&CreateDentryReq{Inode: ino.Inode, Name: "dentryName"}, &Packet{}, "/dentryName")
 
 	err = managerVersionPrepare(&proto.MultiVersionOpRequest{VolumeID: VolNameForTest, Op: proto.CreateVersionPrepare, VerSeq: 25})
 	mp.SetXAttr(&proto.SetXAttrRequest{Inode: ino.Inode, Key: "key1", Value: "1111"}, &Packet{})

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -1,7 +1,28 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package metanode
 
 import (
 	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
 	raftstoremock "github.com/cubefs/cubefs/metanode/mocktest/raftstore"
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util"
@@ -9,12 +30,6 @@ import (
 	"github.com/cubefs/cubefs/util/log"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"math"
-	"os"
-	"reflect"
-	"sync"
-	"testing"
-	"time"
 )
 
 var partitionId uint64 = 10
@@ -1443,10 +1458,10 @@ func TestXAttrOperation(t *testing.T) {
 func TestUpdateDenty(t *testing.T) {
 	newMpWithMock(t)
 	testCreateInode(nil, DirModeType)
-	err := mp.CreateDentry(&CreateDentryReq{Name: "testfile", ParentID: 1, VerSeq: 0, Inode: 1000}, &Packet{})
+	err := mp.CreateDentry(&CreateDentryReq{Name: "testfile", ParentID: 1, VerSeq: 0, Inode: 1000}, &Packet{}, localAddrForAudit)
 	assert.True(t, err == nil)
 	testCreateVer()
-	mp.UpdateDentry(&UpdateDentryReq{Name: "testfile", ParentID: 1, Inode: 2000}, &Packet{})
+	mp.UpdateDentry(&UpdateDentryReq{Name: "testfile", ParentID: 1, Inode: 2000}, &Packet{}, localAddrForAudit)
 	den := &Dentry{Name: "testfile", ParentId: 1}
 	den.setVerSeq(math.MaxUint64)
 	denRsp, status := mp.getDentry(den)

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -43,6 +43,10 @@ import (
 	"github.com/cubefs/cubefs/util/timeutil"
 )
 
+// NOTE: if the operation is invoked by local machine
+// the remote addr is "127.0.0.1"
+const localAddrForAudit = "127.0.0.1"
+
 var (
 	ErrIllegalHeartbeatAddress = errors.New("illegal heartbeat address")
 	ErrIllegalReplicateAddress = errors.New("illegal replicate address")
@@ -126,25 +130,25 @@ func (c *MetaPartitionConfig) sortPeers() {
 
 // OpInode defines the interface for the inode operations.
 type OpInode interface {
-	CreateInode(req *CreateInoReq, p *Packet) (err error)
-	UnlinkInode(req *UnlinkInoReq, p *Packet) (err error)
-	UnlinkInodeBatch(req *BatchUnlinkInoReq, p *Packet) (err error)
+	CreateInode(req *CreateInoReq, p *Packet, remoteAddr string) (err error)
+	UnlinkInode(req *UnlinkInoReq, p *Packet, remoteAddr string) (err error)
+	UnlinkInodeBatch(req *BatchUnlinkInoReq, p *Packet, remoteAddr string) (err error)
 	InodeGet(req *InodeGetReq, p *Packet) (err error)
 	InodeGetSplitEk(req *InodeGetSplitReq, p *Packet) (err error)
 	InodeGetBatch(req *InodeGetReqBatch, p *Packet) (err error)
-	CreateInodeLink(req *LinkInodeReq, p *Packet) (err error)
-	EvictInode(req *EvictInodeReq, p *Packet) (err error)
-	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet) (err error)
+	CreateInodeLink(req *LinkInodeReq, p *Packet, remoteAddr string) (err error)
+	EvictInode(req *EvictInodeReq, p *Packet, remoteAddr string) (err error)
+	EvictInodeBatch(req *BatchEvictInodeReq, p *Packet, remoteAddr string) (err error)
 	SetAttr(req *SetattrRequest, reqData []byte, p *Packet) (err error)
 	GetInodeTree() *BTree
 	GetInodeTreeLen() int
-	DeleteInode(req *proto.DeleteInodeRequest, p *Packet) (err error)
-	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet) (err error)
+	DeleteInode(req *proto.DeleteInodeRequest, p *Packet, remoteAddr string) (err error)
+	DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p *Packet, remoteAddr string) (err error)
 	ClearInodeCache(req *proto.ClearInodeCacheRequest, p *Packet) (err error)
-	TxCreateInode(req *proto.TxCreateInodeRequest, p *Packet) (err error)
-	TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packet) (err error)
-	TxCreateInodeLink(req *proto.TxLinkInodeRequest, p *Packet) (err error)
-	QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p *Packet) (err error)
+	TxCreateInode(req *proto.TxCreateInodeRequest, p *Packet, remoteAddr string) (err error)
+	TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packet, remoteAddr string) (err error)
+	TxCreateInodeLink(req *proto.TxLinkInodeRequest, p *Packet, remoteAddr string) (err error)
+	QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p *Packet, remoteAddr string) (err error)
 }
 
 type OpExtend interface {
@@ -160,28 +164,28 @@ type OpExtend interface {
 
 // OpDentry defines the interface for the dentry operations.
 type OpDentry interface {
-	CreateDentry(req *CreateDentryReq, p *Packet) (err error)
-	DeleteDentry(req *DeleteDentryReq, p *Packet) (err error)
-	DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet) (err error)
-	UpdateDentry(req *UpdateDentryReq, p *Packet) (err error)
+	CreateDentry(req *CreateDentryReq, p *Packet, remoteAddr string) (err error)
+	DeleteDentry(req *DeleteDentryReq, p *Packet, remoteAddr string) (err error)
+	DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet, remoteAddr string) (err error)
+	UpdateDentry(req *UpdateDentryReq, p *Packet, remoteAddr string) (err error)
 	ReadDir(req *ReadDirReq, p *Packet) (err error)
 	ReadDirLimit(req *ReadDirLimitReq, p *Packet) (err error)
 	ReadDirOnly(req *ReadDirOnlyReq, p *Packet) (err error)
 	Lookup(req *LookupReq, p *Packet) (err error)
 	GetDentryTree() *BTree
 	GetDentryTreeLen() int
-	TxCreateDentry(req *proto.TxCreateDentryRequest, p *Packet) (err error)
-	TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Packet) (err error)
-	TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Packet) (err error)
-	QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, p *Packet) (err error)
+	TxCreateDentry(req *proto.TxCreateDentryRequest, p *Packet, remoteAddr string) (err error)
+	TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Packet, remoteAddr string) (err error)
+	TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Packet, remoteAddr string) (err error)
+	QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, p *Packet, remoteAddr string) (err error)
 }
 
 type OpTransaction interface {
 	TxCreate(req *proto.TxCreateRequest, p *Packet) (err error)
 	TxCommitRM(req *proto.TxApplyRMRequest, p *Packet) error
 	TxRollbackRM(req *proto.TxApplyRMRequest, p *Packet) error
-	TxCommit(req *proto.TxApplyRequest, p *Packet) (err error)
-	TxRollback(req *proto.TxApplyRequest, p *Packet) (err error)
+	TxCommit(req *proto.TxApplyRequest, p *Packet, remoteAddr string) (err error)
+	TxRollback(req *proto.TxApplyRequest, p *Packet, remoteAddr string) (err error)
 	TxGetInfo(req *proto.TxGetInfoRequest, p *Packet) (err error)
 	TxGetCnt() (uint64, uint64, uint64)
 	TxGetTree() (*BTree, *BTree, *BTree)
@@ -194,7 +198,7 @@ type OpExtent interface {
 	BatchObjExtentAppend(req *proto.AppendObjExtentKeysRequest, p *Packet) (err error)
 	ExtentsList(req *proto.GetExtentsRequest, p *Packet) (err error)
 	ObjExtentsList(req *proto.GetExtentsRequest, p *Packet) (err error)
-	ExtentsTruncate(req *ExtentsTruncateReq, p *Packet) (err error)
+	ExtentsTruncate(req *ExtentsTruncateReq, p *Packet, remoteAddr string) (err error)
 	BatchExtentAppend(req *proto.AppendExtentKeysRequest, p *Packet) (err error)
 	// ExtentsDelete(req *proto.DelExtentKeyRequest, p *Packet) (err error)
 }
@@ -1557,7 +1561,7 @@ func (mp *metaPartition) delPartitionInodesVersion(verSeq uint64, wg *sync.WaitG
 			Inode:  inode.Inode,
 			VerSeq: verSeq,
 		}
-		mp.UnlinkInode(req, p)
+		mp.UnlinkInode(req, p, localAddrForAudit)
 		// check empty result.
 		// if result is OpAgain, means the extDelCh maybe full,
 		// so let it sleep 1s.

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -1478,7 +1478,7 @@ func (mp *metaPartition) delPartitionDentriesVersion(verSeq uint64, wg *sync.Wai
 			Name:        den.Name,
 			Verseq:      verSeq,
 		}
-		mp.DeleteDentry(req, p)
+		mp.DeleteDentry(req, p, localAddrForAudit)
 		// check empty result.
 		// if result is OpAgain, means the extDelCh maybe full,
 		// so let it sleep 1s.

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -21,11 +21,16 @@ import (
 	"time"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/log"
 )
 
-func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Packet) (err error) {
+func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -76,7 +81,11 @@ func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Pac
 }
 
 // CreateDentry returns a new dentry.
-func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet) (err error) {
+func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -118,7 +127,11 @@ func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet) (err erro
 	return
 }
 
-func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, p *Packet) (err error) {
+func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -169,7 +182,11 @@ func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, 
 	return
 }
 
-func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Packet) (err error) {
+func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Ino, req.ParentID)
+	}()
 	txInfo := req.TxInfo.GetCopy()
 	den := &Dentry{
 		ParentId: req.ParentID,
@@ -240,7 +257,11 @@ func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Pac
 }
 
 // DeleteDentry deletes a dentry.
-func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet) (err error) {
+func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), 0, req.ParentID)
+	}()
 	if req.InodeCreateTime > 0 {
 		if mp.vol.volDeleteLockTime > 0 && req.InodeCreateTime+mp.vol.volDeleteLockTime*60*60 > time.Now().Unix() {
 			err = errors.NewErrorf("the current Inode[%v] is still locked for deletion", req.Name)
@@ -287,16 +308,24 @@ func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet) (err erro
 }
 
 // DeleteDentry deletes a dentry.
-func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet) (err error) {
+func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet, remoteAddr string) (err error) {
 	db := make(DentryBatch, 0, len(req.Dens))
-
-	for _, d := range req.Dens {
+	start := time.Now()
+	for i, d := range req.Dens {
 		db = append(db, &Dentry{
 			ParentId: req.ParentID,
 			Name:     d.Name,
 			Inode:    d.Inode,
 			Type:     d.Type,
 		})
+		den := &d
+		fullPath := ""
+		if len(req.FullPaths) > i {
+			fullPath = req.FullPaths[i]
+		}
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), den.Name, fullPath, err, time.Since(start).Milliseconds(), den.Inode, req.ParentID)
+		}()
 	}
 
 	val, err := db.Marshal()
@@ -349,7 +378,11 @@ func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet)
 	return
 }
 
-func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Packet) (err error) {
+func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -414,7 +447,11 @@ func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Pac
 }
 
 // UpdateDentry updates a dentry.
-func (mp *metaPartition) UpdateDentry(req *UpdateDentryReq, p *Packet) (err error) {
+func (mp *metaPartition) UpdateDentry(req *UpdateDentryReq, p *Packet, remoteAddr string) (err error) {
+	start := time.Now()
+	defer func() {
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -29,7 +29,7 @@ import (
 func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
@@ -84,7 +84,7 @@ func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Pac
 func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
 	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
@@ -130,7 +130,7 @@ func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet, remoteAdd
 func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
 	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
@@ -185,7 +185,7 @@ func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, 
 func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Ino, req.ParentID)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Ino, req.ParentID)
 	}()
 	txInfo := req.TxInfo.GetCopy()
 	den := &Dentry{
@@ -260,7 +260,7 @@ func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Pac
 func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), 0, req.ParentID)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), 0, req.ParentID)
 	}()
 	if req.InodeCreateTime > 0 {
 		if mp.vol.volDeleteLockTime > 0 && req.InodeCreateTime+mp.vol.volDeleteLockTime*60*60 > time.Now().Unix() {
@@ -381,7 +381,7 @@ func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet,
 func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
 	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
@@ -450,7 +450,7 @@ func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Pac
 func (mp *metaPartition) UpdateDentry(req *UpdateDentryReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
 	}()
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -465,7 +465,7 @@ func (mp *metaPartition) ExtentsTruncate(req *ExtentsTruncateReq, p *Packet, rem
 	fileSize := uint64(0)
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, fileSize)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, fileSize)
 	}()
 	ino := NewInode(req.Inode, proto.Mode(os.ModePerm))
 	item := mp.inodeTree.CopyGet(ino)

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -24,8 +24,6 @@ import (
 	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/exporter"
 
-	"github.com/cubefs/cubefs/util/exporter"
-
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/log"

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -111,7 +111,7 @@ func (mp *metaPartition) CreateInode(req *CreateInoReq, p *Packet, remoteAddr st
 	)
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), inoID, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
 	}()
 	inoID, err = mp.nextInodeID()
 	if err != nil {
@@ -163,7 +163,7 @@ func (mp *metaPartition) QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p 
 	)
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), inoID, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
 	}()
 	inoID, err = mp.nextInodeID()
 	if err != nil {
@@ -226,7 +226,7 @@ func (mp *metaPartition) QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p 
 func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	txInfo := req.TxInfo.GetCopy()
 	var status uint8
@@ -316,7 +316,7 @@ func (mp *metaPartition) UnlinkInode(req *UnlinkInoReq, p *Packet, remoteAddr st
 	)
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	makeRspFunc := func() {
 		status := msg.Status
@@ -575,7 +575,7 @@ func (mp *metaPartition) InodeGetBatch(req *InodeGetReqBatch, p *Packet) (err er
 func (mp *metaPartition) TxCreateInodeLink(req *proto.TxLinkInodeRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	txInfo := req.TxInfo.GetCopy()
 	ino := NewInode(req.Inode, 0)
@@ -627,7 +627,7 @@ func (mp *metaPartition) TxCreateInodeLink(req *proto.TxLinkInodeRequest, p *Pac
 func (mp *metaPartition) CreateInodeLink(req *LinkInodeReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	var r interface{}
 	var val []byte
@@ -675,7 +675,7 @@ func (mp *metaPartition) CreateInodeLink(req *LinkInodeReq, p *Packet, remoteAdd
 func (mp *metaPartition) EvictInode(req *EvictInodeReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	ino := NewInode(req.Inode, 0)
 	val, err := ino.Marshal()
@@ -773,7 +773,7 @@ func (mp *metaPartition) GetInodeTreeLen() int {
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), req.Inode, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
 	}()
 	var bytes = make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, req.Inode)
@@ -852,7 +852,7 @@ func (mp *metaPartition) TxCreateInode(req *proto.TxCreateInodeRequest, p *Packe
 	)
 	start := time.Now()
 	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.FullPath, err, time.Since(start).Milliseconds(), inoID, 0)
+		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
 	}()
 	inoID, err = mp.nextInodeID()
 	if err != nil {

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -324,7 +324,7 @@ func (v *Volume) SetXAttr(path string, key string, data []byte, autoCreate bool)
 			return err
 		}
 		var inodeInfo *proto.InodeInfo
-		if inodeInfo, err = v.mw.Create_ll(parentID, filename, DefaultFileMode, 0, 0, nil); err != nil {
+		if inodeInfo, err = v.mw.Create_ll(parentID, filename, DefaultFileMode, 0, 0, nil, path); err != nil {
 			return err
 		}
 		inode = inodeInfo.Inode
@@ -685,7 +685,7 @@ func (v *Volume) PutObject(path string, reader io.Reader, opt *PutFileOption) (f
 	// This file has only inode but no dentry. In this way, this temporary file can be made invisible
 	// in the true sense. In order to avoid the adverse impact of other user operations on temporary data.
 	var invisibleTempDataInode *proto.InodeInfo
-	if invisibleTempDataInode, err = v.mw.InodeCreate_ll(parentId, DefaultFileMode, 0, 0, nil, make([]uint64, 0)); err != nil {
+	if invisibleTempDataInode, err = v.mw.InodeCreate_ll(parentId, DefaultFileMode, 0, 0, nil, make([]uint64, 0), fixedPath); err != nil {
 		log.LogErrorf("PutObject: inode create fail: volume(%v) path(%v) err(%v)", v.name, path, err)
 		return
 	}
@@ -694,10 +694,10 @@ func (v *Volume) PutObject(path string, reader io.Reader, opt *PutFileOption) (f
 		if err != nil {
 			log.LogWarnf("PutObject: unlink temp inode: volume(%v) path(%v) inode(%v)",
 				v.name, path, invisibleTempDataInode.Inode)
-			_, _ = v.mw.InodeUnlink_ll(invisibleTempDataInode.Inode)
+			_, _ = v.mw.InodeUnlink_ll(invisibleTempDataInode.Inode, fixedPath)
 			log.LogWarnf("PutObject: evict temp inode: volume(%v) path(%v) inode(%v)",
 				v.name, path, invisibleTempDataInode.Inode)
-			_ = v.mw.Evict(invisibleTempDataInode.Inode)
+			_ = v.mw.Evict(invisibleTempDataInode.Inode, fixedPath)
 		}
 	}()
 
@@ -806,7 +806,7 @@ func (v *Volume) PutObject(path string, reader io.Reader, opt *PutFileOption) (f
 	}
 
 	// apply new inode to dentry
-	err = v.applyInodeToDEntry(parentId, lastPathItem.Name, invisibleTempDataInode.Inode, false)
+	err = v.applyInodeToDEntry(parentId, lastPathItem.Name, invisibleTempDataInode.Inode, false, fixedPath)
 	if err != nil {
 		log.LogErrorf("PutObject: apply new inode to dentry fail: parentID(%v) name(%v) inode(%v) err(%v)",
 			parentId, lastPathItem.Name, invisibleTempDataInode.Inode, err)
@@ -820,7 +820,7 @@ func (v *Volume) PutObject(path string, reader io.Reader, opt *PutFileOption) (f
 	return fsInfo, nil
 }
 
-func (v *Volume) applyInodeToDEntry(parentId uint64, name string, inode uint64, isCompleteMultipart bool) (err error) {
+func (v *Volume) applyInodeToDEntry(parentId uint64, name string, inode uint64, isCompleteMultipart bool, fullPath string) (err error) {
 	var existMode uint32
 	_, existMode, err = v.mw.Lookup_ll(parentId, name) // exist object inode
 	if err != nil && err != syscall.ENOENT {
@@ -829,7 +829,7 @@ func (v *Volume) applyInodeToDEntry(parentId uint64, name string, inode uint64, 
 	}
 
 	if err == syscall.ENOENT {
-		if err = v.applyInodeToNewDentry(parentId, name, inode); err != nil {
+		if err = v.applyInodeToNewDentry(parentId, name, inode, fullPath); err != nil {
 			log.LogErrorf("applyInodeToDEntry: apply inode to new dentry fail: parentID(%v) name(%v) inode(%v) err(%v)",
 				parentId, name, inode, err)
 			return
@@ -846,7 +846,7 @@ func (v *Volume) applyInodeToDEntry(parentId uint64, name string, inode uint64, 
 		// current implementation doesn't support object versioning, so uploading a object with a key already existed in bucket
 		// is implemented with replacing the old one instead.
 		// refer: https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
-		if err = v.applyInodeToExistDentry(parentId, name, inode, isCompleteMultipart); err != nil {
+		if err = v.applyInodeToExistDentry(parentId, name, inode, isCompleteMultipart, fullPath); err != nil {
 			log.LogErrorf("applyInodeToDEntry: apply inode to exist dentry fail: parentID(%v) name(%v) inode(%v) err(%v)",
 				parentId, name, inode, err)
 			return
@@ -903,9 +903,9 @@ func (v *Volume) DeletePath(path string) (err error) {
 
 	// delete dentry with condition when objectlock is open
 	if objetLock != nil {
-		_, err = v.mw.DeleteWithCond_ll(parent, ino, name, mode.IsDir())
+		_, err = v.mw.DeleteWithCond_ll(parent, ino, name, mode.IsDir(), path)
 	} else {
-		_, err = v.mw.Delete_ll(parent, name, mode.IsDir())
+		_, err = v.mw.Delete_ll(parent, name, mode.IsDir(), path)
 	}
 	if err != nil {
 		return
@@ -921,7 +921,7 @@ func (v *Volume) DeletePath(path string) (err error) {
 
 	log.LogInfof("DeletePath: evict: volume(%v) path(%v) inode(%v)", v.name, path, ino)
 	// Evict inode
-	if err = v.mw.Evict(ino); err != nil {
+	if err = v.mw.Evict(ino, path); err != nil {
 		log.LogWarnf("DeletePath Evict: path(%v) inode(%v)", path, ino)
 	}
 	err = nil
@@ -1002,7 +1002,7 @@ func (v *Volume) WritePart(path string, multipartId string, partId uint16, reade
 
 	// create temp file (inode only, invisible for user)
 	var tempInodeInfo *proto.InodeInfo
-	if tempInodeInfo, err = v.mw.InodeCreate_ll(0, DefaultFileMode, 0, 0, nil, make([]uint64, 0)); err != nil {
+	if tempInodeInfo, err = v.mw.InodeCreate_ll(0, DefaultFileMode, 0, 0, nil, make([]uint64, 0), path); err != nil {
 		log.LogErrorf("WritePart: meta create inode fail: multipartID(%v) partID(%v) err(%v)",
 			multipartId, partId, err)
 		return nil, err
@@ -1016,19 +1016,19 @@ func (v *Volume) WritePart(path string, multipartId string, partId uint16, reade
 		if err != nil {
 			log.LogWarnf("WritePart: unlink part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
 				v.name, path, multipartId, partId, tempInodeInfo.Inode)
-			_, _ = v.mw.InodeUnlink_ll(tempInodeInfo.Inode)
+			_, _ = v.mw.InodeUnlink_ll(tempInodeInfo.Inode, path)
 			log.LogWarnf("WritePart: evict part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
 				v.name, path, multipartId, partId, tempInodeInfo.Inode)
-			_ = v.mw.Evict(tempInodeInfo.Inode)
+			_ = v.mw.Evict(tempInodeInfo.Inode, path)
 		}
 		// Delete the old inode and release the written data.
 		if exist {
 			log.LogWarnf("WritePart: unlink old part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
 				v.name, path, multipartId, partId, oldInode)
-			_, _ = v.mw.InodeUnlink_ll(oldInode)
+			_, _ = v.mw.InodeUnlink_ll(oldInode, path)
 			log.LogWarnf("WritePart: evict old part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
 				v.name, path, multipartId, partId, oldInode)
-			_ = v.mw.Evict(oldInode)
+			_ = v.mw.Evict(oldInode, path)
 		}
 	}()
 
@@ -1111,7 +1111,7 @@ func (v *Volume) AbortMultipart(path string, multipartID string) (err error) {
 		for _, part := range multipartInfo.Parts {
 			log.LogWarnf("AbortMultipart: unlink part inode: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v)",
 				v.name, path, multipartID, part.ID, part.Inode)
-			if _, err = v.mw.InodeUnlink_ll(part.Inode); err != nil {
+			if _, err = v.mw.InodeUnlink_ll(part.Inode, path); err != nil {
 				log.LogErrorf("AbortMultipart: meta inode unlink fail: volume(%v) path(%v) multipartID(%v) partID(%v) inode(%v) err(%v)",
 					v.name, path, multipartID, part.ID, part.Inode, err)
 			}
@@ -1175,7 +1175,7 @@ func (v *Volume) CompleteMultipart(path, multipartID string, multipartInfo *prot
 
 	// create inode for complete data
 	var completeInodeInfo *proto.InodeInfo
-	if completeInodeInfo, err = v.mw.InodeCreate_ll(parentId, DefaultFileMode, 0, 0, nil, make([]uint64, 0)); err != nil {
+	if completeInodeInfo, err = v.mw.InodeCreate_ll(parentId, DefaultFileMode, 0, 0, nil, make([]uint64, 0), path); err != nil {
 		log.LogErrorf("CompleteMultipart: meta inode create fail: volume(%v) path(%v) multipartID(%v) err(%v)",
 			v.name, path, multipartID, err)
 		return
@@ -1186,7 +1186,7 @@ func (v *Volume) CompleteMultipart(path, multipartID string, multipartInfo *prot
 		if err != nil {
 			log.LogWarnf("CompleteMultipart: destroy inode: volume(%v) path(%v) multipartID(%v) inode(%v)",
 				v.name, path, multipartID, completeInodeInfo.Inode)
-			if deleteErr := v.mw.InodeDelete_ll(completeInodeInfo.Inode); deleteErr != nil {
+			if deleteErr := v.mw.InodeDelete_ll(completeInodeInfo.Inode, path); deleteErr != nil {
 				log.LogErrorf("CompleteMultipart: meta delete complete inode fail: volume(%v) path(%v) multipartID(%v) inode(%v) err(%v)",
 					v.name, path, multipartID, completeInodeInfo.Inode, err)
 			}
@@ -1293,7 +1293,7 @@ func (v *Volume) CompleteMultipart(path, multipartID string, multipartInfo *prot
 	}
 
 	// apply new inode to dentry
-	if err = v.applyInodeToDEntry(parentId, filename, completeInodeInfo.Inode, true); err != nil {
+	if err = v.applyInodeToDEntry(parentId, filename, completeInodeInfo.Inode, true, path); err != nil {
 		log.LogErrorf("CompleteMultipart: apply inode to dentry fail: volume(%v) multipartID(%v) parentId(%v) "+
 			"fileName(%v) inode(%v) err(%v)", v.name, multipartID, parentId, filename, completeInodeInfo.Inode, err)
 		return
@@ -1312,7 +1312,7 @@ func (v *Volume) CompleteMultipart(path, multipartID string, multipartInfo *prot
 		for _, part := range parts {
 			log.LogWarnf("CompleteMultipart: destroy part inode: volume(%v) multipartID(%v) partID(%v) inode(%v)",
 				v.name, multipartID, part.ID, part.Inode)
-			if err2 = v.mw.InodeDelete_ll(part.Inode); err2 != nil {
+			if err2 = v.mw.InodeDelete_ll(part.Inode, path); err2 != nil {
 				log.LogWarnf("CompleteMultipart: delete part inode fail: volume(%v) multipartID(%v) part(%v) err(%v)",
 					v.name, multipartID, part, err2)
 			}
@@ -1321,7 +1321,7 @@ func (v *Volume) CompleteMultipart(path, multipartID string, multipartInfo *prot
 		for discardedInode, partNum := range discardedPartInodes {
 			log.LogWarnf("CompleteMultipart: discard part: volume(%v) multipartID(%v) partNum(%v) inode(%v)",
 				v.name, multipartID, partNum, discardedInode)
-			if _, err2 = v.mw.InodeUnlink_ll(discardedInode); err2 != nil {
+			if _, err2 = v.mw.InodeUnlink_ll(discardedInode, path); err2 != nil {
 				log.LogWarnf("CompleteMultipart: unlink inode fail: volume(%v) multipartID(%v) inode(%v) err(%v)",
 					v.name, multipartID, discardedInode, err2)
 			}
@@ -1451,8 +1451,8 @@ func (v *Volume) appendInodeHash(h hash.Hash, inode uint64, total uint64, preAll
 	return
 }
 
-func (v *Volume) applyInodeToNewDentry(parentID uint64, name string, inode uint64) (err error) {
-	if err = v.mw.DentryCreate_ll(parentID, name, inode, DefaultFileMode); err != nil {
+func (v *Volume) applyInodeToNewDentry(parentID uint64, name string, inode uint64, fullPath string) (err error) {
+	if err = v.mw.DentryCreate_ll(parentID, name, inode, DefaultFileMode, fullPath); err != nil {
 		log.LogErrorf("applyInodeToNewDentry: meta dentry create fail: parentID(%v) name(%v) inode(%v) mode(%v) err(%v)",
 			parentID, name, inode, DefaultFileMode, err)
 		return err
@@ -1460,9 +1460,9 @@ func (v *Volume) applyInodeToNewDentry(parentID uint64, name string, inode uint6
 	return
 }
 
-func (v *Volume) applyInodeToExistDentry(parentID uint64, name string, inode uint64, isCompleteMultipart bool) (err error) {
+func (v *Volume) applyInodeToExistDentry(parentID uint64, name string, inode uint64, isCompleteMultipart bool, fullPath string) (err error) {
 	var oldInode uint64
-	oldInode, err = v.mw.DentryUpdate_ll(parentID, name, inode)
+	oldInode, err = v.mw.DentryUpdate_ll(parentID, name, inode, fullPath)
 	if err != nil {
 		log.LogErrorf("applyInodeToExistDentry: meta update dentry fail: parentID(%v) name(%v) inode(%v) err(%v)",
 			parentID, name, inode, err)
@@ -1489,13 +1489,13 @@ func (v *Volume) applyInodeToExistDentry(parentID uint64, name string, inode uin
 
 	// unlink and evict old inode
 	log.LogWarnf("applyInodeToExistDentry: unlink inode: volume(%v) inode(%v)", v.name, oldInode)
-	if _, err = v.mw.InodeUnlink_ll(oldInode); err != nil {
+	if _, err = v.mw.InodeUnlink_ll(oldInode, fullPath); err != nil {
 		log.LogWarnf("applyInodeToExistDentry: unlink inode fail: volume(%v) inode(%v) err(%v)",
 			v.name, oldInode, err)
 	}
 
 	log.LogWarnf("applyInodeToExistDentry: evict inode: volume(%v) inode(%v)", v.name, oldInode)
-	if err = v.mw.Evict(oldInode); err != nil {
+	if err = v.mw.Evict(oldInode, fullPath); err != nil {
 		log.LogWarnf("applyInodeToExistDentry: evict inode fail: volume(%v) inode(%v) err(%v)",
 			v.name, oldInode, err)
 	}
@@ -1805,8 +1805,9 @@ func (v *Volume) Close() error {
 // and the actual search result is a non-directory, an ENOENT error is returned.
 //
 // ENOENT:
-// 		0x2 ENOENT No such file or directory. A component of a specified
-// 		pathname did not exist, or the pathname was an empty string.
+//
+//	0x2 ENOENT No such file or directory. A component of a specified
+//	pathname did not exist, or the pathname was an empty string.
 func (v *Volume) recursiveLookupTarget(path string, notUseCache bool) (parent uint64, ino uint64, name string, mode os.FileMode, err error) {
 	parent = rootIno
 	var pathIterator = NewPathIterator(path)
@@ -1998,7 +1999,7 @@ func (v *Volume) recursiveMakeDirectory(path string) (partentIno uint64, err err
 		}
 		if err == syscall.ENOENT {
 			var info *proto.InodeInfo
-			info, err = v.mw.Create_ll(partentIno, pathItem.Name, uint32(DefaultDirMode), 0, 0, nil)
+			info, err = v.mw.Create_ll(partentIno, pathItem.Name, uint32(DefaultDirMode), 0, 0, nil, path[:pathIterator.cursor])
 			if err != nil && err == syscall.EEXIST {
 				existInode, mode, e := v.mw.Lookup_ll(partentIno, pathItem.Name)
 				if e != nil {
@@ -2047,7 +2048,7 @@ func (v *Volume) lookupDirectories(dirs []string, autoCreate bool) (inode uint64
 		if lookupErr == syscall.ENOENT {
 			var inodeInfo *proto.InodeInfo
 			var createErr error
-			inodeInfo, createErr = v.mw.Create_ll(parentId, dir, uint32(DefaultDirMode), 0, 0, nil)
+			inodeInfo, createErr = v.mw.Create_ll(parentId, dir, uint32(DefaultDirMode), 0, 0, nil, "/"+dir)
 			if createErr != nil && createErr != syscall.EEXIST {
 				log.LogErrorf("lookupDirectories: meta create fail, parentID(%v) name(%v) mode(%v) err(%v)", parentId, dir, os.ModeDir, createErr)
 				return 0, createErr
@@ -2749,7 +2750,7 @@ func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective stri
 	}
 
 	// create target file inode and set target inode to be source file inode
-	if tInodeInfo, err = v.mw.InodeCreate_ll(tParentId, uint32(sMode), 0, 0, nil, make([]uint64, 0)); err != nil {
+	if tInodeInfo, err = v.mw.InodeCreate_ll(tParentId, uint32(sMode), 0, 0, nil, make([]uint64, 0), targetPath); err != nil {
 		return
 	}
 	defer func() {
@@ -2757,10 +2758,10 @@ func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective stri
 		if err != nil {
 			log.LogWarnf("CopyFile: unlink target temp inode: volume(%v) path(%v) inode(%v) ",
 				v.name, targetPath, tInodeInfo.Inode)
-			_, _ = v.mw.InodeUnlink_ll(tInodeInfo.Inode)
+			_, _ = v.mw.InodeUnlink_ll(tInodeInfo.Inode, targetPath)
 			log.LogWarnf("CopyFile: evict target temp inode: volume(%v) path(%v) inode(%v)",
 				v.name, targetPath, tInodeInfo.Inode)
-			_ = v.mw.Evict(tInodeInfo.Inode)
+			_ = v.mw.Evict(tInodeInfo.Inode, targetPath)
 		}
 	}()
 	if err = v.ec.OpenStream(tInodeInfo.Inode); err != nil {
@@ -2955,7 +2956,7 @@ func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective stri
 	}
 
 	// apply new inode to dentry
-	err = v.applyInodeToDEntry(tParentId, tLastName, tInodeInfo.Inode, false)
+	err = v.applyInodeToDEntry(tParentId, tLastName, tInodeInfo.Inode, false, targetPath)
 	if err != nil {
 		log.LogErrorf("CopyFile: apply inode to new dentry fail: path(%v) parentID(%v) name(%v) inode(%v) err(%v)",
 			targetPath, tParentId, tLastName, tInodeInfo.Inode, err)
@@ -2968,12 +2969,12 @@ func (v *Volume) CopyFile(sv *Volume, sourcePath, targetPath, metaDirective stri
 	return
 }
 
-func (v *Volume) copyFile(parentID uint64, newFileName string, sourceFileInode uint64, mode uint32) (info *proto.InodeInfo, err error) {
+func (v *Volume) copyFile(parentID uint64, newFileName string, sourceFileInode uint64, mode uint32, newPath string, sourcePath string) (info *proto.InodeInfo, err error) {
 
-	if err = v.mw.DentryCreate_ll(parentID, newFileName, sourceFileInode, mode); err != nil {
+	if err = v.mw.DentryCreate_ll(parentID, newFileName, sourceFileInode, mode, newPath); err != nil {
 		return
 	}
-	if info, err = v.mw.InodeLink_ll(sourceFileInode); err != nil {
+	if info, err = v.mw.InodeLink_ll(sourceFileInode, sourcePath); err != nil {
 		return
 	}
 	return

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -183,6 +183,19 @@ func (d Dentry) String() string {
 	return fmt.Sprintf("Dentry{Name(%v),Inode(%v),Type(%v)}", d.Name, d.Inode, d.Type)
 }
 
+type RequestExtend struct {
+	FullPaths []string `json:"fullPaths"`
+}
+
+// NOTE: batch request may have multi full path
+// values, but other request only have one
+func (r *RequestExtend) GetFullPath() string {
+	if len(r.FullPaths) < 1 {
+		return ""
+	}
+	return r.FullPaths[0]
+}
+
 // CreateInodeRequest defines the request to create an inode.
 type QuotaCreateInodeRequest struct {
 	VolName     string   `json:"vol"`
@@ -192,7 +205,7 @@ type QuotaCreateInodeRequest struct {
 	Gid         uint32   `json:"gid"`
 	Target      []byte   `json:"tgt"`
 	QuotaIds    []uint32 `json:"qids"`
-	FullPath    string   `json:"fullPath"`
+	RequestExtend
 }
 
 type CreateInodeRequest struct {
@@ -202,7 +215,7 @@ type CreateInodeRequest struct {
 	Uid         uint32 `json:"uid"`
 	Gid         uint32 `json:"gid"`
 	Target      []byte `json:"tgt"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 // CreateInodeResponse defines the response to the request of creating an inode.
@@ -236,7 +249,7 @@ type TxCreateInodeRequest struct {
 	Target      []byte           `json:"tgt"`
 	QuotaIds    []uint32         `json:"qids"`
 	TxInfo      *TransactionInfo `json:"tx"`
-	FullPath    string           `json:"fullPath"`
+	RequestExtend
 }
 
 // TxCreateInodeResponse defines the response with transaction info to the request of creating an inode.
@@ -294,7 +307,7 @@ type LinkInodeRequest struct {
 	Inode       uint64 `json:"ino"`
 	UniqID      uint64 `json:"uiq"`
 	IsRename    bool   `json:"rename"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 // LinkInodeResponse defines the response to the request of linking an inode.
@@ -307,7 +320,7 @@ type TxLinkInodeRequest struct {
 	PartitionID uint64           `json:"pid"`
 	Inode       uint64           `json:"ino"`
 	TxInfo      *TransactionInfo `json:"tx"`
-	FullPath    string           `json:"fullPath"`
+	RequestExtend
 }
 
 func (tx *TxLinkInodeRequest) GetInfo() string {
@@ -334,7 +347,7 @@ type TxUnlinkInodeRequest struct {
 	Inode       uint64           `json:"ino"`
 	Evict       bool             `json:"evict"`
 	TxInfo      *TransactionInfo `json:"tx"`
-	FullPath    string           `json:"fullPath"`
+	RequestExtend
 }
 
 func (tx *TxUnlinkInodeRequest) GetInfo() string {
@@ -354,7 +367,7 @@ type UnlinkInodeRequest struct {
 	UniqID      uint64 `json:"uid"` //for request dedup
 	VerSeq      uint64 `json:"ver"`
 	DenVerSeq   uint64 `json:"denVer"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 // UnlinkInodeRequest defines the request to unlink an inode.
@@ -383,7 +396,7 @@ type EvictInodeRequest struct {
 	VolName     string `json:"vol"`
 	PartitionID uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 // EvictInodeRequest defines the request to evict some inode.
@@ -404,7 +417,7 @@ type QuotaCreateDentryRequest struct {
 	Mode        uint32   `json:"mode"`
 	QuotaIds    []uint32 `json:"qids"`
 	VerSeq      uint64   `json:"seq"`
-	FullPath    string   `json:"fullPath"`
+	RequestExtend
 }
 
 type CreateDentryRequest struct {
@@ -415,7 +428,7 @@ type CreateDentryRequest struct {
 	Name        string `json:"name"`
 	Mode        uint32 `json:"mode"`
 	VerSeq      uint64 `json:"seq"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 type TxPack interface {
@@ -432,7 +445,7 @@ type TxCreateDentryRequest struct {
 	Mode        uint32           `json:"mode"`
 	QuotaIds    []uint32         `json:"qids"`
 	TxInfo      *TransactionInfo `json:"tx"`
-	FullPath    string           `json:"fullPath"`
+	RequestExtend
 }
 
 func (tx *TxCreateDentryRequest) GetInfo() string {
@@ -450,7 +463,7 @@ type UpdateDentryRequest struct {
 	ParentID    uint64 `json:"pino"`
 	Name        string `json:"name"`
 	Inode       uint64 `json:"ino"` // new inode number
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 // UpdateDentryResponse defines the response to the request of updating a dentry.
@@ -466,7 +479,7 @@ type TxUpdateDentryRequest struct {
 	Inode       uint64           `json:"ino"`    // new inode number
 	OldIno      uint64           `json:"oldIno"` // new inode number
 	TxInfo      *TransactionInfo `json:"tx"`
-	FullPath    string           `json:"fullPath"`
+	RequestExtend
 }
 
 func (tx *TxUpdateDentryRequest) GetInfo() string {
@@ -484,7 +497,7 @@ type TxDeleteDentryRequest struct {
 	Name        string           `json:"name"`
 	Ino         uint64           `json:"ino"`
 	TxInfo      *TransactionInfo `json:"tx"`
-	FullPath    string           `json:"fullPath"`
+	RequestExtend
 }
 
 func (tx *TxDeleteDentryRequest) GetInfo() string {
@@ -503,7 +516,7 @@ type DeleteDentryRequest struct {
 	Name            string `json:"name"`
 	InodeCreateTime int64  `json:"inodeCreateTime"`
 	Verseq          uint64 `json:"ver"`
-	FullPath        string `json:"fullPath"`
+	RequestExtend
 }
 
 type BatchDeleteDentryRequest struct {
@@ -697,7 +710,7 @@ type TruncateRequest struct {
 	PartitionID uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
 	Size        uint64 `json:"sz"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 type EmptyExtentKeyRequest struct {
@@ -747,7 +760,7 @@ type DeleteInodeRequest struct {
 	VolName     string `json:"vol"`
 	PartitionId uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
-	FullPath    string `json:"fullPath"`
+	RequestExtend
 }
 
 // DeleteInodeRequest defines the request to delete an inode.

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -192,6 +192,7 @@ type QuotaCreateInodeRequest struct {
 	Gid         uint32   `json:"gid"`
 	Target      []byte   `json:"tgt"`
 	QuotaIds    []uint32 `json:"qids"`
+	FullPath    string   `json:"fullPath"`
 }
 
 type CreateInodeRequest struct {
@@ -201,6 +202,7 @@ type CreateInodeRequest struct {
 	Uid         uint32 `json:"uid"`
 	Gid         uint32 `json:"gid"`
 	Target      []byte `json:"tgt"`
+	FullPath    string `json:"fullPath"`
 }
 
 // CreateInodeResponse defines the response to the request of creating an inode.
@@ -234,6 +236,7 @@ type TxCreateInodeRequest struct {
 	Target      []byte           `json:"tgt"`
 	QuotaIds    []uint32         `json:"qids"`
 	TxInfo      *TransactionInfo `json:"tx"`
+	FullPath    string           `json:"fullPath"`
 }
 
 // TxCreateInodeResponse defines the response with transaction info to the request of creating an inode.
@@ -291,6 +294,7 @@ type LinkInodeRequest struct {
 	Inode       uint64 `json:"ino"`
 	UniqID      uint64 `json:"uiq"`
 	IsRename    bool   `json:"rename"`
+	FullPath    string `json:"fullPath"`
 }
 
 // LinkInodeResponse defines the response to the request of linking an inode.
@@ -303,6 +307,7 @@ type TxLinkInodeRequest struct {
 	PartitionID uint64           `json:"pid"`
 	Inode       uint64           `json:"ino"`
 	TxInfo      *TransactionInfo `json:"tx"`
+	FullPath    string           `json:"fullPath"`
 }
 
 func (tx *TxLinkInodeRequest) GetInfo() string {
@@ -329,6 +334,7 @@ type TxUnlinkInodeRequest struct {
 	Inode       uint64           `json:"ino"`
 	Evict       bool             `json:"evict"`
 	TxInfo      *TransactionInfo `json:"tx"`
+	FullPath    string           `json:"fullPath"`
 }
 
 func (tx *TxUnlinkInodeRequest) GetInfo() string {
@@ -348,6 +354,7 @@ type UnlinkInodeRequest struct {
 	UniqID      uint64 `json:"uid"` //for request dedup
 	VerSeq      uint64 `json:"ver"`
 	DenVerSeq   uint64 `json:"denVer"`
+	FullPath    string `json:"fullPath"`
 }
 
 // UnlinkInodeRequest defines the request to unlink an inode.
@@ -355,6 +362,7 @@ type BatchUnlinkInodeRequest struct {
 	VolName     string   `json:"vol"`
 	PartitionID uint64   `json:"pid"`
 	Inodes      []uint64 `json:"inos"`
+	FullPaths   []string `json:"fullPaths"`
 }
 
 // UnlinkInodeResponse defines the response to the request of unlinking an inode.
@@ -375,6 +383,7 @@ type EvictInodeRequest struct {
 	VolName     string `json:"vol"`
 	PartitionID uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
+	FullPath    string `json:"fullPath"`
 }
 
 // EvictInodeRequest defines the request to evict some inode.
@@ -382,6 +391,7 @@ type BatchEvictInodeRequest struct {
 	VolName     string   `json:"vol"`
 	PartitionID uint64   `json:"pid"`
 	Inodes      []uint64 `json:"inos"`
+	FullPaths   []string `json:"fullPaths"`
 }
 
 // CreateDentryRequest defines the request to create a dentry.
@@ -394,6 +404,7 @@ type QuotaCreateDentryRequest struct {
 	Mode        uint32   `json:"mode"`
 	QuotaIds    []uint32 `json:"qids"`
 	VerSeq      uint64   `json:"seq"`
+	FullPath    string   `json:"fullPath"`
 }
 
 type CreateDentryRequest struct {
@@ -404,6 +415,7 @@ type CreateDentryRequest struct {
 	Name        string `json:"name"`
 	Mode        uint32 `json:"mode"`
 	VerSeq      uint64 `json:"seq"`
+	FullPath    string `json:"fullPath"`
 }
 
 type TxPack interface {
@@ -420,6 +432,7 @@ type TxCreateDentryRequest struct {
 	Mode        uint32           `json:"mode"`
 	QuotaIds    []uint32         `json:"qids"`
 	TxInfo      *TransactionInfo `json:"tx"`
+	FullPath    string           `json:"fullPath"`
 }
 
 func (tx *TxCreateDentryRequest) GetInfo() string {
@@ -437,6 +450,7 @@ type UpdateDentryRequest struct {
 	ParentID    uint64 `json:"pino"`
 	Name        string `json:"name"`
 	Inode       uint64 `json:"ino"` // new inode number
+	FullPath    string `json:"fullPath"`
 }
 
 // UpdateDentryResponse defines the response to the request of updating a dentry.
@@ -452,6 +466,7 @@ type TxUpdateDentryRequest struct {
 	Inode       uint64           `json:"ino"`    // new inode number
 	OldIno      uint64           `json:"oldIno"` // new inode number
 	TxInfo      *TransactionInfo `json:"tx"`
+	FullPath    string           `json:"fullPath"`
 }
 
 func (tx *TxUpdateDentryRequest) GetInfo() string {
@@ -469,6 +484,7 @@ type TxDeleteDentryRequest struct {
 	Name        string           `json:"name"`
 	Ino         uint64           `json:"ino"`
 	TxInfo      *TransactionInfo `json:"tx"`
+	FullPath    string           `json:"fullPath"`
 }
 
 func (tx *TxDeleteDentryRequest) GetInfo() string {
@@ -487,6 +503,7 @@ type DeleteDentryRequest struct {
 	Name            string `json:"name"`
 	InodeCreateTime int64  `json:"inodeCreateTime"`
 	Verseq          uint64 `json:"ver"`
+	FullPath        string `json:"fullPath"`
 }
 
 type BatchDeleteDentryRequest struct {
@@ -494,6 +511,7 @@ type BatchDeleteDentryRequest struct {
 	PartitionID uint64   `json:"pid"`
 	ParentID    uint64   `json:"pino"`
 	Dens        []Dentry `json:"dens"`
+	FullPaths   []string `json:"fullPaths"`
 }
 
 // DeleteDentryResponse defines the response to the request of deleting a dentry.
@@ -679,6 +697,7 @@ type TruncateRequest struct {
 	PartitionID uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
 	Size        uint64 `json:"sz"`
+	FullPath    string `json:"fullPath"`
 }
 
 type EmptyExtentKeyRequest struct {
@@ -728,6 +747,7 @@ type DeleteInodeRequest struct {
 	VolName     string `json:"vol"`
 	PartitionId uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
+	FullPath    string `json:"fullPath"`
 }
 
 // DeleteInodeRequest defines the request to delete an inode.
@@ -735,6 +755,7 @@ type DeleteInodeBatchRequest struct {
 	VolName     string   `json:"vol"`
 	PartitionId uint64   `json:"pid"`
 	Inodes      []uint64 `json:"ino"`
+	FullPaths   []string `json:"fullPaths"`
 }
 
 // AppendExtentKeysRequest defines the request to append an extent key.

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -40,7 +40,7 @@ import (
 type SplitExtentKeyFunc func(parentInode, inode uint64, key proto.ExtentKey) error
 type AppendExtentKeyFunc func(parentInode, inode uint64, key proto.ExtentKey, discard []proto.ExtentKey) error
 type GetExtentsFunc func(inode uint64) (uint64, uint64, []proto.ExtentKey, error)
-type TruncateFunc func(inode, size uint64) error
+type TruncateFunc func(inode, size uint64, fullPath string) error
 type EvictIcacheFunc func(inode uint64)
 type LoadBcacheFunc func(key string, buf []byte, offset uint64, size uint32) (int, error)
 type CacheBcacheFunc func(key string, buf []byte) error
@@ -517,7 +517,7 @@ func (client *ExtentClient) Write(inode uint64, offset int, data []byte, flags i
 	return
 }
 
-func (client *ExtentClient) Truncate(mw *meta.MetaWrapper, parentIno uint64, inode uint64, size int) error {
+func (client *ExtentClient) Truncate(mw *meta.MetaWrapper, parentIno uint64, inode uint64, size int, fullPath string) error {
 	prefix := fmt.Sprintf("Truncate{ino(%v)size(%v)}", inode, size)
 	s := client.GetStreamer(inode)
 	if s == nil {
@@ -531,7 +531,7 @@ func (client *ExtentClient) Truncate(mw *meta.MetaWrapper, parentIno uint64, ino
 		info, err = mw.InodeGet_ll(inode)
 		oldSize = info.Size
 	}
-	err = s.IssueTruncRequest(size)
+	err = s.IssueTruncRequest(size, fullPath)
 	if err != nil {
 		err = errors.Trace(err, prefix)
 		log.LogError(errors.Stack(err))

--- a/sdk/meta/operation.go
+++ b/sdk/meta/operation.go
@@ -49,8 +49,8 @@ func (mw *MetaWrapper) txIcreate(tx *Transaction, mp *MetaPartition, mode, uid, 
 		Target:      target,
 		QuotaIds:    quotaIds,
 		TxInfo:      tx.txInfo,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	resp := new(proto.TxCreateInodeResponse)
 	defer func() {
@@ -118,8 +118,8 @@ func (mw *MetaWrapper) quotaIcreate(mp *MetaPartition, mode, uid, gid uint32, ta
 		Gid:         gid,
 		Target:      target,
 		QuotaIds:    quotaIds,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpQuotaCreateInode
@@ -177,8 +177,8 @@ func (mw *MetaWrapper) icreate(mp *MetaPartition, mode, uid, gid uint32, target 
 		Uid:         uid,
 		Gid:         gid,
 		Target:      target,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaCreateInode
@@ -306,8 +306,8 @@ func (mw *MetaWrapper) txIunlink(tx *Transaction, mp *MetaPartition, inode uint6
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		TxInfo:      tx.txInfo,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 	resp := new(proto.TxUnlinkInodeResponse)
 	metric := exporter.NewTPCnt("OpMetaTxUnlinkInode")
 	defer func() {
@@ -344,8 +344,8 @@ func (mw *MetaWrapper) iunlink(mp *MetaPartition, inode uint64, verSeq uint64, d
 		UniqID:      uniqID,
 		VerSeq:      verSeq,
 		DenVerSeq:   denVerSeq,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaUnlinkInode
@@ -438,8 +438,8 @@ func (mw *MetaWrapper) ievict(mp *MetaPartition, inode uint64, fullPath string) 
 		VolName:     mw.volname,
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaEvictInode
@@ -491,8 +491,8 @@ func (mw *MetaWrapper) txDcreate(tx *Transaction, mp *MetaPartition, parentID ui
 		Mode:        mode,
 		QuotaIds:    quotaIds,
 		TxInfo:      tx.txInfo,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	metric := exporter.NewTPCnt("OpMetaTxCreateDentry")
 	defer func() {
@@ -539,8 +539,8 @@ func (mw *MetaWrapper) quotaDcreate(mp *MetaPartition, parentID uint64, name str
 		Name:        name,
 		Mode:        mode,
 		QuotaIds:    quotaIds,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpQuotaCreateDentry
@@ -594,8 +594,8 @@ func (mw *MetaWrapper) dcreate(mp *MetaPartition, parentID uint64, name string, 
 		Name:        name,
 		Mode:        mode,
 		VerSeq:      verSeq,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaCreateDentry
@@ -646,8 +646,8 @@ func (mw *MetaWrapper) txDupdate(tx *Transaction, mp *MetaPartition, parentID ui
 		Inode:       newInode,
 		OldIno:      oldIno,
 		TxInfo:      tx.txInfo,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	resp := new(proto.TxUpdateDentryResponse)
 	metric := exporter.NewTPCnt("OpMetaTxUpdateDentry")
@@ -681,8 +681,8 @@ func (mw *MetaWrapper) dupdate(mp *MetaPartition, parentID uint64, name string, 
 		ParentID:    parentID,
 		Name:        name,
 		Inode:       newInode,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaUpdateDentry
@@ -806,8 +806,8 @@ func (mw *MetaWrapper) txDdelete(tx *Transaction, mp *MetaPartition, parentID, i
 		Name:        name,
 		Ino:         ino,
 		TxInfo:      tx.txInfo,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	resp := new(proto.TxDeleteDentryResponse)
 
@@ -839,8 +839,8 @@ func (mw *MetaWrapper) ddelete(mp *MetaPartition, parentID uint64, name string, 
 		Name:            name,
 		InodeCreateTime: inodeCreateTime,
 		Verseq:          verSeq,
-		FullPath:        fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 	log.LogDebugf("action[ddelete] %v", req)
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaDeleteDentry
@@ -1411,8 +1411,8 @@ func (mw *MetaWrapper) truncate(mp *MetaPartition, inode, size uint64, fullPath 
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		Size:        size,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaTruncate
@@ -1458,8 +1458,8 @@ func (mw *MetaWrapper) txIlink(tx *Transaction, mp *MetaPartition, inode uint64,
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		TxInfo:      tx.txInfo,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	resp := new(proto.TxLinkInodeResponse)
 	metric := exporter.NewTPCnt("OpMetaTxLinkInode")
@@ -1501,8 +1501,8 @@ func (mw *MetaWrapper) ilinkWork(mp *MetaPartition, inode uint64, op uint8, full
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		UniqID:      uniqID,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 
 	packet := proto.NewPacketReqID()
 	packet.Opcode = op
@@ -1822,8 +1822,8 @@ func (mw *MetaWrapper) idelete(mp *MetaPartition, inode uint64, fullPath string)
 		VolName:     mw.volname,
 		PartitionId: mp.PartitionID,
 		Inode:       inode,
-		FullPath:    fullPath,
 	}
+	req.FullPaths = []string{fullPath}
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaDeleteInode
 	packet.PartitionID = mp.PartitionID

--- a/sdk/meta/operation.go
+++ b/sdk/meta/operation.go
@@ -32,7 +32,7 @@ import (
 //
 // txIcreate create inode and tx together
 func (mw *MetaWrapper) txIcreate(tx *Transaction, mp *MetaPartition, mode, uid, gid uint32,
-	target []byte, quotaIds []uint32) (status int, info *proto.InodeInfo, err error) {
+	target []byte, quotaIds []uint32, fullPath string) (status int, info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("txIcreate", err, bgTime, 1)
@@ -49,6 +49,7 @@ func (mw *MetaWrapper) txIcreate(tx *Transaction, mp *MetaPartition, mode, uid, 
 		Target:      target,
 		QuotaIds:    quotaIds,
 		TxInfo:      tx.txInfo,
+		FullPath:    fullPath,
 	}
 
 	resp := new(proto.TxCreateInodeResponse)
@@ -102,7 +103,7 @@ func (mw *MetaWrapper) txIcreate(tx *Transaction, mp *MetaPartition, mode, uid, 
 	return status, resp.Info, nil
 }
 
-func (mw *MetaWrapper) quotaIcreate(mp *MetaPartition, mode, uid, gid uint32, target []byte, quotaIds []uint32) (status int,
+func (mw *MetaWrapper) quotaIcreate(mp *MetaPartition, mode, uid, gid uint32, target []byte, quotaIds []uint32, fullPath string) (status int,
 	info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
@@ -117,6 +118,7 @@ func (mw *MetaWrapper) quotaIcreate(mp *MetaPartition, mode, uid, gid uint32, ta
 		Gid:         gid,
 		Target:      target,
 		QuotaIds:    quotaIds,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -161,7 +163,7 @@ func (mw *MetaWrapper) quotaIcreate(mp *MetaPartition, mode, uid, gid uint32, ta
 	return statusOK, resp.Info, nil
 }
 
-func (mw *MetaWrapper) icreate(mp *MetaPartition, mode, uid, gid uint32, target []byte) (status int,
+func (mw *MetaWrapper) icreate(mp *MetaPartition, mode, uid, gid uint32, target []byte, fullPath string) (status int,
 	info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
@@ -175,6 +177,7 @@ func (mw *MetaWrapper) icreate(mp *MetaPartition, mode, uid, gid uint32, target 
 		Uid:         uid,
 		Gid:         gid,
 		Target:      target,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -292,7 +295,7 @@ func (mw *MetaWrapper) SendTxPack(req proto.TxPack, resp interface{}, Opcode uin
 	return
 }
 
-func (mw *MetaWrapper) txIunlink(tx *Transaction, mp *MetaPartition, inode uint64) (status int, info *proto.InodeInfo, err error) {
+func (mw *MetaWrapper) txIunlink(tx *Transaction, mp *MetaPartition, inode uint64, fullPath string) (status int, info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("txIunlink", err, bgTime, 1)
@@ -303,6 +306,7 @@ func (mw *MetaWrapper) txIunlink(tx *Transaction, mp *MetaPartition, inode uint6
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		TxInfo:      tx.txInfo,
+		FullPath:    fullPath,
 	}
 	resp := new(proto.TxUnlinkInodeResponse)
 	metric := exporter.NewTPCnt("OpMetaTxUnlinkInode")
@@ -320,7 +324,7 @@ func (mw *MetaWrapper) txIunlink(tx *Transaction, mp *MetaPartition, inode uint6
 	return statusOK, resp.Info, nil
 }
 
-func (mw *MetaWrapper) iunlink(mp *MetaPartition, inode uint64, verSeq uint64, denVerSeq uint64) (status int, info *proto.InodeInfo, err error) {
+func (mw *MetaWrapper) iunlink(mp *MetaPartition, inode uint64, verSeq uint64, denVerSeq uint64, fullPath string) (status int, info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("iunlink", err, bgTime, 1)
@@ -340,6 +344,7 @@ func (mw *MetaWrapper) iunlink(mp *MetaPartition, inode uint64, verSeq uint64, d
 		UniqID:      uniqID,
 		VerSeq:      verSeq,
 		DenVerSeq:   denVerSeq,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -423,7 +428,7 @@ func (mw *MetaWrapper) iclearCache(mp *MetaPartition, inode uint64) (status int,
 	return status, nil
 }
 
-func (mw *MetaWrapper) ievict(mp *MetaPartition, inode uint64) (status int, err error) {
+func (mw *MetaWrapper) ievict(mp *MetaPartition, inode uint64, fullPath string) (status int, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("ievict", err, bgTime, 1)
@@ -433,6 +438,7 @@ func (mw *MetaWrapper) ievict(mp *MetaPartition, inode uint64) (status int, err 
 		VolName:     mw.volname,
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -466,7 +472,7 @@ func (mw *MetaWrapper) ievict(mp *MetaPartition, inode uint64) (status int, err 
 	return statusOK, nil
 }
 
-func (mw *MetaWrapper) txDcreate(tx *Transaction, mp *MetaPartition, parentID uint64, name string, inode uint64, mode uint32, quotaIds []uint32) (status int, err error) {
+func (mw *MetaWrapper) txDcreate(tx *Transaction, mp *MetaPartition, parentID uint64, name string, inode uint64, mode uint32, quotaIds []uint32, fullPath string) (status int, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("txDcreate", err, bgTime, 1)
@@ -485,6 +491,7 @@ func (mw *MetaWrapper) txDcreate(tx *Transaction, mp *MetaPartition, parentID ui
 		Mode:        mode,
 		QuotaIds:    quotaIds,
 		TxInfo:      tx.txInfo,
+		FullPath:    fullPath,
 	}
 
 	metric := exporter.NewTPCnt("OpMetaTxCreateDentry")
@@ -514,7 +521,7 @@ func (mw *MetaWrapper) txDcreate(tx *Transaction, mp *MetaPartition, parentID ui
 }
 
 func (mw *MetaWrapper) quotaDcreate(mp *MetaPartition, parentID uint64, name string, inode uint64, mode uint32,
-	quotaIds []uint32) (status int, err error) {
+	quotaIds []uint32, fullPath string) (status int, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("dcreate", err, bgTime, 1)
@@ -532,6 +539,7 @@ func (mw *MetaWrapper) quotaDcreate(mp *MetaPartition, parentID uint64, name str
 		Name:        name,
 		Mode:        mode,
 		QuotaIds:    quotaIds,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -565,7 +573,7 @@ func (mw *MetaWrapper) quotaDcreate(mp *MetaPartition, parentID uint64, name str
 	return
 }
 
-func (mw *MetaWrapper) dcreate(mp *MetaPartition, parentID uint64, name string, inode uint64, mode uint32) (status int, err error) {
+func (mw *MetaWrapper) dcreate(mp *MetaPartition, parentID uint64, name string, inode uint64, mode uint32, fullPath string) (status int, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("dcreate", err, bgTime, 1)
@@ -586,6 +594,7 @@ func (mw *MetaWrapper) dcreate(mp *MetaPartition, parentID uint64, name string, 
 		Name:        name,
 		Mode:        mode,
 		VerSeq:      verSeq,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -619,7 +628,7 @@ func (mw *MetaWrapper) dcreate(mp *MetaPartition, parentID uint64, name string, 
 	return
 }
 
-func (mw *MetaWrapper) txDupdate(tx *Transaction, mp *MetaPartition, parentID uint64, name string, newInode, oldIno uint64) (status int, oldInode uint64, err error) {
+func (mw *MetaWrapper) txDupdate(tx *Transaction, mp *MetaPartition, parentID uint64, name string, newInode, oldIno uint64, fullPath string) (status int, oldInode uint64, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("txDupdate", err, bgTime, 1)
@@ -637,6 +646,7 @@ func (mw *MetaWrapper) txDupdate(tx *Transaction, mp *MetaPartition, parentID ui
 		Inode:       newInode,
 		OldIno:      oldIno,
 		TxInfo:      tx.txInfo,
+		FullPath:    fullPath,
 	}
 
 	resp := new(proto.TxUpdateDentryResponse)
@@ -655,7 +665,7 @@ func (mw *MetaWrapper) txDupdate(tx *Transaction, mp *MetaPartition, parentID ui
 	return statusOK, resp.Inode, nil
 }
 
-func (mw *MetaWrapper) dupdate(mp *MetaPartition, parentID uint64, name string, newInode uint64) (status int, oldInode uint64, err error) {
+func (mw *MetaWrapper) dupdate(mp *MetaPartition, parentID uint64, name string, newInode uint64, fullPath string) (status int, oldInode uint64, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("dupdate", err, bgTime, 1)
@@ -671,6 +681,7 @@ func (mw *MetaWrapper) dupdate(mp *MetaPartition, parentID uint64, name string, 
 		ParentID:    parentID,
 		Name:        name,
 		Inode:       newInode,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -782,7 +793,7 @@ func (mw *MetaWrapper) txCreateTX(tx *Transaction, mp *MetaPartition) (status in
 //	return statusOK, nil
 //}
 
-func (mw *MetaWrapper) txDdelete(tx *Transaction, mp *MetaPartition, parentID, ino uint64, name string) (status int, inode uint64, err error) {
+func (mw *MetaWrapper) txDdelete(tx *Transaction, mp *MetaPartition, parentID, ino uint64, name string, fullPath string) (status int, inode uint64, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("txDdelete", err, bgTime, 1)
@@ -795,6 +806,7 @@ func (mw *MetaWrapper) txDdelete(tx *Transaction, mp *MetaPartition, parentID, i
 		Name:        name,
 		Ino:         ino,
 		TxInfo:      tx.txInfo,
+		FullPath:    fullPath,
 	}
 
 	resp := new(proto.TxDeleteDentryResponse)
@@ -814,7 +826,7 @@ func (mw *MetaWrapper) txDdelete(tx *Transaction, mp *MetaPartition, parentID, i
 	return statusOK, resp.Inode, nil
 }
 
-func (mw *MetaWrapper) ddelete(mp *MetaPartition, parentID uint64, name string, inodeCreateTime int64, verSeq uint64) (status int, inode uint64, denVer uint64, err error) {
+func (mw *MetaWrapper) ddelete(mp *MetaPartition, parentID uint64, name string, inodeCreateTime int64, verSeq uint64, fullPath string) (status int, inode uint64, denVer uint64, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("ddelete", err, bgTime, 1)
@@ -827,6 +839,7 @@ func (mw *MetaWrapper) ddelete(mp *MetaPartition, parentID uint64, name string, 
 		Name:            name,
 		InodeCreateTime: inodeCreateTime,
 		Verseq:          verSeq,
+		FullPath:        fullPath,
 	}
 	log.LogDebugf("action[ddelete] %v", req)
 	packet := proto.NewPacketReqID()
@@ -880,7 +893,7 @@ func (mw *MetaWrapper) canDeleteInode(mp *MetaPartition, info *proto.InodeInfo, 
 	return true, nil
 }
 
-func (mw *MetaWrapper) ddeletes(mp *MetaPartition, parentID uint64, dentries []proto.Dentry) (status int,
+func (mw *MetaWrapper) ddeletes(mp *MetaPartition, parentID uint64, dentries []proto.Dentry, fullPaths []string) (status int,
 	resp *proto.BatchDeleteDentryResponse, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
@@ -892,6 +905,7 @@ func (mw *MetaWrapper) ddeletes(mp *MetaPartition, parentID uint64, dentries []p
 		PartitionID: mp.PartitionID,
 		ParentID:    parentID,
 		Dens:        dentries,
+		FullPaths:   fullPaths,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -1386,7 +1400,7 @@ func (mw *MetaWrapper) getObjExtents(mp *MetaPartition, inode uint64) (status in
 // 	return status, nil
 // }
 
-func (mw *MetaWrapper) truncate(mp *MetaPartition, inode, size uint64) (status int, err error) {
+func (mw *MetaWrapper) truncate(mp *MetaPartition, inode, size uint64, fullPath string) (status int, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("truncate", err, bgTime, 1)
@@ -1397,6 +1411,7 @@ func (mw *MetaWrapper) truncate(mp *MetaPartition, inode, size uint64) (status i
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		Size:        size,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -1432,7 +1447,7 @@ func (mw *MetaWrapper) truncate(mp *MetaPartition, inode, size uint64) (status i
 	return statusOK, nil
 }
 
-func (mw *MetaWrapper) txIlink(tx *Transaction, mp *MetaPartition, inode uint64) (status int, info *proto.InodeInfo, err error) {
+func (mw *MetaWrapper) txIlink(tx *Transaction, mp *MetaPartition, inode uint64, fullPath string) (status int, info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("txIlink", err, bgTime, 1)
@@ -1443,6 +1458,7 @@ func (mw *MetaWrapper) txIlink(tx *Transaction, mp *MetaPartition, inode uint64)
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		TxInfo:      tx.txInfo,
+		FullPath:    fullPath,
 	}
 
 	resp := new(proto.TxLinkInodeResponse)
@@ -1463,11 +1479,11 @@ func (mw *MetaWrapper) txIlink(tx *Transaction, mp *MetaPartition, inode uint64)
 	return statusOK, resp.Info, nil
 }
 
-func (mw *MetaWrapper) ilink(mp *MetaPartition, inode uint64) (status int, info *proto.InodeInfo, err error) {
-	return mw.ilinkWork(mp, inode, proto.OpMetaLinkInode)
+func (mw *MetaWrapper) ilink(mp *MetaPartition, inode uint64, fullPath string) (status int, info *proto.InodeInfo, err error) {
+	return mw.ilinkWork(mp, inode, proto.OpMetaLinkInode, fullPath)
 }
 
-func (mw *MetaWrapper) ilinkWork(mp *MetaPartition, inode uint64, op uint8) (status int, info *proto.InodeInfo, err error) {
+func (mw *MetaWrapper) ilinkWork(mp *MetaPartition, inode uint64, op uint8, fullPath string) (status int, info *proto.InodeInfo, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("ilink", err, bgTime, 1)
@@ -1485,6 +1501,7 @@ func (mw *MetaWrapper) ilinkWork(mp *MetaPartition, inode uint64, op uint8) (sta
 		PartitionID: mp.PartitionID,
 		Inode:       inode,
 		UniqID:      uniqID,
+		FullPath:    fullPath,
 	}
 
 	packet := proto.NewPacketReqID()
@@ -1795,7 +1812,7 @@ func (mw *MetaWrapper) addMultipartPart(mp *MetaPartition, path, multipartId str
 	return status, resp.OldInode, resp.Update, nil
 }
 
-func (mw *MetaWrapper) idelete(mp *MetaPartition, inode uint64) (status int, err error) {
+func (mw *MetaWrapper) idelete(mp *MetaPartition, inode uint64, fullPath string) (status int, err error) {
 	bgTime := stat.BeginStat()
 	defer func() {
 		stat.EndStat("idelete", err, bgTime, 1)
@@ -1805,6 +1822,7 @@ func (mw *MetaWrapper) idelete(mp *MetaPartition, inode uint64) (status int, err
 		VolName:     mw.volname,
 		PartitionId: mp.PartitionID,
 		Inode:       inode,
+		FullPath:    fullPath,
 	}
 	packet := proto.NewPacketReqID()
 	packet.Opcode = proto.OpMetaDeleteInode

--- a/util/auditlog/auditlog.go
+++ b/util/auditlog/auditlog.go
@@ -273,7 +273,7 @@ func NewAudit(dir, logModule string, logMaxSize int64) (*Audit, error) {
 // format for client:
 // [COMMON HEADER] IP_ADDR HOSTNAME OP SRC DST(Rename) ERR LATENCY SRC_INODE DST_INODE(Rename)
 // format for server(inode):
-// [COMMON HEADER] CLIENT_ADDR VOLUME OP ("nil") FULL_PATH ERR LATENCY INODE FILE_SIZE
+// [COMMON HEADER] CLIENT_ADDR VOLUME OP ("nil") FULL_PATH ERR LATENCY INODE FILE_SIZE(Trunc)
 // format for server(dentry):
 // [COMMON HEADER] CLIENT_ADDR VOLUME OP NAME FULL_PATH ERR LATENCY INODE PARENT_INODE
 // format for server(transaction):

--- a/util/auditlog/auditlog_test.go
+++ b/util/auditlog/auditlog_test.go
@@ -1,0 +1,95 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package auditlog_test
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/cubefs/cubefs/util/auditlog"
+	"github.com/stretchr/testify/require"
+)
+
+const testLogModule = "test"
+
+const testLogMax = 1024
+
+const testLogCount = 1024
+
+const testBufSize = 0
+
+const testResetBufSize = 1024
+
+const testPrefix = "test"
+
+func AuditLogTest(audit *auditlog.Audit, baseDir string, t *testing.T) {
+	audit.ResetWriterBufferSize(testBufSize)
+	dir, module, max := audit.GetInfo()
+	t.Logf("log dir in %v\n", dir)
+	require.Equal(t, path.Join(baseDir, testLogModule), dir)
+	require.Equal(t, testLogModule, module)
+	require.EqualValues(t, testLogMax, max)
+	for i := 0; i < testLogCount; i++ {
+		audit.LogClientOp("nil", "nil", "nil", nil, 0, 0, 0)
+	}
+	// NOTE: wait for flush
+	time.Sleep(2 * time.Second)
+	dentries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, dentry := range dentries {
+		t.Logf("log file %v\n", dentry.Name())
+	}
+	// NOTE: we have prefix, so shiftfile()
+	// must be invoked once
+	require.NotEqualValues(t, 1, len(dentries))
+	audit.ResetWriterBufferSize(testResetBufSize)
+}
+
+func TestAuditLog(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	audit, err := auditlog.NewAuditWithPrefix(tmpDir, testLogModule, testLogMax, auditlog.NewAuditPrefix(testPrefix))
+	require.NoError(t, err)
+	defer audit.Stop()
+	AuditLogTest(audit, tmpDir, t)
+}
+
+func TestGlobalAuditLog(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	_, err = auditlog.InitAuditWithPrefix(tmpDir, testLogModule, testLogMax, auditlog.NewAuditPrefix(testPrefix))
+	require.NoError(t, err)
+	defer auditlog.StopAudit()
+	auditlog.ResetWriterBufferSize(testBufSize)
+	dir, module, max, err := auditlog.GetAuditLogInfo()
+	require.NoError(t, err)
+	require.Equal(t, path.Join(tmpDir, testLogModule), dir)
+	require.Equal(t, testLogModule, module)
+	require.EqualValues(t, testLogMax, max)
+	for i := 0; i < testLogCount; i++ {
+		auditlog.LogClientOp("nil", "nil", "nil", nil, 0, 0, 0)
+	}
+	// NOTE: wait for flush
+	time.Sleep(2 * time.Second)
+	dentries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, dentry := range dentries {
+		t.Logf("log file %v\n", dentry.Name())
+	}
+	require.NotEqualValues(t, 1, len(dentries))
+	auditlog.ResetWriterBufferSize(testResetBufSize)
+}

--- a/util/caps/caps.go
+++ b/util/caps/caps.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package caps
 
 import (


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Support metadata operations back-end audit log:
    *  Inode write operations.
    * Dentry write operations.
    * Transaction commit and rollback.
    * Snapshot tool doesn't support audit log full path.
* Rename `auditlog.FormatLog` to `auditlog.LogClientOp`, for distinguish back-end log from client log.
* Refactor `util/auditlog` and fix path bug.
* Add `util/auditlog.go` unit test.


**Test Command:**
```sh
$ mdtest -z 3 -b 4 -I 10
```

**Audit log in [here](https://github.com/NaturalSelect/logs/tree/main/cubefs/audit).**

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/cubefs]
└─$ bash cp_audit.sh 
Create dentry count:
1787
Delete dentry count:
1786
Create inode count:
1787
Delete inode count:
1786
Create /out dentry:
2023-09-27 20:36:20 CST, 172.16.1.103:56186, ltptest, OpMetaCreateDentry, out, /out, nil, 0 us, 8391053, 1
Delete /out dentry:
Create /out inode:
2023-09-27 20:36:20 CST, 172.16.1.101:44250, ltptest, OpMetaCreateInode, nil, /out, nil, 0 us, 8391053, 0
Delete /out inode:

┌──(nature㉿LAPTOP-9TS0FG11)-[~/cubefs]
└─$ ls ~/disk/client/mnt
out

```

**Format of audit log:**

Common Header:

```log
[PREFIX] CURRENT_TIME TIME_ZONE
```

Client Audit Log

```log
[COMMON HEADER] IP_ADDR HOSTNAME OP SRC_NAME DST_NAME(if Rename) ERR LATENCY SRC_INODE DST_INODE(if Rename)
```

Server Audit Log:

*Inode:*

```log
[COMMON HEADER] CLIENT_ADDR VOLUME OP ("nil") FULL_PATH ERR LATENCY INODE FILE_SIZE(Trunc)
```

*Dentry:*

```log
[COMMON HEADER] CLIENT_ADDR VOLUME OP NAME FULL_PATH ERR LATENCY INODE PARENT_INODE
```

*Transaction:*
```log
[COMMON HEADER] CLIENT_ADDR VOLUME OP TX_ID ("nil") ERR LATENCY TM_ID (0)
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2625

**Special notes for your reviewer**:

* Old version of sdk(including Client,Libsdk,LcNode,ObjectNode,etc..) doesn't support full path. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
