### PR TITLE
feat(workflow): remove pre-installed android sdk to free up disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
             docs-zh/**
             **.md
 
+      - name: Remove pre-installed software to free up disk space
+        if: steps.changed-files.outputs.only_changed != 'true'
+        run: |
+          sudo rm -rf /usr/local/lib/android
+
       - name: S3 tests
         if: steps.changed-files.outputs.only_changed != 'true'
         run: |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

github action always fails because the disk is not enough

this pr removed Android SDKs and free up 14GB of space

There is actually more useless pre-installed software, such as .NET SDKs. But at present, the space is very enough after removing the android SDKs.

![image](https://github.com/cubefs/cubefs/assets/86180691/c46c90b8-db0f-4ad3-bea8-34ba56d5ade8)

References：

[Ubuntu 22.04 github runner image](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md)

[Maximize available disk space for build tasks](https://github.com/easimon/maximize-build-space/blob/test-report/README.md)

