### PR TITLE
[Feature]: Backend audit log support configure in master

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -148,6 +148,7 @@ func formatSimpleVolView(svv *proto.SimpleVolView) string {
 	sb.WriteString(fmt.Sprintf("  Tx conflict retry interval(ms)  : %v\n", svv.TxConflictRetryInterval))
 	sb.WriteString(fmt.Sprintf("  Tx limit interval(s)            : %v\n", svv.TxOpLimit))
 	sb.WriteString(fmt.Sprintf("  Forbidden                       : %v\n", svv.Forbidden))
+	sb.WriteString(fmt.Sprintf("  EnableAuditLog                  : %v\n", svv.EnableAuditLog))
 	sb.WriteString(fmt.Sprintf("  Quota                           : %v\n", formatEnabledDisabled(svv.EnableQuota)))
 	if svv.VolType == 1 {
 		sb.WriteString(fmt.Sprintf("  ObjBlockSize         : %v byte\n", svv.ObjBlockSize))

--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -49,6 +49,7 @@ func newVolCmd(client *master.MasterClient) *cobra.Command {
 		newVolTransferCmd(client),
 		newVolAddDPCmd(client),
 		newVolSetForbiddenCmd(client),
+		newVolSetAuditLogCmd(client),
 	)
 	return cmd
 }
@@ -939,6 +940,36 @@ func newVolSetForbiddenCmd(client *master.MasterClient) *cobra.Command {
 				return
 			}
 			stdout("Volume forbidden property has been set successfully, please wait few minutes for the settings to take effect.\n")
+		},
+	}
+	return cmd
+}
+
+var (
+	cmdVolSetAuditLogUse   = "set-auditlog [VOLUME] [STATUS]"
+	cmdVolSetAuditLogShort = "Enable/Disable backend audit log for volume"
+)
+
+func newVolSetAuditLogCmd(client *master.MasterClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   cmdVolSetAuditLogUse,
+		Short: cmdVolSetAuditLogShort,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+			settingStr := args[1]
+			var err error
+			defer func() {
+				errout(err)
+			}()
+			enable, err := strconv.ParseBool(settingStr)
+			if err != nil {
+				return
+			}
+			if err = client.AdminAPI().SetVolumeAuditLog(name, enable); err != nil {
+				return
+			}
+			stdout("Volume audit log has been set successfully, please wait few minutes for the settings to take effect.\n")
 		},
 	}
 	return cmd

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -676,6 +676,9 @@ func (c *Cluster) checkMetaNodeHeartbeat() {
 			if vol.Forbidden {
 				hbReq.ForbiddenVols = append(hbReq.ForbiddenVols, vol.Name)
 			}
+			if !vol.EnableAuditLog {
+				hbReq.DisableAuditVols = append(hbReq.DisableAuditVols, vol.Name)
+			}
 
 			spaceInfo := vol.uidSpaceManager.getSpaceOp()
 			hbReq.UidLimitInfo = append(hbReq.UidLimitInfo, spaceInfo...)

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -290,6 +290,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 		Path(proto.AdminVolForbidden).
 		HandlerFunc(m.forbidVolume)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
+		Path(proto.AdminVolEnableAuditLog).
+		HandlerFunc(m.setEnableAuditLogForVolume)
+	router.NewRoute().Methods(http.MethodGet, http.MethodPost).
 		Path(proto.AdminClusterForbidMpDecommission).
 		HandlerFunc(m.setupForbidMetaPartitionDecommission)
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -284,6 +284,7 @@ type volValue struct {
 	IopsRMagnify, IopsWMagnify, FlowRMagnify, FlowWMagnify uint32
 	ClientReqPeriod, ClientHitTriggerCnt                   uint32
 	Forbidden                                              bool
+	EnableAuditLog                                         bool
 }
 
 func (v *volValue) Bytes() (raw []byte, err error) {
@@ -346,6 +347,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 
 		DpReadOnlyWhenVolFull: vol.DpReadOnlyWhenVolFull,
 		Forbidden:             vol.Forbidden,
+		EnableAuditLog:        vol.EnableAuditLog,
 	}
 
 	return

--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -165,11 +165,11 @@ func (mds *MockDataServer) handleTryToLeader(conn net.Conn, p *proto.Packet, adm
 	return
 }
 
-func (mds *MockDataServer) CheckVolPartition(name string, forbidden bool) bool {
+func (mds *MockDataServer) CheckVolPartition(name string, cond func(*MockDataPartition) bool) bool {
 	mds.RLock()
 	defer mds.RUnlock()
 	for _, dp := range mds.partitions {
-		if dp.VolName == name && dp.IsForbidden() != forbidden {
+		if dp.VolName == name && !cond(dp) {
 			return false
 		}
 	}
@@ -235,6 +235,7 @@ func (mds *MockDataServer) handleCreateDataPartition(conn net.Conn, p *proto.Pac
 		total:       req.PartitionSize,
 		used:        defaultUsedSize,
 	}
+	partition.SetForbidden(false)
 	mds.Lock()
 	defer mds.Unlock()
 	mds.partitions = append(mds.partitions, partition)

--- a/master/mocktest/partition.go
+++ b/master/mocktest/partition.go
@@ -28,15 +28,16 @@ func (md *MockDataPartition) SetForbidden(status bool) {
 }
 
 type MockMetaPartition struct {
-	PartitionID uint64
-	Start       uint64
-	End         uint64
-	Status      int8
-	Cursor      uint64
-	VolName     string
-	Members     []proto.Peer
-	Replicas    []*MockMetaReplica
-	Forbidden   int32
+	PartitionID    uint64
+	Start          uint64
+	End            uint64
+	Status         int8
+	Cursor         uint64
+	VolName        string
+	Members        []proto.Peer
+	Replicas       []*MockMetaReplica
+	Forbidden      int32
+	EnableAuditLog int32
 }
 
 // MockMetaReplica defines the replica of a meta partition
@@ -62,6 +63,18 @@ func (mm *MockMetaPartition) isLeaderMetaNode(addr string) bool {
 	}
 
 	return false
+}
+
+func (mm *MockMetaPartition) IsEnableAuditLog() bool {
+	return atomic.LoadInt32(&mm.EnableAuditLog) != 0
+}
+
+func (mm *MockMetaPartition) SetEnableAuditLog(status bool) {
+	val := 0
+	if status {
+		val = 1
+	}
+	atomic.StoreInt32(&mm.EnableAuditLog, int32(val))
 }
 
 func (mm *MockMetaPartition) IsForbidden() bool {

--- a/master/vol.go
+++ b/master/vol.go
@@ -112,6 +112,7 @@ type Vol struct {
 	VersionMgr              *VolVersionManager
 	Forbidden               bool
 	mpsLock                 *mpsLockManager
+	EnableAuditLog          bool
 }
 
 func newVol(vv volValue) (vol *Vol) {
@@ -180,6 +181,7 @@ func newVol(vv volValue) (vol *Vol) {
 	vol.qosManager.volUpdateMagnify(magnifyQosVal)
 	vol.DpReadOnlyWhenVolFull = vv.DpReadOnlyWhenVolFull
 	vol.mpsLock = newMpsLockManager(vol)
+	vol.EnableAuditLog = true
 	return
 }
 
@@ -201,6 +203,7 @@ func newVolFromVolValue(vv *volValue) (vol *Vol) {
 		vol.txConflictRetryInterval = proto.DefaultTxConflictRetryInterval
 	}
 	vol.Forbidden = vv.Forbidden
+	vol.EnableAuditLog = vv.EnableAuditLog
 	return vol
 }
 

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -37,7 +37,7 @@ const (
 )
 
 func (m *metadataManager) checkFollowerRead(volNames []string, partition MetaPartition) {
-	volName := partition.GetBaseConfig().VolName
+	volName := partition.GetVolName()
 	for _, name := range volNames {
 		if name == volName {
 			partition.SetFollowerRead(true)
@@ -49,7 +49,7 @@ func (m *metadataManager) checkFollowerRead(volNames []string, partition MetaPar
 }
 
 func (m *metadataManager) checkForbiddenVolume(volNames []string, partition MetaPartition) {
-	volName := partition.GetBaseConfig().VolName
+	volName := partition.GetVolName()
 	for _, name := range volNames {
 		if name == volName {
 			partition.SetForbidden(true)
@@ -57,6 +57,18 @@ func (m *metadataManager) checkForbiddenVolume(volNames []string, partition Meta
 		}
 	}
 	partition.SetForbidden(false)
+	return
+}
+
+func (m *metadataManager) checkDisableAuditLogVolume(volNames []string, partition MetaPartition) {
+	volName := partition.GetVolName()
+	for _, name := range volNames {
+		if name == volName {
+			partition.SetEnableAuditLog(false)
+			return
+		}
+	}
+	partition.SetEnableAuditLog(true)
 	return
 }
 
@@ -97,6 +109,7 @@ func (m *metadataManager) opMasterHeartbeat(conn net.Conn, p *Packet,
 		m.Range(true, func(id uint64, partition MetaPartition) bool {
 			m.checkFollowerRead(req.FLReadVols, partition)
 			m.checkForbiddenVolume(req.ForbiddenVols, partition)
+			m.checkDisableAuditLogVolume(req.DisableAuditVols, partition)
 			partition.SetUidLimit(req.UidLimitInfo)
 			partition.SetTxInfo(req.TxInfo)
 			partition.setQuotaHbInfo(req.QuotaHbInfos)

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -278,6 +278,8 @@ type MetaPartition interface {
 	ForceSetMetaPartitionToFininshLoad()
 	IsForbidden() bool
 	SetForbidden(status bool)
+	IsEnableAuditLog() bool
+	SetEnableAuditLog(status bool)
 }
 
 type UidManager struct {
@@ -516,6 +518,7 @@ type metaPartition struct {
 	multiVersionList       *proto.VolVersionInfoList
 	versionLock            sync.Mutex
 	verUpdateChan          chan []byte
+	enableAuditLog         bool
 }
 
 func (mp *metaPartition) IsForbidden() bool {
@@ -524,6 +527,14 @@ func (mp *metaPartition) IsForbidden() bool {
 
 func (mp *metaPartition) SetForbidden(status bool) {
 	mp.config.Forbidden = status
+}
+
+func (mp *metaPartition) IsEnableAuditLog() bool {
+	return mp.enableAuditLog
+}
+
+func (mp *metaPartition) SetEnableAuditLog(status bool) {
+	mp.enableAuditLog = status
 }
 
 func (mp *metaPartition) acucumRebuildStart() bool {
@@ -875,6 +886,7 @@ func NewMetaPartition(conf *MetaPartitionConfig, manager *metadataManager) MetaP
 		multiVersionList: &proto.VolVersionInfoList{
 			TemporaryVerMap: make(map[uint64]*proto.VolVersionInfo),
 		},
+		enableAuditLog: true,
 	}
 	mp.txProcessor = NewTransactionProcessor(mp)
 	return mp

--- a/metanode/partition_op_dentry.go
+++ b/metanode/partition_op_dentry.go
@@ -28,9 +28,11 @@ import (
 
 func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -83,9 +85,11 @@ func (mp *metaPartition) TxCreateDentry(req *proto.TxCreateDentryRequest, p *Pac
 // CreateDentry returns a new dentry.
 func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		}()
+	}
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -129,9 +133,11 @@ func (mp *metaPartition) CreateDentry(req *CreateDentryReq, p *Packet, remoteAdd
 
 func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		}()
+	}
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -184,9 +190,11 @@ func (mp *metaPartition) QuotaCreateDentry(req *proto.QuotaCreateDentryRequest, 
 
 func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Ino, req.ParentID)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Ino, req.ParentID)
+		}()
+	}
 	txInfo := req.TxInfo.GetCopy()
 	den := &Dentry{
 		ParentId: req.ParentID,
@@ -259,9 +267,11 @@ func (mp *metaPartition) TxDeleteDentry(req *proto.TxDeleteDentryRequest, p *Pac
 // DeleteDentry deletes a dentry.
 func (mp *metaPartition) DeleteDentry(req *DeleteDentryReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), 0, req.ParentID)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), 0, req.ParentID)
+		}()
+	}
 	if req.InodeCreateTime > 0 {
 		if mp.vol.volDeleteLockTime > 0 && req.InodeCreateTime+mp.vol.volDeleteLockTime*60*60 > time.Now().Unix() {
 			err = errors.NewErrorf("the current Inode[%v] is still locked for deletion", req.Name)
@@ -323,9 +333,11 @@ func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet,
 		if len(req.FullPaths) > i {
 			fullPath = req.FullPaths[i]
 		}
-		defer func() {
-			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), den.Name, fullPath, err, time.Since(start).Milliseconds(), den.Inode, req.ParentID)
-		}()
+		if mp.IsEnableAuditLog() {
+			defer func() {
+				auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), den.Name, fullPath, err, time.Since(start).Milliseconds(), den.Inode, req.ParentID)
+			}()
+		}
 	}
 
 	val, err := db.Marshal()
@@ -380,9 +392,11 @@ func (mp *metaPartition) DeleteDentryBatch(req *BatchDeleteDentryReq, p *Packet,
 
 func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		}()
+	}
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))
@@ -449,9 +463,11 @@ func (mp *metaPartition) TxUpdateDentry(req *proto.TxUpdateDentryRequest, p *Pac
 // UpdateDentry updates a dentry.
 func (mp *metaPartition) UpdateDentry(req *UpdateDentryReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogDentryOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.Name, req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, req.ParentID)
+		}()
+	}
 	if req.ParentID == req.Inode {
 		err = fmt.Errorf("parentId is equal inodeId")
 		p.PacketErrorWithBody(proto.OpExistErr, []byte(err.Error()))

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -478,9 +478,11 @@ func (mp *metaPartition) ExtentsTruncate(req *ExtentsTruncateReq, p *Packet, rem
 	}
 	fileSize := uint64(0)
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, fileSize)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, fileSize)
+		}()
+	}
 	ino := NewInode(req.Inode, proto.Mode(os.ModePerm))
 	item := mp.inodeTree.CopyGet(ino)
 	if item == nil {

--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -110,9 +110,11 @@ func (mp *metaPartition) CreateInode(req *CreateInoReq, p *Packet, remoteAddr st
 		inoID  uint64
 	)
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
+		}()
+	}
 	inoID, err = mp.nextInodeID()
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpInodeFullErr, []byte(err.Error()))
@@ -162,9 +164,11 @@ func (mp *metaPartition) QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p 
 		inoID  uint64
 	)
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
+		}()
+	}
 	inoID, err = mp.nextInodeID()
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpInodeFullErr, []byte(err.Error()))
@@ -225,9 +229,11 @@ func (mp *metaPartition) QuotaCreateInode(req *proto.QuotaCreateInodeRequest, p 
 
 func (mp *metaPartition) TxUnlinkInode(req *proto.TxUnlinkInodeRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	txInfo := req.TxInfo.GetCopy()
 	var status uint8
 	var respIno *Inode
@@ -315,9 +321,11 @@ func (mp *metaPartition) UnlinkInode(req *UnlinkInoReq, p *Packet, remoteAddr st
 		val   []byte
 	)
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	makeRspFunc := func() {
 		status := msg.Status
 		if status == proto.OpOk {
@@ -382,9 +390,11 @@ func (mp *metaPartition) UnlinkInodeBatch(req *BatchUnlinkInoReq, p *Packet, rem
 		if len(req.FullPaths) > i {
 			fullPath = req.FullPaths[i]
 		}
-		defer func() {
-			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), fullPath, err, time.Since(start).Milliseconds(), ino, 0)
-		}()
+		if mp.IsEnableAuditLog() {
+			defer func() {
+				auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), fullPath, err, time.Since(start).Milliseconds(), ino, 0)
+			}()
+		}
 	}
 
 	val, err := inodes.Marshal()
