### PR TITLE
bugfix(datanode): fix datanode raft snapshot exceed the limit

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1748,7 +1748,11 @@ result:
 func (c *Cluster) dataNode(addr string) (dataNode *DataNode, err error) {
 	value, ok := c.dataNodes.Load(addr)
 	if !ok {
-		err = errors.Trace(dataNodeNotFound(addr), "%v not found", addr)
+		if !c.IsLeader() {
+			err = errors.New("meta data for data nodes is cleared due to leader change!")
+		} else {
+			err = errors.Trace(dataNodeNotFound(addr), "%v not found", addr)
+		}
 		return
 	}
 
@@ -1759,7 +1763,11 @@ func (c *Cluster) dataNode(addr string) (dataNode *DataNode, err error) {
 func (c *Cluster) metaNode(addr string) (metaNode *MetaNode, err error) {
 	value, ok := c.metaNodes.Load(addr)
 	if !ok {
-		err = errors.Trace(metaNodeNotFound(addr), "%v not found", addr)
+		if !c.IsLeader() {
+			err = errors.New("meta data for meta nodes is cleared due to leader change!")
+		} else {
+			err = errors.Trace(metaNodeNotFound(addr), "%v not found", addr)
+		}
 		return
 	}
 	metaNode = value.(*MetaNode)

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -807,9 +807,8 @@ func (s *Streamer) doAppendWrite(data []byte, offset, size int, direct bool, reU
 				continue
 			}
 			ek, err = s.handler.write(data, offset, size, direct)
-			ek.SetSeq(s.verSeq)
-
 			if err == nil && ek != nil {
+				ek.SetSeq(s.verSeq)
 				if !s.dirty {
 					s.dirtylist.Put(s.handler)
 					s.dirty = true


### PR DESCRIPTION
**What this PR does / why we need it**:
If the DP offline operation triggers Raft to synchronize WAL logs through snashot, it will cause an infinite loop when generating the snashot iterator
