### PR TITLE
[Fix]: Audit log performance problem

### DIFF
--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -945,7 +945,9 @@ func newVolSetAuditLogCmd(client *master.MasterClient) *cobra.Command {
 			settingStr := args[1]
 			var err error
 			defer func() {
-				errout("Error:%v", err)
+				if err != nil {
+					errout("Error:%v", err)
+				}
 			}()
 			enable, err := strconv.ParseBool(settingStr)
 			if err != nil {

--- a/util/auditlog/auditlog.go
+++ b/util/auditlog/auditlog.go
@@ -117,7 +117,7 @@ type Audit struct {
 	stopC            chan struct{}
 	resetWriterBuffC chan int
 	pid              int
-	lock             sync.Mutex
+	lock             sync.RWMutex
 }
 
 var gAdt *Audit = nil
@@ -335,8 +335,8 @@ func (a *Audit) ResetWriterBufferSize(size int) {
 }
 
 func (a *Audit) AddLog(content string) {
-	a.lock.Lock()
-	defer a.lock.Unlock()
+	a.lock.RLock()
+	defer a.lock.RUnlock()
 	select {
 	case a.bufferC <- content:
 		return
@@ -427,8 +427,8 @@ func ResetWriterBufferSize(size int) {
 }
 
 func AddLog(content string) {
-	gAdtMutex.Lock()
-	defer gAdtMutex.Unlock()
+	gAdtMutex.RLock()
+	defer gAdtMutex.RUnlock()
 	if gAdt == nil {
 		return
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Avoid `sync.Mutex` in `Audit`.
* Using `RLock` instead of `Lock`.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
