### PR TITLE
[Fix]: Decommissioned disk is still shown in datanode

### DIFF
--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -26,6 +26,7 @@ const (
 	CliOpSet                  = "set"
 	CliOpUpdate               = "update"
 	CliOpDecommission         = "decommission"
+	CliOpRecommission         = "recommission"
 	CliOpMigrate              = "migrate"
 	CliOpDownloadZip          = "load"
 	CliOpMetaCompatibility    = "meta"

--- a/cli/cmd/disk.go
+++ b/cli/cmd/disk.go
@@ -22,6 +22,7 @@ func newDiskCmd(client *master.MasterClient) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newListBadDiskCmd(client),
+		newDecommissionDiskCmd(client),
 	)
 	return cmd
 }
@@ -54,6 +55,29 @@ func newListBadDiskCmd(client *master.MasterClient) *cobra.Command {
 			for _, disk := range infos.BadDisks {
 				stdout("%v\n", formatBadDiskInfoRow(disk))
 			}
+		},
+	}
+	return cmd
+}
+
+const (
+	cmdDecommissionDisksShort = "Decommission disk on datanode"
+)
+
+func newDecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   CliOpDecommission + " [DATA NODE ADDR] [DISK]",
+		Short: cmdDecommissionDisksShort,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			defer func() {
+				errout(err)
+			}()
+			if err = client.AdminAPI().DecommissionDisk(args[0], args[1]); err != nil {
+				return
+			}
+			stdout("Mark disk %v:%v to be decommissioned", args[0], args[1])
 		},
 	}
 	return cmd

--- a/cli/cmd/disk.go
+++ b/cli/cmd/disk.go
@@ -23,6 +23,7 @@ func newDiskCmd(client *master.MasterClient) *cobra.Command {
 	cmd.AddCommand(
 		newListBadDiskCmd(client),
 		newDecommissionDiskCmd(client),
+		newRecommissionDiskCmd(client),
 	)
 	return cmd
 }
@@ -78,6 +79,29 @@ func newDecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
 				return
 			}
 			stdout("Mark disk %v:%v to be decommissioned", args[0], args[1])
+		},
+	}
+	return cmd
+}
+
+const (
+	cmdRecommissionDisksShort = "Recommission disk on datanode"
+)
+
+func newRecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   CliOpRecommission + " [DATA NODE ADDR] [DISK]",
+		Short: cmdRecommissionDisksShort,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			defer func() {
+				errout(err)
+			}()
+			if err = client.AdminAPI().RecommissionDisk(args[0], args[1]); err != nil {
+				return
+			}
+			stdout("Mark disk %v:%v to be recommissioned", args[0], args[1])
 		},
 	}
 	return cmd

