### PR TITLE
fix(client): to avoid connection leak: in function tryInitExtentHandlerByLastEk(), close old s.handler before assigning new instance

### DIFF
--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -717,6 +717,13 @@ func (s *Streamer) tryInitExtentHandlerByLastEk(offset, size int) (isLastEkVerNo
 						VerSeq: seq,
 					},
 				}
+
+				if s.handler != nil {
+					log.LogDebugf("tryInitExtentHandlerByLastEk: close old handler, currentEK.PartitionId(%v)",
+						currentEK.PartitionId)
+					s.closeOpenHandler()
+				}
+
 				s.handler = handler
 				s.dirty = false
 				log.LogDebugf("tryInitExtentHandlerByLastEk: currentEK.PartitionId(%v) found", currentEK.PartitionId)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
to avoid connection leak: in function tryInitExtentHandlerByLastEk(), close old s.handler before assigning new instance
