### PR TITLE
fix: fix problems (dp-size option name, threshold range check, mp/dp stale paritition data)

### DIFF
--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -119,7 +119,7 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 	var optBusiness string
 	var optMPCount int
 	var optReplicaNum string
-	var optSize int
+	var optDPSize int
 	var optVolType int
 	var optFollowerRead string
 	var optZoneName string
@@ -186,7 +186,7 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 				stdout("  description              : %v\n", optBusiness)
 				stdout("  mpCount                  : %v\n", optMPCount)
 				stdout("  replicaNum               : %v\n", optReplicaNum)
-				stdout("  size                     : %v G\n", optSize)
+				stdout("  dpSize                   : %v G\n", optDPSize)
 				stdout("  volType                  : %v\n", optVolType)
 				stdout("  followerRead             : %v\n", followerRead)
 				stdout("  readOnlyWhenFull         : %v\n", dpReadOnlyWhenVolFull)
@@ -215,7 +215,7 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 
 			err = client.AdminAPI().CreateVolName(
 				volumeName, userID, optCapacity, optDeleteLockTime, crossZone, normalZonesFirst, optBusiness,
-				optMPCount, int(replicaNum), optSize, optVolType, followerRead,
+				optMPCount, int(replicaNum), optDPSize, optVolType, followerRead,
 				optZoneName, optCacheRuleKey, optEbsBlkSize, optCacheCap,
 				optCacheAction, optCacheThreshold, optCacheTTL, optCacheHighWater,
 				optCacheLowWater, optCacheLRUInterval, dpReadOnlyWhenVolFull,
@@ -234,7 +234,7 @@ func newVolCreateCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optBusiness, CliFlagBusiness, cmdVolDefaultBusiness, "Description")
 	cmd.Flags().IntVar(&optMPCount, CliFlagMPCount, cmdVolDefaultMPCount, "Specify init meta partition count")
 	cmd.Flags().StringVar(&optReplicaNum, CliFlagReplicaNum, "", "Specify data partition replicas number(default 3 for normal volume,1 for low volume)")
-	cmd.Flags().IntVar(&optSize, CliFlagSize, cmdVolDefaultSize, "Specify data partition size[Unit: GB]")
+	cmd.Flags().IntVar(&optDPSize, CliFlagDataPartitionSize, cmdVolDefaultDPSize, "Specify data partition size[Unit: GB]")
 	cmd.Flags().IntVar(&optVolType, CliFlagVolType, cmdVolDefaultVolType, "Type of volume (default 0)")
 	cmd.Flags().StringVar(&optFollowerRead, CliFlagFollowerRead, "", "Enable read form replica follower")
 	cmd.Flags().StringVar(&optZoneName, CliFlagZoneName, cmdVolDefaultZoneName, "Specify volume zone name")

--- a/docs-zh/source/maintenance/admin-api/master/volume.md
+++ b/docs-zh/source/maintenance/admin-api/master/volume.md
@@ -25,7 +25,7 @@ CubeFS以 **Owner**参数作为用户ID。
 | owner            | string | 卷的所有者，同时也是用户ID                                        | 是   | 无                                |
 | mpCount          | int    | 初始化元数据分片个数                                            | 否   | 3                                |
 | replicaNum       | int    | 副本数                                                   | 否   | 副本卷默认3（支持1,3），纠删码卷默认1（支持1-16个）   |
-| size             | int    | 数据分片大小，单位GB                                           | 否   | 120                              |
+| dpSize           | int    | 数据分片大小，单位GB                                           | 否   | 120                              |
 | enablePosixAcl   | bool   | 是否配置posix权限限制                                         | 否   | false                            |
 | followerRead     | bool   | 允许从follower读取数据，纠删码卷默认true                            | 否   | false                            |
 | crossZone        | bool   | 是否跨区域，如设为true，则不能设置zoneName参数                         | 否   | false                            |

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -17,7 +17,6 @@ package master
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"math"
 	"net/http"
 	"sort"
@@ -26,6 +25,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/uuid"
 
 	authSDK "github.com/cubefs/cubefs/sdk/auth"
 	masterSDK "github.com/cubefs/cubefs/sdk/master"
