### PR TITLE
fix(metanode): snapshot.verlist last seq should not consider as tempo…

### DIFF
--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -722,7 +722,10 @@ func (c *Cluster) syncMultiVersion(vol *Vol, val []byte) (err error) {
 	metadata.Op = opSyncMulitVersion
 	metadata.K = MultiVerPrefix + strconv.FormatUint(vol.ID, 10)
 	metadata.V = val
-
+	if c == nil {
+		log.LogErrorf("syncMultiVersion c is nil")
+		return fmt.Errorf("vol %v but cluster is nil", vol.Name)
+	}
 	return c.submit(metadata)
 }
 
@@ -782,7 +785,9 @@ func (c *Cluster) loadMultiVersion(vol *Vol) (err error) {
 		return vol.VersionMgr.init(c)
 	}
 	vol.VersionMgr.c = c
+	log.LogWarnf("action[loadMultiVersion] vol %v loadMultiVersion set cluster %v vol.VersionMgr %v", vol.Name, c, vol.VersionMgr)
 	for _, value := range result {
+		log.LogWarnf("action[loadMultiVersion] MultiVersion zero and do init")
 		return vol.VersionMgr.loadMultiVersion(c, value)
 	}
 	return
@@ -1399,7 +1404,7 @@ func (c *Cluster) loadVols() (err error) {
 		}
 
 		if err = c.loadMultiVersion(vol); err != nil {
-			log.LogInfof("action[loadVols],vol[%v] load ver manager error %v", vol.Name, err)
+			log.LogInfof("action[loadVols],vol[%v] load ver manager error %v c %v", vol.Name, err, c)
 			continue
 		}
 

