### PR TITLE
fix(client):snapshot. direct write need update handler's fileoffset a…

### DIFF
--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -787,8 +787,11 @@ func (c *Cluster) loadMultiVersion(vol *Vol) (err error) {
 	vol.VersionMgr.c = c
 	log.LogWarnf("action[loadMultiVersion] vol %v loadMultiVersion set cluster %v vol.VersionMgr %v", vol.Name, c, vol.VersionMgr)
 	for _, value := range result {
-		log.LogWarnf("action[loadMultiVersion] MultiVersion zero and do init")
-		return vol.VersionMgr.loadMultiVersion(c, value)
+		if err = vol.VersionMgr.loadMultiVersion(c, value); err != nil {
+			log.LogErrorf("action[loadMultiVersion] vol %v err %v", vol.Name, err)
+			return
+		}
+		log.LogWarnf("action[loadMultiVersion] vol %v MultiVersion zero and do init, verlist %v", vol.Name, vol.VersionMgr)
 	}
 	return
 }

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2381,7 +2381,9 @@ func (m *metadataManager) checkVolVerList() (err error) {
 			if partition.GetVolName() != volName {
 				return true
 			}
-			mpsVerlist[partition.GetBaseConfig().PartitionId] = &proto.VolVersionInfoList{VerList: partition.GetVerList()}
+			log.LogDebugf("action[checkVolVerList] volumeName %v id %v dp verlist %v partition.GetBaseConfig().PartitionId %v",
+				volName, id, partition.GetVerList(), partition.GetBaseConfig().PartitionId)
+			mpsVerlist[id] = &proto.VolVersionInfoList{VerList: partition.GetVerList()}
 			return true
 		})
 		var info *proto.VolVersionInfoList
@@ -2395,6 +2397,7 @@ func (m *metadataManager) checkVolVerList() (err error) {
 			if partition.GetVolName() != volName {
 				return true
 			}
+			log.LogDebugf("action[checkVolVerList] volumeName %v info %v id %v ", volName, info, id)
 			if _, exist := mpsVerlist[id]; exist {
 				if err = partition.checkByMasterVerlist(mpsVerlist[id], info); err != nil {
 					return true
@@ -2633,7 +2636,10 @@ end:
 	}
 	adminTask.Request = nil
 	adminTask.Response = resp
-	m.respondToMaster(adminTask)
+	if errRsp := m.respondToMaster(adminTask); errRsp != nil {
+		log.LogInfof("action[opMultiVersionOp] %s pkt %s, resp success req:%v; respAdminTask: %v, resp: %v, errRsp %v err %v",
+			remoteAddr, p.String(), req, adminTask, resp, errRsp, err)
+	}
 
 	if log.EnableInfo() {
 		rspData, _ := json.Marshal(resp)

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -190,6 +190,7 @@ func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoLis
 	for _, ver := range masterVerList.VerList {
 		verMapMaster[ver.Ver] = ver
 	}
+	log.LogDebugf("checkVerList. vol %v mp %v masterVerList %v mpVerList.VerList %v", mp.config.VolName, mp.config.PartitionId, masterVerList, mpVerList.VerList)
 	mp.multiVersionList.Lock()
 	defer mp.multiVersionList.Unlock()
 	vlen := len(mpVerList.VerList)
@@ -197,14 +198,12 @@ func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoLis
 		if id == vlen-1 {
 			break
 		}
-		log.LogDebugf("checkVerList. vol %v mp %v ver info %v", mp.config.VolName, mp.config.PartitionId, info2)
+		log.LogDebugf("checkVerList. vol %v mp %v ver info %v currMasterSeq %v", mp.config.VolName, mp.config.PartitionId, info2, currMasterSeq)
 		_, exist := verMapMaster[info2.Ver]
 		if !exist {
-			if info2.Ver < currMasterSeq {
-				if _, ok := mp.multiVersionList.TemporaryVerMap[info2.Ver]; !ok {
-					log.LogInfof("checkVerList. vol %v mp %v ver info %v be consider as TemporaryVer", mp.config.VolName, mp.config.PartitionId, info2)
-					mp.multiVersionList.TemporaryVerMap[info2.Ver] = info2
-				}
+			if _, ok := mp.multiVersionList.TemporaryVerMap[info2.Ver]; !ok {
+				log.LogInfof("checkVerList. vol %v mp %v ver info %v be consider as TemporaryVer", mp.config.VolName, mp.config.PartitionId, info2)
+				mp.multiVersionList.TemporaryVerMap[info2.Ver] = info2
 			}
 		}
 	}

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -577,6 +577,10 @@ func (s *Streamer) doDirectWriteByAppend(req *ExtentRequest, direct bool, op uin
 			log.LogErrorf("action[doDirectWriteByAppend] inode %v meta extent split process err %v", s.inode, err)
 			return
 		}
+		// adjust the handler key to last direct write one
+		s.handler.fileOffset = int(extKey.FileOffset)
+		s.handler.size = int(extKey.Size)
+		s.handler.key = extKey
 	}
 	log.LogDebugf("action[doDirectWriteByAppend] inode %v process over!", s.inode)
 	return


### PR DESCRIPTION
…nd size

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The "try direct write" was not performed using streaming write, but the subsequent extent handler's key was not updated. Additionally, this key may have changed its sequence due to the direct write attempt. As a result, when attempting the next append write, it does not meet the conditions for direct append write because the offset of the handler's key is not updated. Furthermore, when creating a new handler, the original handler needs to be closed. However, the handler retains information from the key before the "try direct write," and since the sequence has already changed, the extent cache is updated and replaced with the new sequence. This leads to subsequent writes mistakenly assuming that direct modification write is possible.
