### PR TITLE
enable metanode ttl clear tempory snapshot and some other issues

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2886,9 +2886,7 @@ func (c *Cluster) migrateMetaNode(srcAddr, targetAddr string, limit int) (err er
 		return fmt.Errorf("migrateMataNode no partition can migrate from [%s] to [%s] limit [%v]", srcAddr, targetAddr, limit)
 	}
 
-	if limit <= 0 && targetAddr == "" { // default all mps
-		limit = len(toBeOfflineMps)
-	} else if limit <= 0 {
+	if limit <= 0 {
 		limit = defaultMigrateMpCnt
 	}
 

--- a/master/const.go
+++ b/master/const.go
@@ -191,7 +191,7 @@ const (
 	defaultMinusOfMaxInodeID                     = 1000
 	defaultNodeSetGrpBatchCnt                    = 3
 	defaultMigrateDpCnt                          = 50
-	defaultMigrateMpCnt                          = 15
+	defaultMigrateMpCnt                          = 3
 	defaultMaxReplicaCnt                         = 16
 	defaultIopsRLimit                     uint64 = 1 << 35
 	defaultIopsWLimit                     uint64 = 1 << 35

--- a/master/multi_ver_snapshot.go
+++ b/master/multi_ver_snapshot.go
@@ -776,7 +776,7 @@ func (verMgr *VolVersionManager) getLatestVer() (ver uint64) {
 	if size == 0 {
 		return 0
 	}
-	log.LogInfof("action[getLatestVer] ver len %v verMgr %v", size, verMgr)
+
 	return verMgr.multiVersionList[size-1].Ver
 }
 

--- a/master/vol.go
+++ b/master/vol.go
@@ -222,7 +222,7 @@ func newMpsLockManager(vol *Vol) *mpsLockManager {
 	lc := &mpsLockManager{vol: vol}
 	go lc.CheckExceptionLock(lockCheckInterval, lockExpireInterval)
 	if log.EnableDebug() {
-		atomic.StoreInt32(&lc.enable, 1)
+		atomic.StoreInt32(&lc.enable, 0)
 	}
 	return lc
 }

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -342,6 +342,9 @@ func TestVolMpsLock(t *testing.T) {
 	}
 	expireTime := time.Microsecond * 50
 	vol := newVol(vv)
+	if vol.mpsLock.enable == 0 {
+		return
+	}
 	vol.mpsLock.Lock()
 	mpsLock := vol.mpsLock
 	assert.True(t, !(mpsLock.vol.status() == markDelete || atomic.LoadInt32(&mpsLock.enable) == 0))

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -137,7 +137,7 @@ func (i *Inode) setVerNoCheck(seq uint64) {
 func (i *Inode) setVer(seq uint64) {
 	if i.getVer() > seq {
 		syslog.Println(fmt.Sprintf("inode %v old seq %v cann't use seq %v", i.getVer(), seq, string(debug.Stack())))
-		log.LogFatalf("inode %v old seq %v cann't use seq %v", i.getVer(), seq, string(debug.Stack()))
+		log.LogFatalf("inode %v old seq %v cann't use seq %v stack %v", i.Inode, i.getVer(), seq, string(debug.Stack()))
 	}
 	i.setVerDoWork(seq)
 }

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2530,7 +2530,7 @@ func (m *metadataManager) checkMultiVersionStatus(mp MetaPartition, p *Packet) (
 	}
 	// meta node do not need to check verSeq as strictly as datanode,file append or modAppendWrite on meta node is invisible to other files.
 	// only need to guarantee the verSeq wrote on meta nodes grow up linearly on client's angle
-	log.LogDebugf("action[checkmultiSnap.multiVersionstatus] mp ver %v, packet ver %v", mp.GetVerSeq(), p.VerSeq)
+	log.LogDebugf("action[checkmultiSnap.multiVersionstatus] mp %v ver %v, packet ver %v", mp.GetBaseConfig().PartitionId, mp.GetVerSeq(), p.VerSeq)
 	if mp.GetVerSeq() >= p.VerSeq {
 		if mp.GetVerSeq() > p.VerSeq {
 			log.LogDebugf("action[checkmultiSnap.multiVersionstatus] mp ver %v, packet ver %v", mp.GetVerSeq(), p.VerSeq)

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2544,7 +2544,7 @@ func (m *metadataManager) checkMultiVersionStatus(mp MetaPartition, p *Packet) (
 		_, err = mp.checkVerList(&proto.VolVersionInfoList{VerList: p.VerList}, true)
 		return
 	}
-	p.Opcode = proto.OpAgainVerionList
+	p.ResultCode = proto.OpAgainVerionList
 	// need return and tell client
 	err = fmt.Errorf("vol %v req seq %v but not found commit status", mp.GetVolName(), p.VerSeq)
 	if value, ok := m.volUpdating.Load(mp.GetVolName()); ok {

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -1559,6 +1560,20 @@ func TestGetAllVerList(t *testing.T) {
 			{Ver: 40, Status: proto.VersionNormal},
 			{Ver: 50, Status: proto.VersionNormal}},
 	}
+	tmp := mp.multiVersionList.VerList
+	mp.multiVersionList.VerList = append(mp.multiVersionList.VerList[:1], mp.multiVersionList.VerList[2:]...)
+	tmp = append(tmp, &proto.VolVersionInfo{Ver: 30, Status: proto.VersionNormal})
+
+	sort.SliceStable(tmp, func(i, j int) bool {
+		if tmp[i].Ver < tmp[j].Ver {
+			return true
+		}
+		return false
+	})
+
+	t.Logf("tmp %v", tmp)
+	t.Logf("mp.multiVersionList %v", mp.multiVersionList)
+
 	mp.multiVersionList.TemporaryVerMap = make(map[uint64]*proto.VolVersionInfo)
 	mp.multiVersionList.TemporaryVerMap[25] = &proto.VolVersionInfo{Ver: 25, Status: proto.VersionNormal}
 	mp.multiVersionList.TemporaryVerMap[45] = &proto.VolVersionInfo{Ver: 45, Status: proto.VersionNormal}

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -1549,3 +1549,21 @@ func TestMpMultiVerStore(t *testing.T) {
 	err := mp.loadMultiVer(filePath, crc)
 	assert.True(t, err == nil)
 }
+
+func TestGetAllVerList(t *testing.T) {
+	initMp(t)
+	mp.multiVersionList = &proto.VolVersionInfoList{
+		VerList: []*proto.VolVersionInfo{
+			{Ver: 20, Status: proto.VersionNormal},
+			{Ver: 30, Status: proto.VersionNormal},
+			{Ver: 40, Status: proto.VersionNormal},
+			{Ver: 50, Status: proto.VersionNormal}},
+	}
+	mp.multiVersionList.TemporaryVerMap = make(map[uint64]*proto.VolVersionInfo)
+	mp.multiVersionList.TemporaryVerMap[25] = &proto.VolVersionInfo{Ver: 25, Status: proto.VersionNormal}
+	mp.multiVersionList.TemporaryVerMap[45] = &proto.VolVersionInfo{Ver: 45, Status: proto.VersionNormal}
+	newList := mp.GetAllVerList()
+	oldList := mp.multiVersionList.VerList
+	t.Logf("newList %v oldList %v", newList, oldList)
+	assert.True(t, true)
+}

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -543,14 +543,21 @@ func (mp *metaPartition) acucumUidSizeByLoad(ino *Inode) {
 func (mp *metaPartition) GetVerList() []*proto.VolVersionInfo {
 	mp.multiVersionList.RLock()
 	defer mp.multiVersionList.RUnlock()
-	return mp.multiVersionList.VerList
+
+	verList := make([]*proto.VolVersionInfo, len(mp.multiVersionList.VerList))
+	copy(verList, mp.multiVersionList.VerList)
+
+	return verList
 }
 
 // include TemporaryVerMap or else cann't recycle temporary version after restart
 func (mp *metaPartition) GetAllVerList() (verList []*proto.VolVersionInfo) {
 	mp.multiVersionList.RLock()
 	defer mp.multiVersionList.RUnlock()
-	verList = mp.multiVersionList.VerList
+
+	verList = make([]*proto.VolVersionInfo, len(mp.multiVersionList.VerList))
+	copy(verList, mp.multiVersionList.VerList)
+
 	for _, verInfo := range mp.multiVersionList.TemporaryVerMap {
 		verList = append(verList, verInfo)
 	}

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -213,7 +213,14 @@ func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoLis
 			if verInfo.Ver == verSeq {
 				log.LogInfof("checkVerList.updateVerList vol %v mp %v ver info %v be consider as TemporaryVer and do deletion verlist %v",
 					mp.config.VolName, mp.config.PartitionId, verInfo, mp.multiVersionList.VerList)
-				mp.multiVersionList.VerList = append(mp.multiVersionList.VerList[:index], mp.multiVersionList.VerList[index+1:]...)
+				if index == len(mp.multiVersionList.VerList)-1 {
+					log.LogErrorf("checkVerList.updateVerList vol %v mp %v last ver info %v should not be consider as TemporaryVer and do deletion verlist %v",
+						mp.config.VolName, mp.config.PartitionId, verInfo, mp.multiVersionList.VerList)
+					return
+				} else {
+					mp.multiVersionList.VerList = append(mp.multiVersionList.VerList[:index], mp.multiVersionList.VerList[index+1:]...)
+				}
+
 				log.LogInfof("checkVerList.updateVerList vol %v mp %v verlist %v", mp.config.VolName, mp.config.PartitionId, mp.multiVersionList.VerList)
 				break
 			}

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -214,7 +214,7 @@ func (mp *metaPartition) checkByMasterVerlist(mpVerList *proto.VolVersionInfoLis
 				log.LogInfof("checkVerList.updateVerList vol %v mp %v ver info %v be consider as TemporaryVer and do deletion verlist %v",
 					mp.config.VolName, mp.config.PartitionId, verInfo, mp.multiVersionList.VerList)
 				if index == len(mp.multiVersionList.VerList)-1 {
-					log.LogErrorf("checkVerList.updateVerList vol %v mp %v last ver info %v should not be consider as TemporaryVer and do deletion verlist %v",
+					log.LogInfof("checkVerList.updateVerList vol %v mp %v last ver info %v should not be consider as TemporaryVer and do deletion verlist %v",
 						mp.config.VolName, mp.config.PartitionId, verInfo, mp.multiVersionList.VerList)
 					return
 				} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix(client): An abnormal condition occurs when the metanode triggers clients to make verlist requests again.
update(master):disable print stack of mps lock for dead lock debug
fix(metanode):enable metanode ttl clear tempory snapshot
enhance(master): mp migrate need limit the parrallel count