### PR TITLE
refactor(data): optimize the determination of datanode disk's unavailable status:

### DIFF
--- a/cli/cmd/disk.go
+++ b/cli/cmd/disk.go
@@ -45,7 +45,7 @@ func newListBadDiskCmd(client *master.MasterClient) *cobra.Command {
 			if infos, err = client.AdminAPI().QueryBadDisks(); err != nil {
 				return
 			}
-			stdout("[Unavaliable disks]:\n")
+			stdout("(partitionID=0 means detected by datanode disk checking, not associated with any partition)\n\n[Unavaliable disks]:\n")
 			stdout("%v\n", formatBadDiskTableHeader())
 
 			sort.SliceStable(infos.BadDisks, func(i, j int) bool {

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -864,9 +864,10 @@ func formatQuotaInfo(info *proto.QuotaInfo) string {
 var badDiskDetailTableRowPattern = "%-18v    %-18v    %-18v    %-18v    %-18v"
 
 func formatBadDiskTableHeader() string {
-	return fmt.Sprintf(badDiskDetailTableRowPattern, "Address", "Path", "TotalPartitionCnt", "DiskErrPartitionCnt", "DiskErrPartitionList")
+	return fmt.Sprintf(badDiskDetailTableRowPattern, "Address", "Path", "TotalPartitionCnt", "DiskErrPartitionCnt", "PartitionIdsWithDiskErr")
 }
 
 func formatBadDiskInfoRow(disk proto.BadDiskInfo) string {
-	return fmt.Sprintf(badDiskDetailTableRowPattern, disk.Address, disk.Path, disk.TotalPartitionCnt, len(disk.DiskErrPartitionList), disk.DiskErrPartitionList)
+	msgDpIdList := fmt.Sprintf("%v", disk.DiskErrPartitionList)
+	return fmt.Sprintf(badDiskDetailTableRowPattern, disk.Address, disk.Path, disk.TotalPartitionCnt, len(disk.DiskErrPartitionList), msgDpIdList)
 }

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -596,6 +596,9 @@ func (dp *DataPartition) statusUpdate() {
 			status = proto.Unavailable
 		}
 	}
+	if dp.getDiskErrCnt() > 0 {
+		dp.partitionStatus = proto.Unavailable
+	}
 
 	log.LogInfof("action[statusUpdate] dp %v raft status %v dp.status %v, status %v, disk status %v, res:%v",
 		dp.partitionID, dp.raftStatus, dp.Status(), status, float64(dp.disk.Status), int(math.Min(float64(status), float64(dp.disk.Status))))
@@ -626,7 +629,7 @@ func (dp *DataPartition) checkIsDiskError(err error, rwFlag uint8) {
 
 	dp.stopRaft()
 	dp.incDiskErrCnt()
-	dp.disk.triggerDiskError(rwFlag, &dp.partitionID)
+	dp.disk.triggerDiskError(rwFlag, dp.partitionID)
 
 	//must after change disk.status
 	dp.statusUpdate()
@@ -1196,6 +1199,10 @@ func (dp *DataPartition) handleDecommissionRecoverFailed() {
 }
 
 func (dp *DataPartition) incDiskErrCnt() {
-	atomic.AddUint64(&dp.diskErrCnt, 1)
-	log.LogErrorf("[incDiskErrCnt]: dp(%v) disk err count:%v", dp.partitionID, dp.diskErrCnt)
+	diskErrCnt := atomic.AddUint64(&dp.diskErrCnt, 1)
+	log.LogWarnf("[incDiskErrCnt]: dp(%v) disk err count:%v", dp.partitionID, diskErrCnt)
+}
+
+func (dp *DataPartition) getDiskErrCnt() uint64 {
+	return atomic.LoadUint64(&dp.diskErrCnt)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
refactor(data): optimize the determination of datanode disk's unavailable status:
(1) add 2 conf item: diskUnavailableErrorCount and diskUnavailablePartitionErrorCount. 
(2) when encounter disk error, set disk as unavailable if disk error count reaches diskUnavailableErrorCount or partition count with disk error reaches diskUnavailablePartitionErrorCount. 
(3) if a partition encounter 1 disk error, set the partition's status as unavailable.
