### PR TITLE
fix(security): leaks magic secret key when starting blobstore access service

### DIFF
--- a/blobstore/access/server.go
+++ b/blobstore/access/server.go
@@ -78,8 +78,6 @@ func initWithRegionMagic(regionMagic string) {
 		log.Warn("no region magic setting, using default secret keys for checksum")
 		return
 	}
-
-	log.Info("using magic secret keys for checksum with:", regionMagic)
 	b := sha1.Sum([]byte(regionMagic))
 	initTokenSecret(b[:8])
 	initLocationSecret(b[:8])


### PR DESCRIPTION

see more in cubefs advisories:
https://github.com/cubefs/cubefs/security/advisories/GHSA-8h2x-gr2c-c275

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CubeFS leaks magic secret key when starting blobstore access service.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes # security/advisories/GHSA-8h2x-gr2c-c275

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
