### PR TITLE
fixbug(datannode,master,client): fix server bugs

### DIFF
--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 
@@ -196,9 +197,10 @@ func (si *ItemIterator) Close() {
 
 // Next returns the next item in the iterator.
 func (si *ItemIterator) Next() (data []byte, err error) {
-	appIDBuf := make([]byte, 8)
-	binary.BigEndian.PutUint64(appIDBuf, si.applyID)
-	data = appIDBuf[:]
+	//appIDBuf := make([]byte, 8)
+	//binary.BigEndian.PutUint64(appIDBuf, si.applyID)
+	//data = appIDBuf[:]
+	err = io.EOF
 	return
 }
 

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1748,7 +1748,11 @@ result:
 func (c *Cluster) dataNode(addr string) (dataNode *DataNode, err error) {
 	value, ok := c.dataNodes.Load(addr)
 	if !ok {
-		err = errors.Trace(dataNodeNotFound(addr), "%v not found", addr)
+		if !c.IsLeader() {
+			err = errors.New("meta data for data nodes is cleared due to leader change!")
+		} else {
+			err = errors.Trace(dataNodeNotFound(addr), "%v not found", addr)
+		}
 		return
 	}
 
@@ -1759,7 +1763,11 @@ func (c *Cluster) dataNode(addr string) (dataNode *DataNode, err error) {
 func (c *Cluster) metaNode(addr string) (metaNode *MetaNode, err error) {
 	value, ok := c.metaNodes.Load(addr)
 	if !ok {
-		err = errors.Trace(metaNodeNotFound(addr), "%v not found", addr)
+		if !c.IsLeader() {
+			err = errors.New("meta data for meta nodes is cleared due to leader change!")
+		} else {
+			err = errors.Trace(metaNodeNotFound(addr), "%v not found", addr)
+		}
 		return
 	}
 	metaNode = value.(*MetaNode)

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -346,20 +346,13 @@ func (mp *metaPartition) fsmUnlinkInode(ino *Inode, uniqID uint64) (resp *InodeR
 
 	//Fix#760: when nlink == 0, push into freeList and delay delete inode after 7 days
 	if inode.IsTempFile() {
-		mp.updateUsedInfo(-1*int64(inode.Size), -1, inode.Inode)
-		inode.DoWriteFunc(func() {
-			if inode.NLink == 0 {
-				inode.AccessTime = time.Now().Unix()
-				mp.freeList.Push(inode.Inode)
-				mp.uidManager.doMinusUidSpace(inode.Uid, inode.Inode, inode.Size)
-			}
-		})
-
 		// all snapshot between create to last deletion cleaned
 		if inode.NLink == 0 && inode.getLayerLen() == 0 {
+			mp.updateUsedInfo(-1*int64(inode.Size), -1, inode.Inode)
 			log.LogDebugf("action[fsmUnlinkInode] mp %v unlink inode %v and push to freeList", mp.config.PartitionId, inode)
 			inode.AccessTime = time.Now().Unix()
 			mp.freeList.Push(inode.Inode)
+			mp.uidManager.doMinusUidSpace(inode.Uid, inode.Inode, inode.Size)
 			log.LogDebugf("action[fsmUnlinkInode] mp %v ino %v", mp.config.PartitionId, inode)
 		}
 	}

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -807,9 +807,8 @@ func (s *Streamer) doAppendWrite(data []byte, offset, size int, direct bool, reU
 				continue
 			}
 			ek, err = s.handler.write(data, offset, size, direct)
-			ek.SetSeq(s.verSeq)
-
 			if err == nil && ek != nil {
+				ek.SetSeq(s.verSeq)
 				if !s.dirty {
 					s.dirtylist.Put(s.handler)
 					s.dirty = true


### PR DESCRIPTION
**What this PR does / why we need it**:
1.fix datanode raft snapshot exceed the limit #2302
2.Add leader change infomation when data/meta node not found in memory
3.link of inode count minus wrongly caused by code merge
4.ExtentHandler write may need serveral times and ek maybe nil before success