--- a/master/multi_ver_snapshot.go
+++ b/master/multi_ver_snapshot.go
@@ -82,6 +82,10 @@ func (verMgr *VolVersionManager) Persist() (err error) {
 	if val, err = json.Marshal(persistInfo); err != nil {
 		return
 	}
+	if verMgr.c == nil {
+		log.LogErrorf("vol %v cluster nil", verMgr.vol.Name)
+		return fmt.Errorf("persist vol %v cluster nil", verMgr.vol.Name)
+	}
 	if err = verMgr.c.syncMultiVersion(verMgr.vol, val); err != nil {
 		return
 	}

--- a/master/vol.go
+++ b/master/vol.go
@@ -1195,7 +1195,7 @@ func (vol *Vol) deleteDataPartitionFromDataNode(c *Cluster, task *proto.AdminTas
 }
 
 func (vol *Vol) deleteVolFromStore(c *Cluster) (err error) {
-
+	log.LogWarnf("deleteVolFromStore vol %v", vol.Name)
 	if err = c.syncDeleteVol(vol); err != nil {
 		return
 	}

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -1509,7 +1509,7 @@ func TestDelPartitionVersion(t *testing.T) {
 	}
 	mp.checkByMasterVerlist(mp.multiVersionList, masterList)
 	mp.checkVerList(masterList, true)
-	assert.True(t, len(mp.multiVersionList.TemporaryVerMap) == 3)
+	assert.True(t, len(mp.multiVersionList.TemporaryVerMap) == 2)
 
 	mp.SetXAttr(&proto.SetXAttrRequest{Inode: ino.Inode, Key: "key1", Value: "2222"}, &Packet{})
 
@@ -1525,17 +1525,14 @@ func TestDelPartitionVersion(t *testing.T) {
 		break
 	}
 	inoNew := mp.getInode(&Inode{Inode: ino.Inode}, false).Msg
-	assert.True(t, inoNew.getVer() == 20)
+	assert.True(t, inoNew.getVer() == 25)
 	extend = mp.extendTree.Get(NewExtend(ino.Inode)).(*Extend)
 	t.Logf("extent verseq %v, multivers %v", extend.verSeq, extend.multiVers)
 	assert.True(t, extend.verSeq == 50)
-	assert.True(t, len(extend.multiVers) == 2)
-	assert.True(t, extend.multiVers[0].verSeq == 30)
-	assert.True(t, extend.multiVers[1].verSeq == 20)
-	t.Logf("extent key1 in multiVers[0] %v, in multiVers[1] %v",
-		string(extend.multiVers[0].dataMap["key1"]), string(extend.multiVers[1].dataMap["key1"]))
+	assert.True(t, len(extend.multiVers) == 1)
+	assert.True(t, extend.multiVers[0].verSeq == 25)
+
 	assert.True(t, string(extend.multiVers[0].dataMap["key1"]) == "1111")
-	assert.True(t, string(extend.multiVers[1].dataMap["key1"]) == "0000")
 
 	err = extend.checkSequence()
 	t.Logf("extent checkSequence err %v", err)

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -1451,6 +1451,8 @@ func (mp *metaPartition) delPartitionVersion(verSeq uint64) {
 	if reqVerSeq == 0 {
 		reqVerSeq = math.MaxUint64
 	}
+
+	log.LogInfof("action[delPartitionVersion] mp %v verSeq %v:%v", mp.config.PartitionId, verSeq, reqVerSeq)
 	go mp.delPartitionInodesVersion(reqVerSeq, &wg)
 	go mp.delPartitionExtendsVersion(reqVerSeq, &wg)
 	go mp.delPartitionDentriesVersion(reqVerSeq, &wg)

--- a/metanode/partition_fsmop_extend.go
+++ b/metanode/partition_fsmop_extend.go
@@ -26,6 +26,7 @@ type ExtendOpResult struct {
 }
 
 func (mp *metaPartition) fsmSetXAttr(extend *Extend) (err error) {
+	extend.verSeq = mp.GetVerSeq()
 	treeItem := mp.extendTree.CopyGet(extend)
 	var e *Extend
 	if treeItem == nil {
@@ -104,8 +105,10 @@ func (mp *metaPartition) fsmRemoveXAttr(reqExtend *Extend) (err error) {
 					log.LogDebugf("mp %v inode %v extent layer %v update seq %v to %v",
 						mp.config.PartitionId, ele.inode, id, ele.verSeq, globalNewVer)
 					ele.verSeq = globalNewVer
+					return
 				}
-				break
+				e.multiVers = append(e.multiVers[:id], e.multiVers[id+1:]...)
+				return
 			}
 		}
 	}

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -192,12 +192,17 @@ func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoLis
 	}
 	mp.multiVersionList.Lock()
 	defer mp.multiVersionList.Unlock()
-	for _, info2 := range mpVerList.VerList {
+	vlen := len(mpVerList.VerList)
+	for id, info2 := range mpVerList.VerList {
+		if id == vlen-1 {
+			break
+		}
 		log.LogDebugf("checkVerList. vol %v mp %v ver info %v", mp.config.VolName, mp.config.PartitionId, info2)
 		_, exist := verMapMaster[info2.Ver]
 		if !exist {
 			if info2.Ver < currMasterSeq {
 				if _, ok := mp.multiVersionList.TemporaryVerMap[info2.Ver]; !ok {
+					log.LogInfof("checkVerList. vol %v mp %v ver info %v be consider as TemporaryVer", mp.config.VolName, mp.config.PartitionId, info2)
 					mp.multiVersionList.TemporaryVerMap[info2.Ver] = info2
 				}
 			}
@@ -207,6 +212,7 @@ func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoLis
 	for verSeq := range mp.multiVersionList.TemporaryVerMap {
 		for index, verInfo := range mp.multiVersionList.VerList {
 			if verInfo.Ver == verSeq {
+				log.LogInfof("checkVerList. vol %v mp %v ver info %v be consider as TemporaryVer and do deletion", mp.config.VolName, mp.config.PartitionId, verInfo)
 				mp.multiVersionList.VerList = append(mp.multiVersionList.VerList[:index], mp.multiVersionList.VerList[index+1:]...)
 				break
 			}


### PR DESCRIPTION
…ry verSeq and do deletion

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

verlist last seq should not consider as tempory verSeq and do deletion, Otherwise, if the seq of the MP rolls back, it will result in abnormal behavior after metanode restart and do replay.

enhance xattr snapshot management

add log for master critical management
