### PR TITLE
fix(metanode/sdk): snapshot related bugs and enhancement

### DIFF
--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -83,7 +83,7 @@ func (s *DataNode) OperatePacket(p *repl.Packet, c net.Conn) (err error) {
 		tpLabels map[string]string
 		tpObject *exporter.TimePointCount
 	)
-
+	log.LogDebugf("action[OperatePacket] %v, pack [%v]", p.GetOpMsg(), p)
 	shallDegrade := p.ShallDegrade()
 	sz := p.Size
 	if !shallDegrade {

--- a/docker/conf/metanode.json
+++ b/docker/conf/metanode.json
@@ -12,6 +12,7 @@
   "totalMem": "536870912",
   "metadataDir": "/cfs/data/meta",
   "raftDir": "/cfs/data/raft",
+  "retainLogs": "100",
   "masterAddr": [
     "192.168.0.11:17010",
     "192.168.0.12:17010",

--- a/master/gapi_user.go
+++ b/master/gapi_user.go
@@ -2,6 +2,8 @@ package master
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util/log"
@@ -347,8 +349,13 @@ func (s *UserService) validatePassword(ctx context.Context, args struct {
 	if err != nil {
 		return nil, err
 	}
+	hashedPassword := sha256.Sum256([]byte(args.Password))
+	hashedPasswordStr := hex.EncodeToString(hashedPassword[:])
 
-	if ak.Password != args.Password {
+	hashedPassword_ := sha256.Sum256([]byte(ak.Password))
+	hashedPasswordStr_ := hex.EncodeToString(hashedPassword_[:])
+
+	if hashedPasswordStr != hashedPasswordStr_ {
 		log.LogWarnf("user:[%s] login pass word has err", args.UserID)
 		return nil, fmt.Errorf("user or password has err")
 	}

--- a/metanode/const.go
+++ b/metanode/const.go
@@ -185,6 +185,8 @@ const (
 
 	opFSMSentToChanV1 = 71
 	opFSMStoreTickV1  = 72
+
+	opFSMVerListSnapShot = 73
 )
 
 var (

--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -71,6 +71,13 @@ func (d *Dentry) getSnapListLen() int {
 	return len(d.multiSnap.dentryList)
 }
 
+func (d *Dentry) addVersion(ver uint64) {
+	dn := d.CopyDirectly().(*Dentry)
+	dn.setVerSeq(d.getSeqFiled())
+	d.setVerSeq(ver)
+	d.multiSnap.dentryList = append([]*Dentry{dn}, d.multiSnap.dentryList...)
+}
+
 func (d *Dentry) setVerSeq(verSeq uint64) {
 	if verSeq == 0 {
 		return

--- a/metanode/extend.go
+++ b/metanode/extend.go
@@ -61,14 +61,14 @@ func (e *Extend) GetExtentByVersion(ver uint64) (extend *Extend) {
 		return e
 	}
 	if isInitSnapVer(ver) {
-		if e.multiVers[0].verSeq != 0 {
+		if e.GetMinVer() != 0 {
 			return nil
 		}
-		return e.multiVers[0]
+		return e.multiVers[len(e.multiVers)-1]
 	}
 	e.versionMu.RLock()
 	defer e.versionMu.RUnlock()
-	for i := len(e.multiVers) - 1; i >= 0; i-- {
+	for i := 0; i < len(e.multiVers)-1; i++ {
 		if e.multiVers[i].verSeq <= ver {
 			return e.multiVers[i]
 		}

--- a/metanode/manager.go
+++ b/metanode/manager.go
@@ -397,12 +397,15 @@ func (m *metadataManager) loadPartitions() (err error) {
 	for i := 0; i < 3; i++ {
 		if metaNodeInfo, err = masterClient.NodeAPI().GetMetaNode(fmt.Sprintf("%s:%s", m.metaNode.localAddr,
 			m.metaNode.listen)); err != nil {
-			log.LogErrorf("loadPartitions: get MetaNode info fail: err(%v)", err)
+			log.LogWarnf("loadPartitions: get MetaNode info fail: err(%v)", err)
 			continue
 		}
 		break
 	}
-
+	if err != nil {
+		log.LogErrorf("loadPartitions: get MetaNode info fail: err(%v)", err)
+		return
+	}
 	if len(metaNodeInfo.PersistenceMetaPartitions) == 0 {
 		log.LogWarnf("loadPartitions: length of PersistenceMetaPartitions is 0, ExpiredPartition check without effect")
 	}

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -15,6 +15,7 @@
 package metanode
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -356,7 +357,7 @@ func TestSplitKeyDeletion(t *testing.T) {
 			verSeq: splitSeq,
 		},
 	}
-
+	mp.verSeq = iTmp.getVer()
 	mp.fsmAppendExtentsWithCheck(iTmp, true)
 	assert.True(t, testGetSplitSize(t, fileIno) == 1)
 	assert.True(t, testGetEkRefCnt(t, fileIno, &initExt) == 4)
@@ -533,6 +534,7 @@ func TestAppendList(t *testing.T) {
 		},
 	}
 	t.Logf("split at middle multiSnap.multiVersions %v", ino.getLayerLen())
+	mp.verSeq = iTmp.getVer()
 	mp.fsmAppendExtentsWithCheck(iTmp, true)
 	t.Logf("split at middle multiSnap.multiVersions %v", ino.getLayerLen())
 
@@ -566,7 +568,7 @@ func TestAppendList(t *testing.T) {
 	t.Logf("split key:%v", splitKey)
 	getExtRsp = testGetExtList(t, ino, ino.getLayerVer(0))
 	t.Logf("split at middle multiSnap.multiVersions %v, extent %v, level 1 %v", ino.getLayerLen(), getExtRsp.Extents, ino.multiSnap.multiVersions[0].Extents.eks)
-
+	mp.verSeq = iTmp.getVer()
 	mp.fsmAppendExtentsWithCheck(iTmp, true)
 	t.Logf("split at middle multiSnap.multiVersions %v", ino.getLayerLen())
 	getExtRsp = testGetExtList(t, ino, ino.getLayerVer(0))
@@ -598,6 +600,7 @@ func TestAppendList(t *testing.T) {
 		},
 	}
 	t.Logf("split key:%v", splitKey)
+	mp.verSeq = iTmp.getVer()
 	mp.fsmAppendExtentsWithCheck(iTmp, true)
 
 	getExtRsp = testGetExtList(t, ino, ino.getLayerVer(0))
@@ -1580,5 +1583,23 @@ func TestGetAllVerList(t *testing.T) {
 	newList := mp.GetAllVerList()
 	oldList := mp.multiVersionList.VerList
 	t.Logf("newList %v oldList %v", newList, oldList)
+	assert.True(t, true)
+}
+
+func TestVerlistSnapshot(t *testing.T) {
+	verList := []*proto.VolVersionInfo{
+		{Ver: 20, Status: proto.VersionNormal},
+	}
+	var verListBuf1 []byte
+	var err error
+	if verListBuf1, err = json.Marshal(verList); err != nil {
+		return
+	}
+	t.Logf("mp.TestVerlistSnapshot  %v", verListBuf1)
+	var verList12 []*proto.VolVersionInfo
+	if err = json.Unmarshal(verListBuf1, &verList12); err != nil {
+		t.Logf("mp.TestVerlistSnapshot  err %v", err)
+	}
+	t.Logf("mp.TestVerlistSnapshot  %v", verList12)
 	assert.True(t, true)
 }

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -1396,10 +1396,15 @@ func (mp *metaPartition) multiVersionTTLWork(dur time.Duration) {
 		case <-ttl.C:
 			log.LogDebugf("[multiVersionTTLWork] begin cache ttl, mp[%v]", mp.config.PartitionId)
 			mp.multiVersionList.RLock()
-			volVersionInfoList := &proto.VolVersionInfoList{
-				VerList:         mp.multiVersionList.VerList,
-				TemporaryVerMap: mp.multiVersionList.TemporaryVerMap,
+			var volVersionInfoList = &proto.VolVersionInfoList{
+				TemporaryVerMap: make(map[uint64]*proto.VolVersionInfo),
 			}
+			copy(volVersionInfoList.VerList, mp.multiVersionList.VerList)
+			for key, value := range mp.multiVersionList.TemporaryVerMap {
+				copiedValue := *value
+				volVersionInfoList.TemporaryVerMap[key] = &copiedValue
+			}
+
 			mp.multiVersionList.RUnlock()
 			for _, version := range volVersionInfoList.TemporaryVerMap {
 				if version.Status == proto.VersionDeleting {

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -266,7 +266,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 		log.LogDebugf("[deleteMarkedInodes] . mp %v inode [%v] inode.Extents: %v, ino verList: %v",
 			mp.config.PartitionId, ino, inode.Extents, inode.GetMultiVerString())
 
-		if inode.getLayerLen() > 1 {
+		if inode.getLayerLen() > 0 {
 			log.LogErrorf("[deleteMarkedInodes] deleteMarkedInodes. mp %v inode [%v] verlist len %v should not drop",
 				mp.config.PartitionId, ino, inode.getLayerLen())
 			return

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -100,7 +100,11 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 		if d.isDeleted() {
 			log.LogDebugf("action[fsmCreateDentry] mp %v newest dentry %v be set deleted flag", mp.config.PartitionId, d)
 			d.Inode = dentry.Inode
-			d.setVerSeq(dentry.getSeqFiled())
+			if d.getVerSeq() == dentry.getVerSeq() {
+				d.setVerSeq(dentry.getSeqFiled())
+			} else {
+				d.addVersion(dentry.getSeqFiled())
+			}
 			d.Type = dentry.Type
 			d.ParentId = dentry.ParentId
 			log.LogDebugf("action[fsmCreateDentry.ver] mp %v latest dentry already deleted.Now create new one [%v]", mp.config.PartitionId, dentry)

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -469,6 +469,11 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 	var (
 		delExtents []proto.ExtentKey
 	)
+	if mp.verSeq < ino.getVer() {
+		status = proto.OpArgMismatchErr
+		log.LogErrorf("fsmAppendExtentsWithCheck.mp %v param ino %v mp seq %v", mp.config.PartitionId, ino, mp.verSeq)
+		return
+	}
 	status = proto.OpOk
 	item := mp.inodeTree.CopyGet(ino)
 

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -354,8 +354,8 @@ func (p *Packet) GetCopy() *Packet {
 }
 
 func (p *Packet) String() string {
-	return fmt.Sprintf("ReqID(%v)Op(%v)PartitionID(%v)ResultCode(%v)ExID(%v)ExtOffset(%v)KernelOff(%v)Type(%v)Seq(%v)",
-		p.ReqID, p.GetOpMsg(), p.PartitionID, p.GetResultMsg(), p.ExtentID, p.ExtentOffset, p.KernelOffset, p.ExtentType, p.VerSeq)
+	return fmt.Sprintf("ReqID(%v)Op(%v)PartitionID(%v)ResultCode(%v)ExID(%v)ExtOffset(%v)KernelOff(%v)Type(%v)Seq(%v)Size(%v)",
+		p.ReqID, p.GetOpMsg(), p.PartitionID, p.GetResultMsg(), p.ExtentID, p.ExtentOffset, p.KernelOffset, p.ExtentType, p.VerSeq, p.Size)
 }
 
 // GetStoreType returns the store type.

--- a/sdk/data/stream/extent_cache.go
+++ b/sdk/data/stream/extent_cache.go
@@ -506,7 +506,7 @@ func (cache *ExtentCache) PrepareWriteRequests(offset, size int, data []byte) []
 	cache.root.DescendLessOrEqual(pivot, func(i btree.Item) bool {
 		ek := i.(*proto.ExtentKey)
 		lower.FileOffset = ek.FileOffset
-		// log.LogDebugf("action[ExtentCache.PrepareWriteRequests] ek [%v], pivot[%v]", ek, pivot)
+		log.LogDebugf("action[ExtentCache.PrepareWriteRequests] ek [%v], pivot[%v]", ek, pivot)
 		return false
 	})
 
@@ -515,7 +515,7 @@ func (cache *ExtentCache) PrepareWriteRequests(offset, size int, data []byte) []
 		ekStart := int(ek.FileOffset)
 		ekEnd := int(ek.FileOffset) + int(ek.Size)
 
-		// log.LogDebugf("PrepareWriteRequests: ino(%v) start(%v) end(%v) ekStart(%v) ekEnd(%v)", cache.inode, start, end, ekStart, ekEnd)
+		log.LogDebugf("action[ExtentCache.PrepareWriteRequests]: ino(%v) start(%v) end(%v) ekStart(%v) ekEnd(%v)", cache.inode, start, end, ekStart, ekEnd)
 
 		if start <= ekStart {
 			if end <= ekStart {
@@ -554,7 +554,7 @@ func (cache *ExtentCache) PrepareWriteRequests(offset, size int, data []byte) []
 		}
 	})
 
-	// log.LogDebugf("PrepareWriteRequests: ino(%v) start(%v) end(%v)", cache.inode, start, end)
+	log.LogDebugf("PrepareWriteRequests: ino(%v) start(%v) end(%v)", cache.inode, start, end)
 	if start < end {
 		// add hole (start, end)
 		req := NewExtentRequest(start, end-start, data[start-offset:end-offset], nil)

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -137,8 +137,8 @@ func NewExtentHandler(stream *Streamer, offset int, storeMode int, size int) *Ex
 
 // String returns the string format of the extent handler.
 func (eh *ExtentHandler) String() string {
-	return fmt.Sprintf("ExtentHandler{ID(%v)Inode(%v)FileOffset(%v)StoreMode(%v)Status(%v)Dp(%v)}",
-		eh.id, eh.inode, eh.fileOffset, eh.storeMode, eh.status, eh.dp)
+	return fmt.Sprintf("ExtentHandler{ID(%v)Inode(%v)FileOffset(%v)Size(%v)StoreMode(%v)Status(%v)Dp(%v)}",
+		eh.id, eh.inode, eh.fileOffset, eh.size, eh.storeMode, eh.status, eh.dp)
 }
 
 func (eh *ExtentHandler) write(data []byte, offset, size int, direct bool) (ek *proto.ExtentKey, err error) {
@@ -245,6 +245,9 @@ func (eh *ExtentHandler) sender() {
 			// For TinyStore, the extent offset is always 0 in the request packet,
 			// and the reply packet tells the real extent offset.
 			extOffset := int(packet.KernelOffset) - eh.fileOffset
+			if eh.key != nil {
+				extOffset += int(eh.key.ExtentOffset)
+			}
 
 			// fill the packet according to the extent
 			packet.PartitionID = eh.dp.PartitionID

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -577,6 +577,7 @@ func (s *Streamer) doDirectWriteByAppend(req *ExtentRequest, direct bool, op uin
 			log.LogErrorf("action[doDirectWriteByAppend] inode %v meta extent split process err %v", s.inode, err)
 			return
 		}
+		log.LogDebugf("action[doDirectWriteByAppend] handler fileoffset %v size %v key %v", s.handler.fileOffset, s.handler.size, s.handler.key)
 		// adjust the handler key to last direct write one
 		s.handler.fileOffset = int(extKey.FileOffset)
 		s.handler.size = int(extKey.Size)
@@ -717,6 +718,7 @@ func (s *Streamer) tryInitExtentHandlerByLastEk(offset, size int) (isLastEkVerNo
 			if isLastEkVerNotEqual {
 				seq = s.verSeq
 			}
+			log.LogDebugf("tryInitExtentHandlerByLastEk NewExtentHandler")
 			handler := NewExtentHandler(s, int(currentEK.FileOffset), storeMode, int(currentEK.Size))
 			handler.key = &proto.ExtentKey{
 				FileOffset:   currentEK.FileOffset,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

[fix(metanode):loadPartitions not check the result of calling master
fix(metanode):xattr read snapshot according verlist 
fix(metanode):add verlist to mp snapshot process 
enhance(client): reconstruct process of try init extentHandler by las… 
fix(metanode).inode with layer len large than 0 should be deleted 
fix(client): reuse the split key for streaming writes
fix(metanode):mmap concurrent access cause panic 

