### PR TITLE
enhance snapshot 1)optimize master enable volumes parrellel strategy check  2) enhance snapshot verlist meta storage and consistent with other meta

### DIFF
--- a/master/multi_ver_snapshot.go
+++ b/master/multi_ver_snapshot.go
@@ -55,8 +55,8 @@ type VolVersionManager struct {
 	sync.RWMutex
 }
 
-func newVersionMgr(vol *Vol) *VolVersionManager {
-	return &VolVersionManager{
+func newVersionMgr(vol *Vol) (mgr *VolVersionManager) {
+	mgr = &VolVersionManager{
 		vol:    vol,
 		wait:   make(chan error, 1),
 		cancel: make(chan bool, 1),
@@ -65,6 +65,7 @@ func newVersionMgr(vol *Vol) *VolVersionManager {
 			metaNodeArray: new(sync.Map),
 		},
 	}
+	return
 }
 func (verMgr *VolVersionManager) String() string {
 	return fmt.Sprintf("mgr:{vol[%v],status[%v] verSeq [%v], prepareinfo [%v]}",

--- a/master/multi_ver_snapshot.go
+++ b/master/multi_ver_snapshot.go
@@ -108,6 +108,11 @@ func (verMgr *VolVersionManager) CommitVer() (ver *proto.VolVersionInfo) {
 		}
 		verMgr.multiVersionList = append(verMgr.multiVersionList, commitVer)
 		verMgr.verSeq = ver.Ver
+		log.LogInfof("action[CommitVer] vol %v verseq %v exit", verMgr.vol.Name, verMgr.verSeq)
+		if err := verMgr.Persist(); err != nil {
+			log.LogErrorf("action[createVer2PhaseTask] vol %v err %v", verMgr.vol.Name, err)
+			return
+		}
 		log.LogDebugf("action[CommitVer] vol %v ask mgr do commit in next step version %v", verMgr.vol.Name, ver)
 		verMgr.wait <- nil
 	} else if verMgr.prepareCommit.op == proto.DeleteVersion {
@@ -122,7 +127,6 @@ func (verMgr *VolVersionManager) CommitVer() (ver *proto.VolVersionInfo) {
 	} else {
 		log.LogErrorf("action[CommitVer] vol %v with seq %v wrong step", verMgr.vol.Name, verMgr.prepareCommit.prepareInfo.Ver)
 	}
-	log.LogInfof("action[CommitVer] vol %v verseq %v exit", verMgr.vol.Name, verMgr.verSeq)
 	return
 }
 

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -711,7 +711,6 @@ func (i *Inode) MarshalValue() (val []byte) {
 
 	if i.multiSnap != nil {
 		for _, ino := range i.multiSnap.multiVersions {
-			//	log.LogInfof("action[MarshalValue] inode %v current verseq %v", ino.Inode, ino.verSeq)
 			ino.MarshalInodeValue(buff)
 		}
 	}

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -1039,10 +1039,10 @@ func (inode *Inode) unlinkTopLayer(mpId uint64, ino *Inode, mpVer uint64, verlis
 		var dIno *Inode
 		if ext2Del, dIno = inode.getAndDelVer(mpId, ino.getVer(), mpVer, verlist); dIno == nil {
 			status = proto.OpNotExistErr
-			log.LogDebugf("action[unlinkTopLayer] ino %v", ino)
+			log.LogDebugf("action[unlinkTopLayer] mp %v iino %v", mpId, ino)
 			return true
 		}
-		log.LogDebugf("action[unlinkTopLayer] inode %v be unlinked, File restore, multiSnap.ekRefMap %v", ino.Inode, inode.multiSnap.ekRefMap)
+		log.LogDebugf("action[unlinkTopLayer] mp %v inode %v be unlinked, File restore, multiSnap.ekRefMap %v", mpId, ino.Inode, inode.multiSnap.ekRefMap)
 		dIno.DecNLink() // dIno should be inode
 		doMore = true
 		return

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -1042,7 +1042,7 @@ func (inode *Inode) unlinkTopLayer(mpId uint64, ino *Inode, mpVer uint64, verlis
 			log.LogDebugf("action[unlinkTopLayer] mp %v iino %v", mpId, ino)
 			return true
 		}
-		log.LogDebugf("action[unlinkTopLayer] mp %v inode %v be unlinked, File restore, multiSnap.ekRefMap %v", mpId, ino.Inode, inode.multiSnap.ekRefMap)
+		log.LogDebugf("action[unlinkTopLayer] mp %v inode %v be unlinked", mpId, ino.Inode)
 		dIno.DecNLink() // dIno should be inode
 		doMore = true
 		return
@@ -1062,8 +1062,8 @@ func (inode *Inode) unlinkTopLayer(mpId uint64, ino *Inode, mpVer uint64, verlis
 			return
 		}
 
-		log.LogDebugf("action[unlinkTopLayer] need restore.ino %v withSeq %v equal mp seq, verlist %v multiSnap.ekRefMap %v",
-			ino, inode.getVer(), verlist, inode.multiSnap.ekRefMap)
+		log.LogDebugf("action[unlinkTopLayer] need restore.ino %v withSeq %v equal mp seq, verlist %v",
+			ino, inode.getVer(), verlist)
 		// need restore
 		if !proto.IsDir(inode.Type) {
 			delFunc()
@@ -1104,7 +1104,6 @@ func (inode *Inode) unlinkTopLayer(mpId uint64, ino *Inode, mpVer uint64, verlis
 		log.LogDebugf("action[unlinkTopLayer] inode %v be unlinked, File create ver 1st layer", ino.Inode)
 	}
 	return
-
 }
 
 func (inode *Inode) dirUnlinkVerInlist(ino *Inode, mpVer uint64, verlist *proto.VolVersionInfoList) (ext2Del []proto.ExtentKey, doMore bool, status uint8) {

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -1526,3 +1526,13 @@ func TestDelPartitionVersion(t *testing.T) {
 	assert.True(t, err == nil)
 	assert.True(t, len(mp.multiVersionList.TemporaryVerMap) == 0)
 }
+
+func TestMpMultiVerStore(t *testing.T) {
+	initMp(t)
+	filePath := "/tmp/"
+	crc, _ := mp.storeMultiVersion(filePath, &storeMsg{
+		multiVerList: []*proto.VolVersionInfo{{Ver: 20, Status: proto.VersionNormal}, {Ver: 30, Status: proto.VersionNormal}},
+	})
+	err := mp.loadMultiVer(filePath, crc)
+	assert.True(t, err == nil)
+}

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -652,7 +652,7 @@ func testDelDirSnapshotVersion(t *testing.T, verSeq uint64, dirIno *Inode, dirDe
 	//testPrintAllDentry(t)
 
 	rDirIno := dirIno.Copy().(*Inode)
-	rDirIno.setVer(verSeq)
+	rDirIno.setVerNoCheck(verSeq)
 
 	rspDelIno := mp.fsmUnlinkInode(rDirIno, 0)
 

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -389,7 +389,7 @@ func (mp *metaPartition) ExtentsList(req *proto.GetExtentsRequest, p *Packet) (e
 		if req.VerSeq > 0 && ino.getVer() > 0 && (req.VerSeq < ino.getVer() || isInitSnapVer(req.VerSeq)) {
 			mp.GetExtentByVer(ino, req, resp)
 			vIno := ino.Copy().(*Inode)
-			vIno.setVer(req.VerSeq)
+			vIno.setVerNoCheck(req.VerSeq)
 			if vIno = mp.getInodeByVer(vIno); vIno != nil {
 				resp.Generation = vIno.Generation
 				resp.Size = vIno.Size


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

enhance(master):Allow the periodic snapshot check strategy for volumes to run on a per-volume basis, utilizing routines
fix(metanode):snapshot.multiver meta store uniq with other snapshot meta
 fix(master):snapshot.master persist snapshot info after creation as soon as possible
