### PR TITLE
fix(master): close fsm.raftstore before closing rocksdb when master shutdown

### DIFF
--- a/master/metadata_fsm.go
+++ b/master/metadata_fsm.go
@@ -288,3 +288,10 @@ func (mf *MetadataFsm) HandleLeaderChange(leader uint64) {
 func (mf *MetadataFsm) delKeyAndPutIndex(key string, cmdMap map[string][]byte) (err error) {
 	return mf.store.DeleteKeyAndPutIndex(key, cmdMap, true)
 }
+
+// Stop stops the RaftServer
+func (mf *MetadataFsm) Stop() {
+	if mf.rs != nil {
+		mf.rs.Stop()
+	}
+}

--- a/master/server.go
+++ b/master/server.go
@@ -17,13 +17,14 @@ package master
 import (
 	"context"
 	"fmt"
-	"github.com/cubefs/cubefs/raftstore/raftstore_db"
 	syslog "log"
 	"net/http"
 	"net/http/httputil"
 	"regexp"
 	"strconv"
 	"sync"
+
+	"github.com/cubefs/cubefs/raftstore/raftstore_db"
 
 	"github.com/cubefs/cubefs/util/stat"
 
@@ -192,6 +193,13 @@ func (m *Server) Shutdown() {
 		}
 	}
 	stat.CloseStat()
+
+	// stop raftServer first
+	if m.fsm != nil {
+		m.fsm.Stop()
+	}
+
+	// then stop rocksDBStore
 	if m.rocksDBStore != nil {
 		m.rocksDBStore.Close()
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Bug: master applied data into closed rocksdb instance while shutting down, which caused panic.
close fsm.raftstore before closing rocksdb when master shutdown.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
