### PR TITLE
fix(master): panic when concurrent read/write map

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -101,7 +101,7 @@ func stdoutf(format string, a ...interface{}) {
 
 func stdoutlnf(format string, a ...interface{}) {
 	stdoutf(format, a...)
-	fmt.Fprint(os.Stdout)
+	fmt.Fprintln(os.Stdout)
 }
 
 func errout(err error) {

--- a/master/topology.go
+++ b/master/topology.go
@@ -2136,10 +2136,11 @@ func (l *DecommissionDataPartitionList) Put(id uint64, value *DataPartition, c *
 		value.SetDecommissionStatus(markDecommission)
 	}
 
+	l.mu.Lock()
 	if _, ok := l.cacheMap[value.PartitionID]; ok {
+		l.mu.Unlock()
 		return
 	}
-	l.mu.Lock()
 	elm := l.decommissionList.PushBack(value)
 	l.cacheMap[value.PartitionID] = elm
 	l.mu.Unlock()


### PR DESCRIPTION
**What this PR does / why we need it**:


panic when concurrent read/write decommissiondatapartition list