### PR TITLE
refactor(client): if request datanode to create extent failed, not remove the datapartition form dpSelector if it is the last one.

### DIFF
--- a/sdk/data/wrapper/data_partition_selector.go
+++ b/sdk/data/wrapper/data_partition_selector.go
@@ -38,6 +38,9 @@ type DataPartitionSelector interface {
 
 	// RemoveDP removes specified data partition.
 	RemoveDP(partitionID uint64)
+
+	// Count return number of data partitions held by selector.
+	Count() int
 }
 
 var (
@@ -127,6 +130,10 @@ func (w *Wrapper) RemoveDataPartitionForWrite(partitionID uint64) {
 	w.Lock.RLock()
 	dpSelector := w.dpSelector
 	w.Lock.RUnlock()
+
+	if dpSelector.Count() <= 1 {
+		return
+	}
 
 	dpSelector.RemoveDP(partitionID)
 }

--- a/sdk/data/wrapper/default_random_selector.go
+++ b/sdk/data/wrapper/default_random_selector.go
@@ -130,6 +130,12 @@ func (s *DefaultRandomSelector) RemoveDP(partitionID uint64) {
 	return
 }
 
+func (s *DefaultRandomSelector) Count() int {
+	s.RLock()
+	defer s.RUnlock()
+	return len(s.partitions)
+}
+
 func (s *DefaultRandomSelector) getLocalLeaderDataPartition(exclude map[string]struct{}) *DataPartition {
 	s.RLock()
 	localLeaderPartitions := s.localLeaderPartitions

--- a/sdk/data/wrapper/k_faster_random_selector.go
+++ b/sdk/data/wrapper/k_faster_random_selector.go
@@ -146,6 +146,12 @@ func (s *KFasterRandomSelector) RemoveDP(partitionID uint64) {
 	return
 }
 
+func (s *KFasterRandomSelector) Count() int {
+	s.RLock()
+	defer s.RUnlock()
+	return len(s.partitions)
+}
+
 func swap(s []*DataPartition, i int, j int) {
 	s[i], s[j] = s[j], s[i]
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
if request datanode to create extent failed, not remove the datapartition form dpSelector if it is the last one，
to avoid the dpSelector has no datapartition .


**Special notes for your reviewer**:
if any dn host of the dp can not be connected, it will be add to the exclude map and not retry:
```
func (dp *DataPartition) CheckAllHostsIsAvail(exclude map[string]struct{}) {
	var (
		conn net.Conn
		err  error
	)
	for i := 0; i < len(dp.Hosts); i++ {
		host := dp.Hosts[i]
		if conn, err = util.DailTimeOut(host, proto.ReadDeadlineTime*time.Second); err != nil {
			log.LogWarnf("CheckAllHostsIsAvail: dial host (%v) err(%v)", host, err)
			if strings.Contains(err.Error(), syscall.ECONNREFUSED.Error()) {
				exclude[host] = struct{}{}
			}
			continue
		}
		conn.Close()
	}
}
```