### PR TITLE
fix(cli): fix the bug of empty unavailable replica may appear when us…

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -409,6 +409,9 @@ func formatBadReplicaMpInfoRow(partition *proto.MetaPartitionInfo) string {
 		}
 	}
 	sb.WriteString("]")
+	if sb.String() == "[]" {
+		return ""
+	}
 	return fmt.Sprintf(badReplicaPartitionInfoTablePattern, partition.PartitionID, partition.VolName, partition.ReplicaNum,
 		formatDataPartitionStatus(partition.Status), "["+strings.Join(partition.Hosts, ", ")+"]", sb.String())
 }

--- a/cli/cmd/metapartition.go
+++ b/cli/cmd/metapartition.go
@@ -178,7 +178,10 @@ the corrupt nodes, the few remaining replicas can not reach an agreement with on
 					return
 				}
 				if partition != nil {
-					stdout("%v\n", formatBadReplicaMpInfoRow(partition))
+					badReplicaMpInfoRow := formatBadReplicaMpInfoRow(partition)
+					if "" != badReplicaMpInfoRow {
+						stdout("%v\n", badReplicaMpInfoRow)
+					}
 				}
 			}
 


### PR DESCRIPTION
…ing cli command with metapartition check.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, when executing the cli command for metapartition check, it will first go to the master to get all the metapartitions with unavailable replica, and then go to the master to loop through each metapartition to check if there is really an unavailable replica. If the state of the metapartition changes during this process, you may get an empty unavailable replica.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2692 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