@@ -574,9 +584,11 @@ func (mp *metaPartition) InodeGetBatch(req *InodeGetReqBatch, p *Packet) (err er
 
 func (mp *metaPartition) TxCreateInodeLink(req *proto.TxLinkInodeRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	txInfo := req.TxInfo.GetCopy()
 	ino := NewInode(req.Inode, 0)
 	inoResp := mp.getInode(ino, true)
@@ -626,9 +638,11 @@ func (mp *metaPartition) TxCreateInodeLink(req *proto.TxLinkInodeRequest, p *Pac
 // CreateInodeLink creates an inode link (e.g., soft link).
 func (mp *metaPartition) CreateInodeLink(req *LinkInodeReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	var r interface{}
 	var val []byte
 	if req.UniqID > 0 {
@@ -674,9 +688,11 @@ func (mp *metaPartition) CreateInodeLink(req *LinkInodeReq, p *Packet, remoteAdd
 // EvictInode evicts an inode.
 func (mp *metaPartition) EvictInode(req *EvictInodeReq, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	ino := NewInode(req.Inode, 0)
 	val, err := ino.Marshal()
 	if err != nil {
@@ -710,9 +726,11 @@ func (mp *metaPartition) EvictInodeBatch(req *BatchEvictInodeReq, p *Packet, rem
 		if len(req.FullPaths) > i {
 			fullPath = req.FullPaths[i]
 		}
-		defer func() {
-			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), fullPath, err, time.Since(start).Milliseconds(), ino, 0)
-		}()
+		if mp.IsEnableAuditLog() {
+			defer func() {
+				auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), fullPath, err, time.Since(start).Milliseconds(), ino, 0)
+			}()
+		}
 	}
 
 	val, err := inodes.Marshal()
@@ -772,9 +790,11 @@ func (mp *metaPartition) GetInodeTreeLen() int {
 
 func (mp *metaPartition) DeleteInode(req *proto.DeleteInodeRequest, p *Packet, remoteAddr string) (err error) {
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), req.Inode, 0)
+		}()
+	}
 	var bytes = make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, req.Inode)
 	_, err = mp.submit(opFSMInternalDeleteInode, bytes)
@@ -800,9 +820,11 @@ func (mp *metaPartition) DeleteInodeBatch(req *proto.DeleteInodeBatchRequest, p 
 		if len(req.FullPaths) > i {
 			fullPath = req.FullPaths[i]
 		}
-		defer func() {
-			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), fullPath, err, time.Since(start).Milliseconds(), ino, 0)
-		}()
+		if mp.IsEnableAuditLog() {
+			defer func() {
+				auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), fullPath, err, time.Since(start).Milliseconds(), ino, 0)
+			}()
+		}
 	}
 
 	encoded, err := inodes.Marshal()
