### PR TITLE
Support config rotate size and head room 

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -55,6 +55,8 @@ const (
 	ConfigKeyRole              = "role"
 	ConfigKeyLogDir            = "logDir"
 	ConfigKeyLogLevel          = "logLevel"
+	ConfigKeyLogRotateSize     = "logRotateSize"
+	ConfigKeyLogRotateHeadRoom = "logRotateHeadRoom"
 	ConfigKeyProfPort          = "prof"
 	ConfigKeyWarnLogDir        = "warnLogDir"
 	ConfigKeyBuffersTotalLimit = "buffersTotalLimit"
@@ -161,6 +163,8 @@ func main() {
 	role := cfg.GetString(ConfigKeyRole)
 	logDir := cfg.GetString(ConfigKeyLogDir)
 	logLevel := cfg.GetString(ConfigKeyLogLevel)
+	logRotateSize := cfg.GetInt64(ConfigKeyLogRotateSize)
+	logRotateHeadRoom := cfg.GetInt64(ConfigKeyLogRotateHeadRoom)
 	profPort := cfg.GetString(ConfigKeyProfPort)
 	umpDatadir := cfg.GetString(ConfigKeyWarnLogDir)
 	buffersTotalLimit := cfg.GetInt64(ConfigKeyBuffersTotalLimit)
@@ -222,8 +226,14 @@ func main() {
 	default:
 		level = log.ErrorLevel
 	}
-
-	_, err = log.InitLog(logDir, module, level, nil, logLeftSpaceLimit)
+	rotate := log.NewLogRotate()
+	if logRotateSize > 0 {
+		rotate.SetRotateSizeMb(logRotateSize)
+	}
+	if logRotateHeadRoom > 0 {
+		rotate.SetHeadRoomMb(logRotateHeadRoom)
+	}
+	_, err = log.InitLog(logDir, module, level, rotate, logLeftSpaceLimit)
 	if err != nil {
 		err = errors.NewErrorf("Fatal: failed to init log - %v", err)
 		fmt.Println(err)

--- a/util/log/rotate.go
+++ b/util/log/rotate.go
@@ -15,10 +15,10 @@
 package log
 
 const (
-	// DefaultRollingSize Specifies at what size to roll the output log at
+	// DefaultRotateSize Specifies at what size to rotate the output log at
 	// Units: byte
-	DefaultRollingSize    = 1 * 1024 * 1024 * 1024
-	DefaultMinRollingSize = 200 * 1024 * 1024
+	DefaultRotateSize    = 1 * 1024 * 1024 * 1024
+	DefaultMinRotateSize = 200 * 1024 * 1024
 	// DefaultHeadRoom The tolerance for the log space limit (in megabytes)
 	DefaultHeadRoom = 50 * 1024
 	// DefaultHeadRatio The disk reserve space ratio
@@ -26,23 +26,23 @@ const (
 	DefaultLogLeftSpaceLimit = 5 * 1024
 )
 
-// A log can be rotated by the size or time.
+// LogRotate A log can be rotated by the size or time.
 type LogRotate struct {
-	rollingSize int64 // the size of the rotated log // TODO we should either call rotate or rolling, but not both.
-	headRoom    int64 // capacity reserved for writing the next log on the disk
+	rotateSize int64 // the size of the rotated log
+	headRoom   int64 // capacity reserved for writing the next log on the disk
 }
 
 // NewLogRotate returns a new LogRotate instance.
 func NewLogRotate() *LogRotate {
 	return &LogRotate{
-		rollingSize: DefaultRollingSize,
-		headRoom:    DefaultHeadRoom,
+		rotateSize: DefaultRotateSize,
+		headRoom:   DefaultHeadRoom,
 	}
 }
 
-// SetRollingSizeMb sets the rolling size in terms of MB.
-func (r *LogRotate) SetRollingSizeMb(size int64) {
-	r.rollingSize = size
+// SetRotateSizeMb sets the rotate size in terms of MB.
+func (r *LogRotate) SetRotateSizeMb(size int64) {
+	r.rotateSize = size
 }
 
 // SetHeadRoomMb sets the headroom in terms of MB.

--- a/util/log/rotate.go
+++ b/util/log/rotate.go
@@ -34,10 +34,7 @@ type LogRotate struct {
 
 // NewLogRotate returns a new LogRotate instance.
 func NewLogRotate() *LogRotate {
-	return &LogRotate{
-		rotateSize: DefaultRotateSize,
-		headRoom:   DefaultHeadRoom,
-	}
+	return &LogRotate{}
 }
 
 // SetRotateSizeMb sets the rotate size in terms of MB.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- unify 'rotate' and 'rolling' into 'rotate'
- **support config rotate size and head room**

**Which issue this PR fixes**:
fixes: #1909

**Special notes for your reviewer**:

It seems 'log automatically scrolls when there is not enough space' already has been implemented.
