### PR TITLE
feat(master/datanode/cli):datanode bad disk report to master adds IoErrPartititionCnt and TotalPartititionCnt

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -881,12 +881,12 @@ func formatQuotaInfo(info *proto.QuotaInfo) string {
 	return ret
 }
 
-var badDiskDetailTableRowPattern = "%-18v    %-24v"
+var badDiskDetailTableRowPattern = "%-18v    %-18v    %-18v    %-18v    %-18v"
 
 func formatBadDiskTableHeader() string {
-	return fmt.Sprintf(badDiskDetailTableRowPattern, "ADDRESS", "PATH")
+	return fmt.Sprintf(badDiskDetailTableRowPattern, "Address", "Path", "TotalPartitionCnt", "DiskErrPartitionCnt", "DiskErrPartitionList")
 }
 
 func formatBadDiskInfoRow(disk proto.BadDiskInfo) string {
-	return fmt.Sprintf(badDiskDetailTableRowPattern, disk.Address, disk.Path)
+	return fmt.Sprintf(badDiskDetailTableRowPattern, disk.Address, disk.Path, disk.TotalPartitionCnt, len(disk.DiskErrPartitionList), disk.DiskErrPartitionList)
 }

--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -129,10 +129,10 @@ func (dp *DataPartition) ApplySnapshot(peers []raftproto.Peer, iterator raftprot
 func (dp *DataPartition) HandleFatalEvent(err *raft.FatalError) {
 	if isRaftApplyError(err.Err.Error()) {
 		dp.stopRaft()
-		dp.checkIsDiskError(err.Err)
-		log.LogCriticalf("action[HandleFatalEvent] err(%v).", err)
+		dp.checkIsDiskError(err.Err, 0)
+		log.LogCriticalf("action[HandleFatalEvent] raft apply err(%v), partitionId:%v", err, dp.partitionID)
 	} else {
-		log.LogFatalf("action[HandleFatalEvent] err(%v).", err)
+		log.LogFatalf("action[HandleFatalEvent] err(%v), partitionId:%v", err, dp.partitionID)
 	}
 }
 

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -725,29 +725,6 @@ func (s *DataNode) serveSmuxStream(stream *smux.Stream) {
 	packetProcessor.ServerConn()
 }
 
-// Increase the disk error count by one.
-func (s *DataNode) incDiskErrCnt(partitionID uint64, err error, flag uint8) {
-	if err == nil {
-		return
-	}
-	dp := s.space.Partition(partitionID)
-	if dp == nil {
-		return
-	}
-	d := dp.Disk()
-	if d == nil {
-		return
-	}
-	if !IsDiskErr(err.Error()) {
-		return
-	}
-	if flag == WriteFlag {
-		d.incWriteErrCnt()
-	} else if flag == ReadFlag {
-		d.incReadErrCnt()
-	}
-}
-
 func (s *DataNode) parseSmuxConfig(cfg *config.Config) error {
 	s.enableSmuxConnPool = cfg.GetBool(ConfigKeyEnableSmuxClient)
 	s.smuxPortShift = int(cfg.GetInt64(ConfigKeySmuxPortShift))

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -449,6 +449,7 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 	response.MaxCapacity = stat.MaxCapacityToCreatePartition
 	response.RemainingCapacity = stat.RemainingCapacityToCreatePartition
 	response.BadDisks = make([]string, 0)
+	response.BadDiskStats = make([]proto.BadDiskStat, 0)
 	response.StartTime = s.startTime
 	stat.Unlock()
 
@@ -478,6 +479,13 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 	for _, d := range disks {
 		if d.Status == proto.Unavailable {
 			response.BadDisks = append(response.BadDisks, d.Path)
+
+			bds := proto.BadDiskStat{
+				DiskPath:             d.Path,
+				TotalPartitionCnt:    d.PartitionCount(),
+				DiskErrPartitionList: d.GetDiskErrPartitionList(),
+			}
+			response.BadDiskStats = append(response.BadDiskStats, bds)
 		}
 	}
 }

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -737,7 +737,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 			s.metrics.MetricIOBytes.AddWithLabels(int64(p.Size), metricPartitionIOLabels)
 			partitionIOMetric.SetWithLabels(err, metricPartitionIOLabels)
 		}
-		s.incDiskErrCnt(p.PartitionID, err, WriteFlag)
+		partition.checkIsDiskError(err, WriteFlag)
 		return
 	}
 
@@ -754,7 +754,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 			s.metrics.MetricIOBytes.AddWithLabels(int64(p.Size), metricPartitionIOLabels)
 			partitionIOMetric.SetWithLabels(err, metricPartitionIOLabels)
 		}
