### PR TITLE
[Feature]: Master support Straw2 algorithm when select node and nodeset

### DIFF
--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -16,12 +16,14 @@ package master
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sort"
 	"sync"
 	"time"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util"
 	"github.com/cubefs/cubefs/util/log"
 )
 
@@ -32,6 +34,8 @@ const CarryWeightNodeSelectorName = "CarryWeight"
 const AvailableSpaceFirstNodeSelectorName = "AvailableSpaceFirst"
 
 const TicketNodeSelectorName = "Ticket"
+
+const StrawNodeSelectorName = "Straw"
 
 const DefaultNodeSelectorName = CarryWeightNodeSelectorName
 
@@ -607,6 +611,98 @@ func NewTicketNodeSelector(nodeType NodeType) *TicketNodeSelector {
 	}
 }
 
+const (
+	StrawNodeSelectorRandMax = 65536
+)
+
+// NOTE: this node selector inspired by Straw2 algorithm, which is widely used in ceph
+type StrawNodeSelector struct {
+	rand     *rand.Rand
+	nodeType NodeType
+}
+
+func (s *StrawNodeSelector) GetName() string {
+	return StrawNodeSelectorName
+}
+
+func (s *StrawNodeSelector) getWeight(node Node) float64 {
+	switch s.nodeType {
+	case DataNodeType:
+		dataNode := node.(*DataNode)
+		return float64(dataNode.AvailableSpace) / util.GB
+	case MetaNodeType:
+		metaNode := node.(*MetaNode)
+		return float64(metaNode.Total-metaNode.Used) / util.GB
+	default:
+		panic("unkown node type")
+	}
+}
+
+func (s *StrawNodeSelector) selectOneNode(nodes []Node) (index int, maxNode Node) {
+	maxStraw := float64(0)
+	index = -1
+	for i, node := range nodes {
+		straw := float64(s.rand.Intn(StrawNodeSelectorRandMax))
+		straw = math.Log(straw/float64(StrawNodeSelectorRandMax)) / s.getWeight(node)
+		if index == -1 || straw > maxStraw {
+			maxStraw = straw
+			maxNode = node
+			index = i
+		}
+	}
+	return
+}
+
+func (s *StrawNodeSelector) Select(ns *nodeSet, excludeHosts []string, replicaNum int) (newHosts []string, peers []proto.Peer, err error) {
+
+	nodes := make([]Node, 0)
+	ns.getNodes(s.nodeType).Range(func(key, value interface{}) bool {
+		node := asNodeWrap(value, s.nodeType)
+		if !contains(excludeHosts, node.GetAddr()) {
+			nodes = append(nodes, node)
+		}
+		return true
+	})
+	orderHosts := make([]string, 0)
+	for len(orderHosts) < replicaNum {
+		if len(nodes)+len(orderHosts) < replicaNum {
+			break
+		}
+		index, node := s.selectOneNode(nodes)
+		if index != 0 {
+			nodes[0], nodes[index] = node, nodes[0]
+		}
+		nodes = nodes[1:]
+		if !canAllocPartition(node, s.nodeType) {
+			continue
+		}
+		orderHosts = append(orderHosts, node.GetAddr())
+		node.SelectNodeForWrite()
+		peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr()}
+		peers = append(peers, peer)
+	}
+	// if we cannot get enough writable nodes, return error
+	if len(orderHosts) < replicaNum {
+		err = fmt.Errorf("action[%vNodeSelector::Select] no enough writable hosts,replicaNum:%v  MatchNodeCount:%v  ",
+			s.GetName(), replicaNum, len(orderHosts))
+		return
+	}
+	log.LogInfof("action[%vNodeSelector::Select] peers[%v]", s.GetName(), peers)
+	// reshuffle for primary-backup replication
+	if newHosts, err = reshuffleHosts(orderHosts); err != nil {
+		err = fmt.Errorf("action[%vNodeSelector::Select] err:%v  orderHosts is nil", s.GetName(), err.Error())
+		return
+	}
+	return
+}
+
+func NewStrawNodeSelector(nodeType NodeType) *StrawNodeSelector {
+	return &StrawNodeSelector{
+		rand:     rand.New(rand.NewSource(time.Now().UnixMicro())),
+		nodeType: nodeType,
+	}
+}
+
 func NewNodeSelector(name string, nodeType NodeType) NodeSelector {
 	switch name {
 	case RoundRobinNodeSelectorName:
@@ -617,6 +713,8 @@ func NewNodeSelector(name string, nodeType NodeType) NodeSelector {
 		return NewTicketNodeSelector(nodeType)
 	case AvailableSpaceFirstNodeSelectorName:
 		return NewAvailableSpaceFirstNodeSelector(nodeType)
+	case StrawNodeSelectorName:
+		return NewStrawNodeSelector(nodeType)
 	default:
 		return NewCarryWeightNodeSelector(nodeType)
 	}

--- a/master/node_selector_test.go
+++ b/master/node_selector_test.go
@@ -422,6 +422,67 @@ func TestAvailableSpaceFirstNodeSelector(t *testing.T) {
 	metaNode.Total = tmp
 }
 
+func TestStrawNodeSelector(t *testing.T) {
+	// get first node
+	dataNode := getFirstDataNodeForTest(t, testZone2)
+	metaNode := getFirstMetaNodeForTest(t, testZone2)
+	dataSelectTimes := make(map[uint64]int)
+	metaSelectTimes := make(map[uint64]int)
+	// prepare for datanode
+	tmp := dataNode.AvailableSpace
+	dataNode.Total += dataNode.AvailableSpace
+	dataNode.AvailableSpace *= 2
+	// select test
+	selector := NewStrawNodeSelector(DataNodeType)
+	for i := 0; i != loopNodeSelectorTestCount; i++ {
+		node := DataNodeSelectorTest(t, selector, nil)
+		if node == nil {
+			return
+		}
+		count, _ := dataSelectTimes[node.ID]
+		count += 1
+		dataSelectTimes[node.ID] = count
+	}
+	t.Logf("%v data node select times:\n", selector.GetName())
+	printNodeSelectTimes(t, dataSelectTimes)
+	count, _ := dataSelectTimes[dataNode.ID]
+	for _, c := range dataSelectTimes {
+		if count < c {
+			t.Errorf("%v failed to select data nodes", selector.GetName())
+			return
+		}
+	}
+	// restore status
+	dataNode.Total -= tmp
+	dataNode.AvailableSpace = tmp
+
+	// prepare for metanode
+	tmp = metaNode.Total
+	metaNode.Total *= 2
+	// select test
+	selector = NewStrawNodeSelector(MetaNodeType)
+	for i := 0; i != loopNodeSelectorTestCount; i++ {
+		node := MetaNodeSelectorTest(t, selector, nil)
+		if node == nil {
+			return
+		}
+		count, _ := metaSelectTimes[node.ID]
+		count += 1
+		metaSelectTimes[node.ID] = count
+	}
+	t.Logf("%v meta node select times:\n", selector.GetName())
+	printNodeSelectTimes(t, metaSelectTimes)
+	count, _ = metaSelectTimes[metaNode.ID]
+	for _, c := range metaSelectTimes {
+		if count < c {
+			t.Errorf("%v failed to select meta nodes", selector.GetName())
+			return
+		}
+	}
+	// restore status
+	metaNode.Total = tmp
+}
+
 func prepareDataNodesForBench(count int, initTotal uint64, grow uint64) (ns *nodeSet) {
 	ns = &nodeSet{
 		ID:               1,
@@ -478,12 +539,13 @@ func nodeSelectorBench(selector NodeSelector, nset *nodeSet, onSelect func(addr 
 		if err != nil {
 			return nil, err
 		}
-		peer := peers[0]
-		count, _ := times[peer.ID]
-		count += 1
-		times[peer.ID] = count
-		if onSelect != nil {
-			onSelect(peer.Addr)
+		for _, peer := range peers {
+			count, _ := times[peer.ID]
+			count += 1
+			times[peer.ID] = count
+			if onSelect != nil {
+				onSelect(peer.Addr)
+			}
 		}
 	}
 	return times, nil
@@ -542,5 +604,12 @@ func TestBenchCarryWeightNodeSelector(t *testing.T) {
 	selector := NewCarryWeightNodeSelector(DataNodeType)
 	dataNodeSelectorBench(t, selector)
 	selector = NewCarryWeightNodeSelector(MetaNodeType)
+	metaNodeSelectorBench(t, selector)
+}
+
+func TestBenchStrawNodeSelector(t *testing.T) {
+	selector := NewStrawNodeSelector(DataNodeType)
+	dataNodeSelectorBench(t, selector)
+	selector = NewStrawNodeSelector(MetaNodeType)
 	metaNodeSelectorBench(t, selector)
 }

--- a/master/nodeset_selector_test.go
+++ b/master/nodeset_selector_test.go
@@ -98,6 +98,13 @@ func TestAvailableSpaceFirstNodesetSelector(t *testing.T) {
 	NodesetSelectorTest(t, selector)
 }
 
+func TestStrawNodesetSelector(t *testing.T) {
+	selector := NewStrawNodesetSelector(DataNodeType)
+	NodesetSelectorTest(t, selector)
+	selector = NewStrawNodesetSelector(MetaNodeType)
+	NodesetSelectorTest(t, selector)
+}
+
 func prepareDataNodesetForBench(count int, initTotal uint64, grow uint64) (nsc nodeSetCollection) {
 	nsc = make(nodeSetCollection, 0, count)
 	for i := 0; i < count; i++ {
@@ -230,6 +237,21 @@ func TestBenchmarkTicketNodesetSelector(t *testing.T) {
 		return
 	}
 	selector = NewTicketNodesetSelector(MetaNodeType)
+	err = metaNodesetSelectorBench(t, selector)
+	if err != nil {
+		t.Errorf("%v nodeset selector failed to benchmark %v", selector.GetName(), err)
+		return
+	}
+}
+
+func TestBenchmarkStrawNodesetSelector(t *testing.T) {
+	selector := NewStrawNodesetSelector(DataNodeType)
+	err := dataNodesetSelectorBench(t, selector)
+	if err != nil {
+		t.Errorf("%v nodeset selector failed to benchmark %v", selector.GetName(), err)
+		return
+	}
+	selector = NewStrawNodesetSelector(MetaNodeType)
 	err = metaNodesetSelectorBench(t, selector)
 	if err != nil {
 		t.Errorf("%v nodeset selector failed to benchmark %v", selector.GetName(), err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* Straw2 is a selection algorithm which is widely used in Ceph.
* This pull request make cubefs support Straw2 algorithm.

**Effect:**
```log
=== RUN   TestBenchStrawNodeSelector
    node_selector_test.go:237: Node 3 select times 38
        Node 2 select times 31
        Node 1 select times 21
        Node 0 select times 10
        
    node_selector_test.go:47: Data Node 0
        	Total Space:102400 MB
        	Avaliable Space:45254 MB
        
    node_selector_test.go:47: Data Node 1
        	Total Space:204800 MB
        	Avaliable Space:95745 MB
        
    node_selector_test.go:47: Data Node 2
        	Total Space:307200 MB
        	Avaliable Space:144415 MB
        
    node_selector_test.go:47: Data Node 3
        	Total Space:409600 MB
        	Avaliable Space:218970 MB
        
    node_selector_test.go:237: Node 1 select times 21
        Node 2 select times 27
        Node 3 select times 41
        Node 0 select times 11
        
    node_selector_test.go:53: Meta Node 1
        	Total Space:204800 MB
        	Avaliable Space:86231 MB
        
    node_selector_test.go:53: Meta Node 2
        	Total Space:307200 MB
        	Avaliable Space:163373 MB
        
    node_selector_test.go:53: Meta Node 3
        	Total Space:409600 MB
        	Avaliable Space:190349 MB
        
    node_selector_test.go:53: Meta Node 0
        	Total Space:102400 MB
        	Avaliable Space:64432 MB
        
--- PASS: TestBenchStrawNodeSelector (0.00s)
PASS
ok  	github.com/cubefs/cubefs/master	15.967s
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
