### PR TITLE
fix(master,datanode):Initialize Apply file and add a check condition for dp rollback during dp creation

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -323,10 +323,14 @@ func newDataPartition(dpCfg *dataPartitionCfg, disk *Disk, isCreate bool) (dp *D
 		log.LogWarnf("action[newDataPartition] dp %v NewExtentStore failed %v", partitionID, err.Error())
 		return
 	}
-
+	//store applyid
+	if err = partition.storeAppliedID(partition.appliedID); err != nil {
+		log.LogErrorf("action[newDataPartition] dp %v initial Apply [%v] failed: %v",
+			partition.partitionID, partition.appliedID, err)
+		return
+	}
 	disk.AttachDataPartition(partition)
 	dp = partition
-
 	go partition.statusUpdateScheduler()
 	go partition.startEvict()
 	log.LogInfof("action[newDataPartition] dp %v replica num %v CreateType %v create success",


### PR DESCRIPTION
**What this PR does / why we need it**:
1.Apply will be initialized when new datapartition is created.
2.Only sync up metadate of datapartitons when the creation of the datapartitions fails in the decommission process.