### PR TITLE
snapshot.clean tempory snapshot by inner periodic check

### DIFF
--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -106,6 +106,7 @@ func (d *Dentry) isDeleted() bool {
 func (d *Dentry) setDeleted() {
 	if d.multiSnap == nil {
 		log.LogErrorf("action[setDeleted] d %v be set deleted not found multiSnap", d)
+		return
 	}
 	log.LogDebugf("action[setDeleted] d %v be set deleted", d)
 	d.multiSnap.VerSeq |= uint64(1) << 63

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -1228,7 +1228,7 @@ func (i *Inode) getLastestVer(reqVerSeq uint64, commit bool, verlist *proto.VolV
 	return 0, false
 }
 
-func (i *Inode) ShouldDelVer(mpVer uint64, delVer uint64) (ok bool, err error) {
+func (i *Inode) ShouldDelVer(delVer uint64, mpVer uint64) (ok bool, err error) {
 	if i.getVer() == 0 {
 		if delVer > 0 {
 			if isInitSnapVer(delVer) {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2378,7 +2378,7 @@ func (m *metadataManager) checkVolVerList() (err error) {
 					return true
 				}
 			}
-			if err = partition.checkVerList(info, false); err != nil {
+			if _, err = partition.checkVerList(info, false); err != nil {
 				log.LogErrorf("[checkVolVerList] volumeName %v err %v", volName, err)
 			}
 			return true
@@ -2482,7 +2482,8 @@ func (m *metadataManager) checkMultiVersionStatus(mp MetaPartition, p *Packet) (
 		return
 	}
 	if p.IsVersionList() {
-		return mp.checkVerList(&proto.VolVersionInfoList{VerList: p.VerList}, true, false)
+		_, err = mp.checkVerList(&proto.VolVersionInfoList{VerList: p.VerList}, true)
+		return
 	}
 	p.Opcode = proto.OpAgainVerionList
 	// need return and tell client

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"os"
 	"path"
@@ -212,12 +213,16 @@ type OpMultipart interface {
 
 // MultiVersion operation from master or client
 type OpMultiVersion interface {
+	GetVerSeq() uint64
+	GetVerList() []*proto.VolVersionInfo
+	GetAllVerList() []*proto.VolVersionInfo
 	HandleVersionOp(op uint8, verSeq uint64, verList []*proto.VolVersionInfo, sync bool) (err error)
 	fsmVersionOp(reqData []byte) (err error)
 	GetAllVersionInfo(req *proto.MultiVersionOpRequest, p *Packet) (err error)
 	GetSpecVersionInfo(req *proto.MultiVersionOpRequest, p *Packet) (err error)
 	GetExtentByVer(ino *Inode, req *proto.GetExtentsRequest, rsp *proto.GetExtentsResponse)
 	checkVerList(info *proto.VolVersionInfoList, sync bool) (err error)
+	checkByMasterVerlist(mpVerList *proto.VolVersionInfoList, masterVerList *proto.VolVersionInfoList) (err error)
 }
 
 // OpMeta defines the interface for the metadata operations.
@@ -236,8 +241,6 @@ type OpMeta interface {
 // OpPartition defines the interface for the partition operations.
 type OpPartition interface {
 	GetVolName() (volName string)
-	GetVerSeq() uint64
-	GetVerList() []*proto.VolVersionInfo
 	IsLeader() (leaderAddr string, isLeader bool)
 	LeaderTerm() (leaderID, term uint64)
 	IsFollowerRead() bool
@@ -539,6 +542,23 @@ func (mp *metaPartition) GetVerList() []*proto.VolVersionInfo {
 	return mp.multiVersionList.VerList
 }
 
+// include TemporaryVerMap or else cann't recycle temporary version after restart
+func (mp *metaPartition) GetAllVerList() (verList []*proto.VolVersionInfo) {
+	mp.multiVersionList.RLock()
+	defer mp.multiVersionList.RUnlock()
+	verList = mp.multiVersionList.VerList
+	for _, verInfo := range mp.multiVersionList.TemporaryVerMap {
+		verList = append(verList, verInfo)
+	}
+	sort.SliceStable(verList, func(i, j int) bool {
+		if verList[i].Ver < verList[j].Ver {
+			return true
+		}
+		return false
+	})
+	return
+}
+
 func (mp *metaPartition) checkAndUpdateVerList(verSeq uint64) (err error) {
 	mp.multiVersionList.Lock()
 	defer mp.multiVersionList.Unlock()
@@ -774,12 +794,7 @@ func (mp *metaPartition) onStart(isCreate bool) (err error) {
 		return
 	}
 
-	//// do cache TTL die out process
-	//if err = mp.multiVersionTTLWork(); err != nil {
-	//	err = errors.NewErrorf("[onStart] start CacheTTLWork id=%d: %s",
-	//		mp.config.PartitionId, err.Error())
-	//	return
-	//}
+	go mp.multiVersionTTLWork(time.Hour)
 	return
 }
 
@@ -881,7 +896,9 @@ func NewMetaPartition(conf *MetaPartitionConfig, manager *metadataManager) MetaP
 		manager:          manager,
 		uniqChecker:      newUniqChecker(),
 		verSeq:           conf.VerSeq,
-		multiVersionList: &proto.VolVersionInfoList{},
+		multiVersionList: &proto.VolVersionInfoList{
+			TemporaryVerMap: make(map[uint64]*proto.VolVersionInfo),
+		},
 	}
 	mp.txProcessor = NewTransactionProcessor(mp)
 	return mp
@@ -1372,52 +1389,176 @@ func (mp *metaPartition) canRemoveSelf() (canRemove bool, err error) {
 }
 
 // cacheTTLWork only happen in datalake situation
-func (mp *metaPartition) multiVersionTTLWork() (err error) {
+func (mp *metaPartition) multiVersionTTLWork(dur time.Duration) {
 	// check volume type, only Cold volume will do the cache ttl.
 	if mp.verSeq == 0 {
 		return
 	}
 	// do cache ttl work
-	go func() {
-		// first sleep a rand time, range [0, 1200s(20m)],
-		// make sure all mps is not doing scan work at the same time.
-		rand.Seed(time.Now().Unix())
-		time.Sleep(time.Duration(rand.Intn(1200)))
+	// first sleep a rand time, range [0, 1200s(20m)],
+	// make sure all mps is not doing scan work at the same time.
+	rand.Seed(time.Now().Unix())
+	time.Sleep(time.Duration(rand.Intn(1200)))
 
-		ttl := time.NewTicker(time.Duration(util.OneDaySec()) * time.Second)
-
-		for {
-			select {
-			case <-ttl.C:
-				log.LogDebugf("[multiVersionTTLWork] begin cache ttl, mp[%v]", mp.config.PartitionId)
-				// only leader can do TTL work
-				if _, ok := mp.IsLeader(); !ok {
-					log.LogDebugf("[multiVersionTTLWork] partitionId=%d is not leader, skip", mp.config.PartitionId)
-				}
-
-				for _, version := range mp.multiVersionList.VerList {
-					if version.Status == proto.VersionNormal {
-						continue
-					}
-					go mp.delVersion(version.Ver)
-				}
-
-			case <-mp.stopC:
-				log.LogWarnf("[multiVersionTTLWork] stoped, mp(%d)", mp.config.PartitionId)
-				return
+	ttl := time.NewTicker(dur)
+	snapQueue := make(chan interface{}, 5)
+	for {
+		select {
+		case <-ttl.C:
+			log.LogDebugf("[multiVersionTTLWork] begin cache ttl, mp[%v]", mp.config.PartitionId)
+			// only leader can do TTL work
+			if _, ok := mp.IsLeader(); !ok {
+				log.LogDebugf("[multiVersionTTLWork] partitionId=%d is not leader, skip", mp.config.PartitionId)
 			}
-		}
+			mp.multiVersionList.RLock()
+			volVersionInfoList := &proto.VolVersionInfoList{
+				VerList: mp.multiVersionList.VerList,
+				TemporaryVerMap: mp.multiVersionList.TemporaryVerMap,
+			}
+			mp.multiVersionList.RUnlock()
 
-	}()
+			for _, version := range volVersionInfoList.VerList {
+				if len(volVersionInfoList.TemporaryVerMap) > 0 {
+					if _, exist := volVersionInfoList.TemporaryVerMap[version.Ver];exist {
+						if version.Status == proto.VersionDeleting {
+							break
+						}
+						version.Status = proto.VersionDeleting
+						snapQueue <- nil
+						go func(verSeq uint64) {
+							mp.delPartitionVersion(verSeq)
+							<- snapQueue
+						}(version.Ver)
+					}
+				}
+			}
+			//mp.multiVersionList.RUnlock()
+
+		case <-mp.stopC:
+			log.LogWarnf("[multiVersionTTLWork] stoped, mp(%d)", mp.config.PartitionId)
+			return
+		}
+	}
+
 	return
 }
 
-func (mp *metaPartition) delVersion(verSeq uint64) (err error) {
+func (mp *metaPartition) delPartitionVersion(verSeq uint64) {
+	var wg sync.WaitGroup
+	wg.Add(3)
+	reqVerSeq := verSeq
+	if reqVerSeq == 0 {
+		reqVerSeq = math.MaxUint64
+	}
+	go mp.delPartitionInodesVersion(reqVerSeq, &wg)
+	go mp.delPartitionExtendsVersion(reqVerSeq, &wg)
+	go mp.delPartitionDentriesVersion(reqVerSeq, &wg)
+	wg.Wait()
+
+	mp.multiVersionList.Lock()
+	defer mp.multiVersionList.Unlock()
+	for id, verInfo := range mp.multiVersionList.VerList {
+		if verInfo.Ver > verSeq {
+			log.LogWarnf("action[delPartitionInodesVersion] mp %v verSeq iterator del and done but not found seq %v",
+				mp.config.PartitionId, verSeq)
+			break
+		}
+		if verInfo.Ver == verSeq {
+			mp.multiVersionList.VerList = append(mp.multiVersionList.VerList[:id], mp.multiVersionList.VerList[id+1:]...)
+			log.LogWarnf("action[delPartitionInodesVersion] mp %v verSeq iterator del and done found seq %v and delete",
+				mp.config.PartitionId, verSeq)
+			delete(mp.multiVersionList.TemporaryVerMap, verSeq)
+			return
+		}
+	}
+}
+
+func (mp *metaPartition) delPartitionDentriesVersion(verSeq uint64, wg *sync.WaitGroup) {
+	defer wg.Done()
+	// begin
+	count := 0
+	needSleep := false
+
+	mp.dentryTree.GetTree().Ascend(func(i BtreeItem) bool {
+		if _, ok := mp.IsLeader(); !ok {
+			return false
+		}
+		den := i.(*Dentry)
+		// dir type just skip
+
+		p := &Packet{}
+		req := &proto.DeleteDentryRequest{
+			VolName: mp.config.VolName,
+			ParentID: mp.config.PartitionId,
+			PartitionID: den.ParentId,
+			Name: den.Name,
+			Verseq: verSeq,
+		}
+		mp.DeleteDentry(req, p)
+		// check empty result.
+		// if result is OpAgain, means the extDelCh maybe full,
+		// so let it sleep 1s.
+		if p.ResultCode == proto.OpAgain {
+			needSleep = true
+		}
+
+		// every 1000 inode sleep 1s
+		if count > 1000 || needSleep {
+			count %= 1000
+			needSleep = false
+			time.Sleep(time.Second)
+		}
+		return true
+	})
+}
+
+func (mp *metaPartition) delPartitionExtendsVersion(verSeq uint64, wg *sync.WaitGroup) {
+	defer wg.Done()
+	// begin
+	count := 0
+	needSleep := false
+
+	mp.extendTree.GetTree().Ascend(func(treeItem BtreeItem) bool {
+		if _, ok := mp.IsLeader(); !ok {
+			return false
+		}
+		e := treeItem.(*Extend)
+
+		p := &Packet{}
+		req := &proto.RemoveXAttrRequest{
+			VolName: mp.config.VolName,
+			PartitionId: mp.config.PartitionId,
+			Inode: e.inode,
+			VerSeq: verSeq,
+		}
+		mp.RemoveXAttr(req, p)
+		// check empty result.
+		// if result is OpAgain, means the extDelCh maybe full,
+		// so let it sleep 1s.
+		if p.ResultCode == proto.OpAgain {
+			needSleep = true
+		}
+
+		// every 1000 inode sleep 1s
+		if count > 1000 || needSleep {
+			count %= 1000
+			needSleep = false
+			time.Sleep(time.Second)
+		}
+		return true
+	})
+}
+
+func (mp *metaPartition) delPartitionInodesVersion(verSeq uint64, wg *sync.WaitGroup)  {
+	defer wg.Done()
 	// begin
 	count := 0
 	needSleep := false
 
 	mp.inodeTree.GetTree().Ascend(func(i BtreeItem) bool {
+		if _, ok := mp.IsLeader(); !ok {
+			return false
+		}
 		inode := i.(*Inode)
 		// dir type just skip
 		if proto.IsDir(inode.Type) {

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -267,7 +267,7 @@ func (mp *metaPartition) Apply(command []byte, index uint64) (resp interface{}, 
 			quotaRebuild:   quotaRebuild,
 			uidRebuild:     uidRebuild,
 			uniqChecker:    uniqChecker,
-			multiVerList:   mp.GetVerList(),
+			multiVerList:   mp.GetAllVerList(),
 		}
 		log.LogDebugf("opFSMStoreTick: quotaRebuild [%v] uidRebuild [%v]", quotaRebuild, uidRebuild)
 		mp.storeChan <- msg

--- a/metanode/partition_op_extend.go
+++ b/metanode/partition_op_extend.go
@@ -185,6 +185,7 @@ func (mp *metaPartition) BatchGetXAttr(req *proto.BatchGetXAttrRequest, p *Packe
 
 func (mp *metaPartition) RemoveXAttr(req *proto.RemoveXAttrRequest, p *Packet) (err error) {
 	var extend = NewExtend(req.Inode)
+	extend.verSeq = req.VerSeq
 	extend.Put([]byte(req.Key), nil, mp.verSeq)
 	if _, err = mp.putExtend(opFSMRemoveXAttr, extend); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))

--- a/metanode/partition_op_extend.go
+++ b/metanode/partition_op_extend.go
@@ -185,8 +185,7 @@ func (mp *metaPartition) BatchGetXAttr(req *proto.BatchGetXAttrRequest, p *Packe
 
 func (mp *metaPartition) RemoveXAttr(req *proto.RemoveXAttrRequest, p *Packet) (err error) {
 	var extend = NewExtend(req.Inode)
-	extend.verSeq = req.VerSeq
-	extend.Put([]byte(req.Key), nil, mp.verSeq)
+	extend.Put([]byte(req.Key), nil, req.VerSeq)
 	if _, err = mp.putExtend(opFSMRemoveXAttr, extend); err != nil {
 		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
 		return

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -182,12 +182,42 @@ type VerOpData struct {
 	VerList []*proto.VolVersionInfo
 }
 
-func (mp *metaPartition) checkVerList(masterListInfo *proto.VolVersionInfoList, sync bool) (err error) {
-	mp.multiVersionList.RLock()
+func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoList, masterVerList *proto.VolVersionInfoList) (err error) {
+	var currMasterSeq = masterVerList.GetLastVer()
+	verMapMaster := make(map[uint64]*proto.VolVersionInfo)
+	for _, ver := range masterVerList.VerList {
+		verMapMaster[ver.Ver] = ver
+	}
+	mp.multiVersionList.Lock()
+	defer mp.multiVersionList.Unlock()
+	for _, info2 := range mpVerList.VerList {
+		log.LogDebugf("checkVerList. vol %v mp %v ver info %v", mp.config.VolName, mp.config.PartitionId, info2)
+		_, exist := verMapMaster[info2.Ver]
+		if !exist {
+			if info2.Ver < currMasterSeq {
+				if _, ok := mp.multiVersionList.TemporaryVerMap[info2.Ver]; !ok {
+					mp.multiVersionList.TemporaryVerMap[info2.Ver] = info2
+				}
+			}
+		}
+	}
 
+	for verSeq, _ := range  mp.multiVersionList.TemporaryVerMap {
+		for index, verInfo := range mp.multiVersionList.VerList {
+			if verInfo.Ver == verSeq {
+				mp.multiVersionList.VerList = append(mp.multiVersionList.VerList[:index], mp.multiVersionList.VerList[index+1:]...)
+				break
+			}
+		}
+	}
+	return
+}
+
+func (mp *metaPartition) checkVerList(reqVerListInfo *proto.VolVersionInfoList, sync bool) (err error) {
+	mp.multiVersionList.RLock()
 	verMapLocal := make(map[uint64]*proto.VolVersionInfo)
 	verMapMaster := make(map[uint64]*proto.VolVersionInfo)
-	for _, ver := range masterListInfo.VerList {
+	for _, ver := range reqVerListInfo.VerList {
 		verMapMaster[ver.Ver] = ver
 	}
 
@@ -200,17 +230,8 @@ func (mp *metaPartition) checkVerList(masterListInfo *proto.VolVersionInfoList, 
 		log.LogDebugf("checkVerList. vol %v mp %v ver info %v", mp.config.VolName, mp.config.PartitionId, info2)
 		vms, exist := verMapMaster[info2.Ver]
 		if !exist {
-			// To mitigate the blocking risk caused by the confirmation of the prepare version and the master version,
-			// a version in the prepare phase is preliminarily considered as a valid version.
-			if info2.Status != proto.VersionPrepare {
-				warn := fmt.Sprintf("[checkVerList] vol %v mp %v not found %v in master list", mp.config.VolName, mp.config.PartitionId, info2.Ver)
-				exporter.Warning(warn)
-				log.LogWarn(warn)
-				needUpdate = true
-				continue
-			}
 			log.LogWarnf("checkVerList. vol %v mp %v version info(%v) not exist in master (%v)",
-				mp.config.VolName, mp.config.PartitionId, info2, masterListInfo.VerList)
+				mp.config.VolName, mp.config.PartitionId, info2, reqVerListInfo.VerList)
 		} else if info2.Status != proto.VersionNormal && info2.Status != vms.Status {
 			log.LogWarnf("checkVerList. vol %v mp %v ver %v status abnormal %v", mp.config.VolName, mp.config.PartitionId, info2.Ver, info2.Status)
 			info2.Status = vms.Status
@@ -224,7 +245,7 @@ func (mp *metaPartition) checkVerList(masterListInfo *proto.VolVersionInfoList, 
 	}
 	mp.multiVersionList.RUnlock()
 
-	for _, vInfo := range masterListInfo.VerList {
+	for _, vInfo := range reqVerListInfo.VerList {
 		if vInfo.Status != proto.VersionNormal {
 			log.LogDebugf("checkVerList. vol %v mp %v master info %v", mp.config.VolName, mp.config.PartitionId, vInfo)
 			continue

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -795,6 +795,7 @@ type RemoveXAttrRequest struct {
 	PartitionId uint64 `json:"pid"`
 	Inode       uint64 `json:"ino"`
 	Key         string `json:"key"`
+	VerSeq      uint64 `json:"seq"`
 }
 
 type ListXAttrRequest struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -359,8 +359,9 @@ func (vv *VolVersionInfo) String() string {
 }
 
 type VolVersionInfoList struct {
-	VerList  []*VolVersionInfo
-	Strategy VolumeVerStrategy
+	VerList         []*VolVersionInfo
+	Strategy        VolumeVerStrategy
+	TemporaryVerMap map[uint64]*VolVersionInfo
 	sync.RWMutex
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 enhance(metanode):snapshot.clean tempory snapshot by inner periodic check
    
Adopting a one-phase commit means that the master processor (MP) considers the prepared version as valid, and during the operation, it treats it as a version. This means that the MP may have partial temporary version information. However, the final valid version is on the master, which means that the dependency for reading historical versions on the edge side is the version list of the master, not the version list of the MP. When attempting versions in the form of 0, 100, 150, 200, with 150 being a temporary version, the version 100 is read, and it needs to include 150; otherwise, some data cannot be read due to the temporary version 150. Therefore, on the client side, it is necessary to read using the formal version's seq-1 method, which means reading version 199.
    
 Question: The MP is distributed with versions, some of which have temporary versions and some do not. How should the cleanup of temporary versions be handled? If the dentry is in a partition with temporary versions, but the inode is not, when reading the dentry and obtaining the temporary version, is it possible for the inode data to be misaligned?
    
1) For example, file creation in version 0, creating temporary version 50, with the dentry in the MP being effective, but the inode partition not being effective. At this point, if the dentry is deleted, the retained temporary version 50's dentry information remains, but is it possible that the inode has already been deleted, resulting in an exception when reading with temporary version 50?
    
2) For rename operations, referring to the situation described in 1), as long as it is not read, it will not affect the final state, and version cleanup should also not affect the previous state.
    
    Analysis and answer: 1) User operations will not delete the inode because the dentry must be deleted first. 2) When cleaning up temporary versions in snapshots, the inode will not be deleted because inode version cleanup only considers intermediate versions. 3) When reading, the edge side reads the next formal version minus one, so it sees a consistent version. Therefore, there is no need for targeted processing in this case.
    