@@ -851,9 +873,11 @@ func (mp *metaPartition) TxCreateInode(req *proto.TxCreateInodeRequest, p *Packe
 		inoID  uint64
 	)
 	start := time.Now()
-	defer func() {
-		auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogInodeOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.GetFullPath(), err, time.Since(start).Milliseconds(), inoID, 0)
+		}()
+	}
 	inoID, err = mp.nextInodeID()
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpInodeFullErr, []byte(err.Error()))

--- a/metanode/partition_op_transaction.go
+++ b/metanode/partition_op_transaction.go
@@ -229,9 +229,11 @@ func (mp *metaPartition) TxRollbackRM(req *proto.TxApplyRMRequest, p *Packet) er
 func (mp *metaPartition) TxCommit(req *proto.TxApplyRequest, p *Packet, remoteAddr string) error {
 	var err error
 	start := time.Now()
-	defer func() {
-		auditlog.LogTxOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.TxID, err, time.Since(start).Milliseconds())
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogTxOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.TxID, err, time.Since(start).Milliseconds())
+		}()
+	}
 	status, err := mp.txProcessor.txManager.commitTx(req.TxID, false)
 	if err != nil {
 		p.PacketErrorWithBody(status, []byte(err.Error()))
@@ -244,9 +246,11 @@ func (mp *metaPartition) TxCommit(req *proto.TxApplyRequest, p *Packet, remoteAd
 func (mp *metaPartition) TxRollback(req *proto.TxApplyRequest, p *Packet, remoteAddr string) error {
 	var err error
 	start := time.Now()
-	defer func() {
-		auditlog.LogTxOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.TxID, err, time.Since(start).Milliseconds())
-	}()
+	if mp.IsEnableAuditLog() {
+		defer func() {
+			auditlog.LogTxOp(remoteAddr, mp.GetVolName(), p.GetOpMsg(), req.TxID, err, time.Since(start).Milliseconds())
+		}()
+	}
 	status, err := mp.txProcessor.txManager.rollbackTx(req.TxID, false)
 	if err != nil {
 		p.PacketErrorWithBody(status, []byte(err.Error()))

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -45,6 +45,7 @@ const (
 	AdminVolShrink                            = "/vol/shrink"
 	AdminVolExpand                            = "/vol/expand"
 	AdminVolForbidden                         = "/vol/forbidden"
+	AdminVolEnableAuditLog                    = "/vol/auditlog"
 	AdminCreateVol                            = "/admin/createVol"
 	AdminGetVol                               = "/admin/getVol"
 	AdminClusterFreeze                        = "/cluster/freeze"
@@ -599,7 +600,8 @@ type HeartBeatRequest struct {
 	UidLimitToMetaNode
 	QuotaHeartBeatInfos
 	TxInfos
-	ForbiddenVols []string
+	ForbiddenVols    []string
+	DisableAuditVols []string
 }
 
 // DataPartitionReport defines the partition report.
@@ -834,7 +836,6 @@ type VolView struct {
 	DeleteLockTime int64
 	CacheTTL       int
 	VolType        int
-	Forbidden      bool
 }
 
 func (v *VolView) SetOwner(owner string) {
@@ -1000,8 +1001,9 @@ type SimpleVolView struct {
 	PreloadCapacity  uint64
 	Uids             []UidSimpleInfo
 	// multi version snapshot
-	LatestVer uint64
-	Forbidden bool
+	LatestVer      uint64
+	Forbidden      bool
+	EnableAuditLog bool
 }
 
 type NodeSetInfo struct {

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -507,9 +507,19 @@ func (api *AdminAPI) GetVolumeSimpleInfo(volName string) (vv *proto.SimpleVolVie
 }
 
 func (api *AdminAPI) SetVolumeForbidden(volName string, forbidden bool) (err error) {
-	request := newAPIRequest(http.MethodGet, proto.AdminVolForbidden)
+	request := newAPIRequest(http.MethodPost, proto.AdminVolForbidden)
 	request.addParam("name", volName)
 	request.addParam("forbidden", strconv.FormatBool(forbidden))
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
+func (api *AdminAPI) SetVolumeAuditLog(volName string, enable bool) (err error) {
+	request := newAPIRequest(http.MethodPost, proto.AdminVolEnableAuditLog)
+	request.addParam("name", volName)
+	request.addParam("enable", strconv.FormatBool(enable))
 	if _, err = api.mc.serveRequest(request); err != nil {
 		return
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Backend audit log support configure in master(per volume).
```sh
└─$ ./build/bin/cfs-cli volume -h
Manage cluster volumes

Usage:
  cfs-cli volume [command]

Aliases:
  volume, vol

Available Commands:
  add-dp        Create and add more data partition to a volume
  create        Create a new volume
  delete        Delete a volume from cluster
  expand        Expand capacity of a volume
  info          Show volume information
  list          List cluster volumes
  set-auditlog  Enable/Disable backend audit log for volume
  set-forbidden Set the forbidden property for volume
  shrink        Shrink capacity of a volume
  transfer      Transfer volume to another user. (Change owner of volume)
  update        Update configuration of the volume

Flags:
  -h, --help   help for volume

Use "cfs-cli volume [command] --help" for more information about a command.
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
