### PR TITLE
feat(master): support max mp split when max mp is no leader

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -3273,7 +3273,7 @@ func (c *Cluster) updateInodeIDRange(volName string, start uint64) (err error) {
 	metaPartitionInodeIdStep := gConfig.MetaPartitionInodeIdStep
 	adjustStart = adjustStart + metaPartitionInodeIdStep
 	log.LogWarnf("vol[%v],maxMp[%v],start[%v],adjustStart[%v]", volName, maxPartitionID, start, adjustStart)
-	if err = vol.splitMetaPartition(c, partition, adjustStart, metaPartitionInodeIdStep); err != nil {
+	if err = vol.splitMetaPartition(c, partition, adjustStart, metaPartitionInodeIdStep, false); err != nil {
 		log.LogErrorf("action[updateInodeIDRange]  mp[%v] err[%v]", partition.PartitionID, err)
 	}
 	return

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -1131,7 +1131,7 @@ func (c *Cluster) updateMetaNode(metaNode *MetaNode, metaPartitions []*proto.Met
 			}
 		}
 
-		//send latest end to replica
+		// send latest end to replica metanode, including updating the end after MaxMP split when the old MaxMP is unavailable
 		if mr.End != mp.End {
 			mp.addUpdateMetaReplicaTask(c)
 		}
@@ -1169,7 +1169,7 @@ func (c *Cluster) updateInodeIDUpperBound(mp *MetaPartition, mr *proto.MetaParti
 		log.LogWarnf("updateInodeIDUpperBound: disable auto create meta partition, mp %d", mp.PartitionID)
 		return
 	}
-	if err = vol.splitMetaPartition(c, mp, end, metaPartitionInodeIdStep); err != nil {
+	if err = vol.splitMetaPartition(c, mp, end, metaPartitionInodeIdStep, false); err != nil {
 		log.LogError(err)
 	}
 	return

--- a/master/config.go
+++ b/master/config.go
@@ -89,7 +89,7 @@ const (
 	defaultMaxConcurrentLcNodes                        = 3
 	defaultIntervalToCheckDelVerTaskExpiration         = 3
 	metaPartitionInodeUsageThreshold           float64 = 0.75 // inode usage threshold on a meta partition
-	lowerLimitRWMetaPartition                          = 2    // lower limit of RW meta partition
+	lowerLimitRWMetaPartition                          = 3    // lower limit of RW meta partition, equal defaultReplicaNum
 )
 
 // AddrDatabase is a map that stores the address of a given host (e.g., the leader)

--- a/master/meta_partition.go
+++ b/master/meta_partition.go
@@ -155,7 +155,7 @@ func (mp *MetaPartition) updateInodeIDRangeForAllReplicas() {
 }
 
 //canSplit caller must be add lock
-func (mp *MetaPartition) canSplit(end uint64, metaPartitionInodeIdStep uint64) (err error) {
+func (mp *MetaPartition) canSplit(end uint64, metaPartitionInodeIdStep uint64, ignoreNoLeader bool) (err error) {
 	if end < mp.Start {
 		err = fmt.Errorf("end[%v] less than mp.start[%v]", end, mp.Start)
 		return
@@ -171,6 +171,10 @@ func (mp *MetaPartition) canSplit(end uint64, metaPartitionInodeIdStep uint64) (
 
 	if end <= mp.MaxInodeID {
 		err = fmt.Errorf("next meta partition start must be larger than %v", mp.MaxInodeID)
+		return
+	}
+
+	if ignoreNoLeader {
 		return
 	}
 


### PR DESCRIPTION
1. support max mp split when max mp is no leader.
2. modify lowerLimitRWMetaPartition to 3，which equal defaultReplicaNum when volume was created.