### PR TITLE
 bugfix(metanode): fix log panic in function of deleteMarkedEBSInodes 

### DIFF
--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -390,7 +390,8 @@ func (mp *metaPartition) deleteMarkedEBSInodes(inoSlice []uint64) {
 			continue
 		}
 
-		log.LogDebugf("deleteMarkedEBSInodes. mp %v inode [%v] inode.Extents %v, ino verlist %v", mp.config.PartitionId, ino, inode.Extents, inode.multiSnap.multiVersions)
+		log.LogDebugf("deleteMarkedEBSInodes. mp %v inode [%v] inode.Extents %v, ino verlist %v",
+			mp.config.PartitionId, ino, inode.Extents, inode.GetMultiVerString())
 		if inode.getLayerLen() > 1 {
 			log.LogErrorf("deleteMarkedEBSInodes. mp %v inode [%v] verlist len %v should not drop",
 				mp.config.PartitionId, ino, inode.getLayerLen())


### PR DESCRIPTION
**What this PR does / why we need it**:
fix log panic in function of deleteMarkedEBSInodes

