### PR TITLE
feat(data): add an API to manually set a disk of dataNode as error. t…

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -359,6 +359,11 @@ func (d *Disk) CheckDiskError(err error, rwFlag uint8) {
 	d.triggerDiskError(rwFlag, DiskErrNotAssociatedWithPartition)
 }
 
+func (d *Disk) doDiskError() {
+	d.Status = proto.Unavailable
+	d.ForceExitRaftStore()
+}
+
 func (d *Disk) triggerDiskError(rwFlag uint8, dpId uint64) {
 	mesg := fmt.Sprintf("disk path %v error on %v, dpId %v", d.Path, LocalIP, dpId)
 	exporter.Warning(mesg)
@@ -383,8 +388,7 @@ func (d *Disk) triggerDiskError(rwFlag uint8, dpId uint64) {
 			d.Path, LocalIP, diskErrCnt, d.dataNode.diskUnavailableErrorCount, diskErrPartitionCnt, d.dataNode.diskUnavailablePartitionErrorCount)
 		exporter.Warning(msg)
 		log.LogWarnf(msg)
-		d.Status = proto.Unavailable
-		d.ForceExitRaftStore()
+		d.doDiskError()
 	}
 }
 

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -627,6 +627,7 @@ func (s *DataNode) registerHandler() {
 	http.HandleFunc("/getMetricsDegrade", s.getMetricsDegrade)
 	http.HandleFunc("/qosEnable", s.setQosEnable())
 	http.HandleFunc("/genClusterVersionFile", s.genClusterVersionFile)
+	http.HandleFunc("/setDiskBad", s.setDiskBadAPI)
 }
 
 func (s *DataNode) startTCPService() (err error) {


### PR DESCRIPTION
…his operation will set disk status as unavailable and stop raft of all data partitions on the disk.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
