### PR TITLE
bugfix(raft): fix a bug abount raft decode operation

### DIFF
--- a/depends/tiglabs/raft/proto/codec.go
+++ b/depends/tiglabs/raft/proto/codec.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -241,6 +241,9 @@ func (m *Message) Decode(r *util.BufferReader) error {
 		return err
 	}
 
+	if len(datas) == 0 {
+		return nil
+	}
 	ver := datas[0]
 	if ver == version1 {
 		m.Type = MsgType(datas[1])


### PR DESCRIPTION
**What this PR does / why we need it**:
When the length of the data is 0, return directly without further decoding