### PR TITLE
snapshot.multiVersion's snapshot loading needs to be loaded before inode and detry because it depends on it

### DIFF
--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -227,10 +227,6 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 			panic(newRaftApplyError(err))
 		}
 	}()
-	//if dp.IsRejectWrite() {
-	//	err = fmt.Errorf("partition(%v) disk(%v) err(%v)", dp.partitionID, dp.Disk().Path, syscall.ENOSPC)
-	//	return
-	//}
 
 	if opItem, err = UnmarshalRandWriteRaftLog(command); err != nil {
 		log.LogErrorf("[ApplyRandomWrite] ApplyID(%v) Partition(%v) unmarshal failed(%v)", raftApplyID, dp.partitionID, err)

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -299,6 +299,8 @@ func (s *DataNode) commitCreateVersion(req *proto.MultiVersionOpRequest) (err er
 			log.LogWarnf("action[commitCreateVersion] vol %v seq %v step not prepare", req.VolumeID, ver2Phase.step)
 		}
 
+		s.space.partitionMutex.RLock()
+		defer s.space.partitionMutex.RUnlock()
 		for _, partition := range s.space.partitions {
 			if partition.config.VolName != req.VolumeID {
 				continue

--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -196,6 +196,7 @@ func (d *Dentry) deleteVerSnapshot(delVerSeq uint64, mpVerSeq uint64, verlist []
 	log.LogDebugf("action[deleteVerSnapshot] enter.dentry %v delVerSeq %v mpVer %v verList %v", d, delVerSeq, mpVerSeq, verlist)
 	// create denParm version
 	if !isInitSnapVer(delVerSeq) && delVerSeq > mpVerSeq {
+
 		panic(fmt.Sprintf("Dentry version %v large than mp %v", delVerSeq, mpVerSeq))
 	}
 

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -1411,7 +1411,7 @@ func (i *Inode) getAndDelVer(mpId uint64, dVer uint64, mpVer uint64, verlist *pr
 					i.Inode, i.multiSnap.multiVersions[id].getVer(), nVerSeq, dVer)
 
 				i.multiSnap.multiVersions[id].setVer(nVerSeq)
-				delExtents, ino = i.MultiLayerClearExtByVer(id, nVerSeq), i.multiSnap.multiVersions[id]
+				delExtents, ino = i.MultiLayerClearExtByVer(id+1, nVerSeq), i.multiSnap.multiVersions[id]
 				if len(i.multiSnap.multiVersions[id].Extents.eks) != 0 {
 					log.LogDebugf("action[getAndDelVer] ino %v   after clear self still have ext and left", i.Inode)
 					return

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -1054,8 +1054,11 @@ func (mp *metaPartition) LoadSnapshot(snapshotPath string) (err error) {
 		needLoadUniqStuff = true
 		loadFuncs = append(loadFuncs, mp.loadUniqChecker)
 	}
+
 	if crc_count == CRC_COUNT_MULTI_VER {
-		loadFuncs = append(loadFuncs, mp.loadMultiVer)
+		if err = mp.loadMultiVer(snapshotPath, crcs[CRC_COUNT_MULTI_VER-1]); err != nil {
+			return
+		}
 	} else {
 		mp.storeMultiVersion(snapshotPath, &storeMsg{multiVerList: mp.multiVersionList.VerList})
 	}

--- a/sdk/data/stream/extent_cache.go
+++ b/sdk/data/stream/extent_cache.go
@@ -388,11 +388,13 @@ func (cache *ExtentCache) GetEndForAppendWrite(offset uint64, verSeq uint64, nee
 				if ek.ExtentOffset >= util.ExtentSize {
 					log.LogDebugf("action[ExtentCache.GetEndForAppendWrite] inode %v req offset %v verseq %v not found, exist ek [%v]",
 						cache.inode, offset, verSeq, ek.String())
+					ret = nil
 					return false
 				}
 				//?? should not have the neighbor extent in the next
 				if lastExistEk != nil && ek.IsFileInSequence(lastExistEk) {
 					log.LogErrorf("action[ExtentCache.GetEndForAppendWrite] exist sequence extent %v", lastExistEk)
+					ret = nil
 					return false
 				}
 				log.LogDebugf("action[ExtentCache.GetEndForAppendWrite] inode %v offset %v verseq %v found,ek [%v] lastExistEk[%v], lastExistEkTest[%v]",

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -303,7 +303,7 @@ func (e *Extent) Write(data []byte, offset, size int64, crc uint32, writeType in
 	log.LogDebugf("action[Extent.Write] offset %v size %v writeType %v path %v", offset, size, writeType, e.filePath)
 	if IsAppendWrite(writeType) && e.dataSize != offset {
 		err = newParameterError("extent current size=%d write offset=%d write size=%d", e.dataSize, offset, size)
-		log.LogErrorf("action[Extent.Write] newParameterError path %v offset %v size %v writeType %v err %v", e.filePath,
+		log.LogInfof("action[Extent.Write] newParameterError path %v offset %v size %v writeType %v err %v", e.filePath,
 			offset, size, writeType, err)
 		status = proto.OpTryOtherExtent
 		return

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -292,6 +292,10 @@ func (e *Extent) Write(data []byte, offset, size int64, crc uint32, writeType in
 	if err = e.checkWriteOffsetAndSize(writeType, offset, size); err != nil {
 		log.LogErrorf("action[Extent.Write] checkWriteOffsetAndSize offset %v size %v writeType %v err %v",
 			offset, size, writeType, err)
+		err = newParameterError("extent current size=%d write offset=%d write size=%d", e.dataSize, offset, size)
+		log.LogInfof("action[Extent.Write] newParameterError path %v offset %v size %v writeType %v err %v", e.filePath,
+			offset, size, writeType, err)
+		status = proto.OpTryOtherExtent
 		return
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
snapshot.multiVersion's snapshot loading needs to be loaded before inode and detry because it depends on it
snapshot. need dp space manager lock protect during range in version commit