@@ -3483,6 +3484,10 @@ func (c *Cluster) getMonitorPushAddr() (addr string) {
 }
 
 func (c *Cluster) setMetaNodeThreshold(threshold float32) (err error) {
+	if threshold > 1.0 || threshold < 0.0 {
+		err = fmt.Errorf("set threshold failed: threshold (%v) should between 0.0 and 1.0", threshold)
+		return
+	}
 	oldThreshold := c.cfg.MetaNodeThreshold
 	c.cfg.MetaNodeThreshold = threshold
 	if err = c.syncPutCluster(); err != nil {

--- a/master/const.go
+++ b/master/const.go
@@ -33,7 +33,7 @@ const (
 	thresholdKey          = "threshold"
 	dirQuotaKey           = "dirQuota"
 	dirLimitKey           = "dirSizeLimit"
-	dataPartitionSizeKey  = "size"
+	dataPartitionSizeKey  = "dpSize"
 	metaPartitionCountKey = "mpCount"
 	volCapacityKey        = "capacity"
 	volDeleteLockTimeKey  = "deleteLockTime"

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -562,6 +562,11 @@ func (m *metadataManager) createPartition(request *proto.CreateMetaPartitionRequ
 		err = errors.NewErrorf("[createPartition] partition is nil")
 		return
 	}
+
+	if err = partition.BackupMetadata(); err != nil {
+		err = errors.NewErrorf("[createPartition]->%s", err.Error())
+	}
+
 	if err = partition.PersistMetadata(); err != nil {
 		err = errors.NewErrorf("[createPartition]->%s", err.Error())
 		return

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -246,6 +246,7 @@ type OpPartition interface {
 	GetBaseConfig() MetaPartitionConfig
 	ResponseLoadMetaPartition(p *Packet) (err error)
 	PersistMetadata() (err error)
+	BackupMetadata() (err error)
 	ChangeMember(changeType raftproto.ConfChangeType, peer raftproto.Peer, context []byte) (resp interface{}, err error)
 	Reset() (err error)
 	UpdatePartition(req *UpdatePartitionReq, resp *UpdatePartitionResp) (err error)
@@ -966,6 +967,12 @@ func (mp *metaPartition) GetUniqId() uint64 {
 func (mp *metaPartition) PersistMetadata() (err error) {
 	mp.config.sortPeers()
 	err = mp.persistMetadata()
+	return
+}
+
+// Backup partition to partition.old
+func (mp *metaPartition) BackupMetadata() (err error) {
+	err = mp.backupMetadata()
 	return
 }
 

--- a/metanode/partition_store.go
+++ b/metanode/partition_store.go
@@ -53,6 +53,7 @@ const (
 	uniqIDFile      = "uniqID"
 	uniqCheckerFile = "uniqChecker"
 	verdataFile     = "multiVer"
+	backupSuffix    = ".old"
 )
 
 func (mp *metaPartition) loadMetadata() (err error) {
@@ -781,6 +782,28 @@ func (mp *metaPartition) loadMultiVer(rootDir string) (err error) {
 	log.LogInfof("loadMultiVer: load complete: partitionID(%v) volume(%v) applyID(%v) filename(%v) verlist (%v) mp Ver(%v)",
 		mp.config.PartitionId, mp.config.VolName, mp.applyID, filename, mp.multiVersionList.VerList, mp.verSeq)
 	return
+}
+
+func (mp *metaPartition) backupMetadata() error {
+	_, err := os.Stat(mp.config.RootDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	backupName := mp.config.RootDir + backupSuffix
+	// remove old backup
+	if err = os.RemoveAll(backupName); err != nil {
+		return err
+	}
+
+	if err = os.Rename(mp.config.RootDir, backupName); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (mp *metaPartition) persistMetadata() (err error) {

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -429,7 +429,7 @@ func (api *AdminAPI) VolExpand(volName string, capacity uint64, authKey, clientI
 }
 
 func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, deleteLockTime int64, crossZone, normalZonesFirst bool, business string,
-	mpCount, replicaNum, size, volType int, followerRead bool, zoneName, cacheRuleKey string, ebsBlkSize,
+	mpCount, replicaNum, dpSize, volType int, followerRead bool, zoneName, cacheRuleKey string, ebsBlkSize,
 	cacheCapacity, cacheAction, cacheThreshold, cacheTTL, cacheHighWater, cacheLowWater, cacheLRUInterval int,
 	dpReadOnlyWhenVolFull bool, txMask string, txTimeout uint32, txConflictRetryNum int64, txConflictRetryInterval int64, optEnableQuota string,
 	clientIDKey string) (err error) {
@@ -443,7 +443,7 @@ func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, delet
 	request.addParam("description", business)
 	request.addParam("mpCount", strconv.Itoa(mpCount))
 	request.addParam("replicaNum", strconv.Itoa(replicaNum))
-	request.addParam("size", strconv.Itoa(size))
+	request.addParam("dpSize", strconv.Itoa(dpSize))
 	request.addParam("volType", strconv.Itoa(volType))
 	request.addParam("followerRead", strconv.FormatBool(followerRead))
 	request.addParam("zoneName", zoneName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- (cli/master) changed volume create option from "size" to "dp-size"(cli) / "dpSize"(master api).
- (master) limit metanode memory threshold range check between 0.0 and 1.0 in master api.
- (metanode/datanode) check and rename local existing dp/mp directory to .old when creating new partition to avoid loading error(stale) partition data.

