### PR TITLE
feat(trace): change trace id generator to maphash

### DIFF
--- a/blobstore/common/trace/span_context.go
+++ b/blobstore/common/trace/span_context.go
@@ -16,9 +16,8 @@ package trace
 
 import (
 	"fmt"
-	"math/rand"
+	"hash/maphash"
 	"sync"
-	"time"
 )
 
 const (
@@ -32,17 +31,9 @@ func (id ID) String() string {
 	return fmt.Sprintf("%016x", uint64(id))
 }
 
-var (
-	seededIDGen = rand.New(rand.NewSource(time.Now().UnixNano()))
-	// The golang rand generators are *not* intrinsically thread-safe.
-	seededIDLock sync.Mutex
-)
-
 // RandomID generate ID for traceID or spanID
 func RandomID() ID {
-	seededIDLock.Lock()
-	defer seededIDLock.Unlock()
-	return ID(seededIDGen.Int63())
+	return ID(new(maphash.Hash).Sum64())
 }
 
 // SpanContext implements opentracing.SpanContext

--- a/blobstore/common/trace/span_test.go
+++ b/blobstore/common/trace/span_test.go
@@ -17,6 +17,9 @@ package trace
 import (
 	"context"
 	"errors"
+	"hash/maphash"
+	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -307,4 +310,20 @@ func TestSpan_FinishWithOptions(t *testing.T) {
 			{Timestamp: time.Now()},
 		},
 	})
+}
+
+func Benchmark_RandomID_RandLock(b *testing.B) {
+	var l sync.Mutex
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for ii := 0; ii < b.N; ii++ {
+		l.Lock()
+		r.Uint64()
+		l.Unlock()
+	}
+}
+
+func Benchmark_RandomID_Maphash(b *testing.B) {
+	for ii := 0; ii < b.N; ii++ {
+		new(maphash.Hash).Sum64()
+	}
 }


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/cubefs/cubefs/blobstore/common/trace cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
Benchmark_RandomID_RandLock
Benchmark_RandomID_RandLock-4           83533698                14.94 ns/op            0 B/op          0 allocs/op
Benchmark_RandomID_Maphash
Benchmark_RandomID_Maphash-4            194972664                5.965 ns/op           0 B/op          0 allocs/op
```

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