--- a/datanode/server_handler.go
+++ b/datanode/server_handler.go
@@ -36,27 +36,29 @@ func (s *DataNode) getDiskAPI(w http.ResponseWriter, r *http.Request) {
 	disks := make([]interface{}, 0)
 	for _, diskItem := range s.space.GetDisks() {
 		disk := &struct {
-			Path        string `json:"path"`
-			Total       uint64 `json:"total"`
-			Used        uint64 `json:"used"`
-			Available   uint64 `json:"available"`
-			Unallocated uint64 `json:"unallocated"`
-			Allocated   uint64 `json:"allocated"`
-			Status      int    `json:"status"`
-			RestSize    uint64 `json:"restSize"`
-			DiskRdoSize uint64 `json:"diskRdoSize"`
-			Partitions  int    `json:"partitions"`
+			Path         string `json:"path"`
+			Total        uint64 `json:"total"`
+			Used         uint64 `json:"used"`
+			Available    uint64 `json:"available"`
+			Unallocated  uint64 `json:"unallocated"`
+			Allocated    uint64 `json:"allocated"`
+			Status       int    `json:"status"`
+			RestSize     uint64 `json:"restSize"`
+			DiskRdoSize  uint64 `json:"diskRdoSize"`
+			Partitions   int    `json:"partitions"`
+			Decommission bool   `json:"decommission"`
 		}{
-			Path:        diskItem.Path,
-			Total:       diskItem.Total,
-			Used:        diskItem.Used,
-			Available:   diskItem.Available,
-			Unallocated: diskItem.Unallocated,
-			Allocated:   diskItem.Allocated,
-			Status:      diskItem.Status,
-			RestSize:    diskItem.ReservedSpace,
-			DiskRdoSize: diskItem.DiskRdonlySpace,
-			Partitions:  diskItem.PartitionCount(),
+			Path:         diskItem.Path,
+			Total:        diskItem.Total,
+			Used:         diskItem.Used,
+			Available:    diskItem.Available,
+			Unallocated:  diskItem.Unallocated,
+			Allocated:    diskItem.Allocated,
+			Status:       diskItem.Status,
+			RestSize:     diskItem.ReservedSpace,
+			DiskRdoSize:  diskItem.DiskRdonlySpace,
+			Partitions:   diskItem.PartitionCount(),
+			Decommission: diskItem.GetDecommissionStatus(),
 		}
 		disks = append(disks, disk)
 	}

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -431,7 +431,6 @@ func (manager *SpaceManager) DeletePartition(dpID uint64) {
 
 	delete(manager.partitions, dpID)
 	manager.partitionMutex.Unlock()
-
 	dp.Stop()
 	dp.Disk().DetachDataPartition(dp)
 	os.RemoveAll(dp.Path())

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2733,7 +2733,6 @@ func (c *Cluster) deleteDataReplica(dp *DataPartition, dataNode *DataNode) (err 
 		dp.Unlock()
 		return
 	}
-
 	task := dp.createTaskToDeleteDataPartition(dataNode.Addr)
 	dp.Unlock()
 

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -266,6 +266,7 @@ func (dataNode *DataNode) createHeartbeatTask(masterAddr string, enableDiskQos b
 	request.QosIopsWriteLimit = dataNode.QosIopsWLimit
 	request.QosFlowReadLimit = dataNode.QosFlowRLimit
 	request.QosFlowWriteLimit = dataNode.QosFlowWLimit
+	request.DecommissionDisks = dataNode.getDecommissionedDisks()
 
 	task = proto.NewAdminTask(proto.OpDataNodeHeartbeat, dataNode.Addr, request)
 	return

--- a/master/topology.go
+++ b/master/topology.go
@@ -2267,6 +2267,7 @@ func (l *DecommissionDataPartitionList) traverse(c *Cluster) {
 					dp.ResetDecommissionStatus()
 					c.syncUpdateDataPartition(dp)
 				} else if dp.IsMarkDecommission() && dp.TryAcquireDecommissionToken(c) {
+					// TODO: decommission in here
 					go func(dp *DataPartition) {
 						if !dp.TryToDecommission(c) {
 							//retry should release token

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -601,8 +601,9 @@ type HeartBeatRequest struct {
 	UidLimitToMetaNode
 	QuotaHeartBeatInfos
 	TxInfos
-	ForbiddenVols    []string
-	DisableAuditVols []string
+	ForbiddenVols     []string
+	DisableAuditVols  []string
+	DecommissionDisks []string // NOTE: for datanode
 }
 
 // DataPartitionReport defines the partition report.

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -833,6 +833,16 @@ func (api *AdminAPI) QueryBadDisks() (badDisks *proto.BadDiskInfos, err error) {
 	return
 }
 
+func (api *AdminAPI) DecommissionDisk(addr string, disk string) (err error) {
+	request := newAPIRequest(http.MethodPost, proto.DecommissionDisk)
+	request.params["addr"] = addr
+	request.params["disk"] = disk
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) ListQuotaAll() (volsInfo []*proto.VolInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.QuotaListAll)
 	var data []byte

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -843,6 +843,16 @@ func (api *AdminAPI) DecommissionDisk(addr string, disk string) (err error) {
 	return
 }
 
+func (api *AdminAPI) RecommissionDisk(addr string, disk string) (err error) {
+	request := newAPIRequest(http.MethodPost, proto.RecommissionDisk)
+	request.params["addr"] = addr
+	request.params["disk"] = disk
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) ListQuotaAll() (volsInfo []*proto.VolInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.QuotaListAll)
 	var data []byte


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Add a status `decommission` to `Disk`. 
* When we change `decommission`, we create/remove a `decommissionMark` file in `disk.Path`.
* If a disk is decommissioned, it will not shown in datanode `/disks` API.
* Master synchronous `DecommissionDisks` with datanode using `HearBeatRequest`.
* Cli support decommission disk.
* Cli support to recommission disk.

**Effects:**

_Before decommission:_

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~]
└─$ curl -v "http://172.16.1.101:8080/disks"
*   Trying 172.16.1.101:8080...
* Connected to 172.16.1.101 (172.16.1.101) port 8080
> GET /disks HTTP/1.1
> Host: 172.16.1.101:8080
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sat, 25 Nov 2023 11:12:44 GMT
< Content-Length: 278
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host 172.16.1.101 left intact
{"code":200,"data":{"disks":[{"path":"/home/nature/disk/data1/disk","total":1075732467712,"used":92347719680,"available":928392392704,"unallocated":1075732467712,"allocated":0,"status":2,"restSize":5368709120,"diskRdoSize":5368709120,"partitions":0}],"zone":"default"},"msg":""}
```

_Decommission a disk:_

```log
┌──(root💀LAPTOP-9TS0FG11)-[/home/nature/cubefs]
└─# ./build/bin/cfs-cli disk decommission 172.16.1.101:17310 /home/nature/disk/data1/disk
Mark disk 172.16.1.101:17310:/home/nature/disk/data1/disk to be decommissioned
```

_Request agagin:_

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~]
└─$ curl -v "http://172.16.1.101:8080/disks"
*   Trying 172.16.1.101:8080...
* Connected to 172.16.1.101 (172.16.1.101) port 8080
> GET /disks HTTP/1.1
> Host: 172.16.1.101:8080
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sat, 25 Nov 2023 11:25:08 GMT
< Content-Length: 58
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host 172.16.1.101 left intact
{"code":200,"data":{"disks":[],"zone":"default"},"msg":""}
```

_Debug logs in datanode:_

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/cubefs]
└─$ cat ~/disk/data1/logs/dataNode/dataNode_debug.log | grep checkDecommissionDisks
2023/11/25 19:24:41.612681 [DEBUG] wrap_operator.go:489: action[checkDecommissionDisks] mark /home/nature/disk/data1/disk to be decommissioned
```


*Recommission:*

```log
┌──(root💀LAPTOP-9TS0FG11)-[/home/nature/cubefs]
└─# ./build/bin/cfs-cli disk recommission 172.16.1.101:17310 /home/nature/disk/data1/disk
Mark disk 172.16.1.101:17310:/home/nature/disk/data1/disk to be recommissioned
```

*Debug logs in datanode:*

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/cubefs]
└─$ cat ~/disk/data1/logs/dataNode/dataNode_debug.log | grep checkDecommissionDisks
2023/12/11 11:19:25.434175 [DEBUG] wrap_operator.go:488: action[checkDecommissionDisks] mark /home/nature/disk/data1/disk to be decommissioned
2023/12/11 11:19:37.434252 [DEBUG] wrap_operator.go:483: action[checkDecommissionDisks] mark /home/nature/disk/data1/disk to be undecommissioned
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2777


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