-		partition.checkIsDiskError(err)
+		partition.checkIsDiskError(err, WriteFlag)
 	} else {
 		size := p.Size
 		offset := 0
@@ -777,7 +777,7 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 				s.metrics.MetricIOBytes.AddWithLabels(int64(p.Size), metricPartitionIOLabels)
 				partitionIOMetric.SetWithLabels(err, metricPartitionIOLabels)
 			}
-			partition.checkIsDiskError(err)
+			partition.checkIsDiskError(err, WriteFlag)
 			if err != nil {
 				break
 			}
@@ -785,7 +785,6 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 			offset += currSize
 		}
 	}
-	s.incDiskErrCnt(p.PartitionID, err, WriteFlag)
 }
 
 func (s *DataNode) handleRandomWritePacket(p *repl.Packet) {
@@ -959,7 +958,7 @@ func (s *DataNode) extentRepairReadPacket(p *repl.Packet, connect net.Conn, isRe
 			partitionIOMetric.SetWithLabels(err, metricPartitionIOLabels)
 			tpObject.Set(err)
 		}
-		partition.checkIsDiskError(err)
+		partition.checkIsDiskError(err, ReadFlag)
 		p.CRC = reply.CRC
 		if err != nil {
 			return

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -5935,11 +5935,16 @@ func (m *Server) queryBadDisks(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return true
 		}
-		for _, badDisk := range dataNode.BadDisks {
-			info := proto.BadDiskInfo{Address: dataNode.Addr, Path: badDisk}
+
+		for _, bds := range dataNode.BadDiskStats {
+			info := proto.BadDiskInfo{
+				Address:              dataNode.Addr,
+				Path:                 bds.DiskPath,
+				TotalPartitionCnt:    bds.TotalPartitionCnt,
+				DiskErrPartitionList: bds.DiskErrPartitionList,
+			}
 			infos.BadDisks = append(infos.BadDisks, info)
 		}
-
 		return true
 	})
 

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -49,7 +49,8 @@ type DataNode struct {
 	TotalPartitionSize        uint64
 	NodeSetID                 uint64
 	PersistenceDataPartitions []uint64
-	BadDisks                  []string
+	BadDisks                  []string            //Keep this old field for compatibility
+	BadDiskStats              []proto.BadDiskStat //key: disk path
 	DecommissionedDisks       sync.Map
 	ToBeOffline               bool
 	RdOnly                    bool
@@ -152,7 +153,10 @@ func (dataNode *DataNode) updateNodeMetric(resp *proto.DataNodeHeartbeatResponse
 	dataNode.DataPartitionCount = resp.CreatedPartitionCnt
 	dataNode.DataPartitionReports = resp.PartitionReports
 	dataNode.TotalPartitionSize = resp.TotalPartitionSize
+
 	dataNode.BadDisks = resp.BadDisks
+	dataNode.BadDiskStats = resp.BadDiskStats
+
 	dataNode.StartTime = resp.StartTime
 	if dataNode.Total == 0 {
 		dataNode.UsageRatio = 0.0

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -625,6 +625,12 @@ type DataNodeQosResponse struct {
 	Result     string
 }
 
+type BadDiskStat struct {
+	DiskPath             string
+	TotalPartitionCnt    int
+	DiskErrPartitionList []uint64
+}
+
 // DataNodeHeartbeatResponse defines the response to the data node heartbeat.
 type DataNodeHeartbeatResponse struct {
 	Total               uint64
@@ -639,7 +645,8 @@ type DataNodeHeartbeatResponse struct {
 	PartitionReports    []*DataPartitionReport
 	Status              uint8
 	Result              string
-	BadDisks            []string
+	BadDisks            []string           //Keep this old field for compatibility
+	BadDiskStats        []BadDiskStat      //key: disk path
 	CpuUtil             float64            `json:"cpuUtil"`
 	IoUtils             map[string]float64 `json:"ioUtil"`
 }

--- a/proto/model.go
+++ b/proto/model.go
@@ -337,8 +337,10 @@ type DecommissionProgress struct {
 }
 
 type BadDiskInfo struct {
-	Address string
-	Path    string
+	Address              string
+	Path                 string
+	TotalPartitionCnt    int
+	DiskErrPartitionList []uint64
 }
 
 type BadDiskInfos struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(master/datanode/cli):
   (1)datanode bad disk report to master adds: TotalPartititionCnt and DiskErrPartitionList
   (2)cfs-cli display bad disk adds TotalPartititionCnt and DiskErrPartitionList accordingly
   (3)datanode's data partition add disk err count record and log print

