### PR TITLE
fix(client): snapshot.try append ek process forget the discards process and check failed in metanode

### DIFF
--- a/master/multi_ver_snapshot.go
+++ b/master/multi_ver_snapshot.go
@@ -232,8 +232,6 @@ func (verMgr *VolVersionManager) checkCreateStrategy() {
 
 func (verMgr *VolVersionManager) checkDeleteStrategy() {
 	verMgr.RLock()
-	defer verMgr.RUnlock()
-
 	log.LogDebugf("checkSnapshotStrategy.vol %v try delete snapshot nLen %v, keep cnt %v", verMgr.vol.Name, len(verMgr.multiVersionList)-1, verMgr.strategy.KeepVerCnt)
 	nLen := len(verMgr.multiVersionList)
 	log.LogDebugf("checkSnapshotStrategy.vol %v try delete snapshot nLen %v, keep cnt %v", verMgr.vol.Name, len(verMgr.multiVersionList)-1, verMgr.strategy.KeepVerCnt)

--- a/proto/model.go
+++ b/proto/model.go
@@ -355,7 +355,7 @@ type VolVersionInfo struct {
 }
 
 func (vv *VolVersionInfo) String() string {
-	return fmt.Sprintf("Ver:%v|DelTimt:%v|status:%v", vv.Ver, vv.DelTime, vv.DelTime)
+	return fmt.Sprintf("Ver:%v|DelTimt:%v|status:%v", vv.Ver, vv.DelTime, vv.Status)
 }
 
 type VolVersionInfoList struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1) try append forget the discards process and check failed in metanode
    write request cover the old ek and do append write for performace and discard old ek in the flush stage,
    but the try append(client viewpoint don't know whether the extent right neighbor exist or not,need to try write,
    but the async process of do append write need async dealing, which not easy to manage,
    so use direct write append by raft submit in datanode for simple)
    process use sync way but forget the discard process lead to inconsistent in metanode check
2) defer unlock is stale code and clean or else lead to deadlock