### PR TITLE
feat(util): Log flush output before crash

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -237,6 +237,15 @@ func main() {
 		os.Exit(1)
 	}
 	defer log.LogFlush()
+	if errors.SupportPanicHook() {
+		err = errors.AtPanic(func() {
+			log.LogFlush()
+		})
+		if err != nil {
+			log.LogErrorf("failed to hook go panic")
+			err = nil
+		}
+	}
 
 	_, err = auditlog.InitAudit(logDir, module, auditlog.DefaultAuditLogSize)
 	if err != nil {

--- a/util/errors/panichook.go
+++ b/util/errors/panichook.go
@@ -1,0 +1,89 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package errors
+
+import (
+	"runtime"
+	"sync"
+	_ "unsafe"
+
+	"github.com/brahma-adshonor/gohook"
+)
+
+var ErrUnsupportedArch = New("Unsupported arch")
+
+//go:linkname gopanic runtime.gopanic
+func gopanic(e interface{})
+
+var panicHook func()
+
+// NOTE: trampoline don't works
+var mu sync.Mutex
+
+func hookedPanic(e interface{}) {
+	mu.Lock()
+	defer mu.Unlock()
+	// NOTE: unhook before invoke hook function
+	gohook.UnHook(gopanic)
+	defer gohook.Hook(gopanic, hookedPanic, nil)
+	panicHook()
+	gopanic(e)
+}
+
+func AtPanic(hook func()) error {
+	if !SupportPanicHook() {
+		return ErrUnsupportedArch
+	}
+	panicHook = hook
+	return gohook.Hook(gopanic, hookedPanic, nil)
+}
+
+var (
+	oldToken = false
+	newToken = false
+)
+
+//go:noinline
+func setOldToken() {
+	oldToken = true
+}
+
+//go:noinline
+func setNewToken() {
+	newToken = true
+}
+
+func supportTest() (ok bool) {
+	err := gohook.Hook(setOldToken, setNewToken, nil)
+	if err != nil {
+		return
+	}
+	setOldToken()
+	err = gohook.UnHook(setOldToken)
+	if err != nil {
+		return
+	}
+	setOldToken()
+	ok = oldToken && newToken
+	return
+}
+
+func SupportPanicHook() (ok bool) {
+	switch runtime.GOARCH {
+	case "amd64", "386":
+		ok = supportTest()
+	}
+	return
+}

--- a/util/errors/panichook_test.go
+++ b/util/errors/panichook_test.go
@@ -1,0 +1,51 @@
+// Copyright 2023 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package errors_test
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/util/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPanicHook(t *testing.T) {
+	if !errors.SupportPanicHook() {
+		err := errors.AtPanic(func() {})
+		assert.EqualError(t, err, errors.ErrUnsupportedArch.Error())
+		return
+	}
+	token := false
+	defer func() {
+		r := recover()
+		if r != nil {
+			assert.True(t, token)
+		}
+	}()
+	err := errors.AtPanic(func() {
+		token = true
+	})
+	assert.NoError(t, err)
+	t.Logf("start panic")
+	panic("test")
+}
+
+const loopTestCount = 10
+
+func TestLoopPanicHook(t *testing.T) {
+	for i := 0; i != loopTestCount; i++ {
+		TestPanicHook(t)
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* Support hook `panic`.
* Flush log before crash(support by hook).

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #1910 

**Special notes for your reviewer**:

```log
┌──(nature㉿LAPTOP-9TS0FG11)-[~/cubefs]
└─$ ./build/bin/cfs-server -f -c ~/disk/conf/data1.conf 
panic: I'm panic

goroutine 71 [running]:
github.com/cubefs/cubefs/util/errors.hookedPanic({0x16d6a40, 0x1eec3f0})
        util/errors/panichook.go:38 +0x77
main.main.func2()
        cmd/cmd.go:251 +0x3f
created by main.main
        cmd/cmd.go:248 +0xd59

┌──(nature㉿LAPTOP-9TS0FG11)-[~/cubefs]
└─$ cat ~/disk/data1/logs/dataNode/dataNode_error.log 
2023/12/10 00:06:26.961475 [ERROR] cmd.go:250: You should see me in log file
```

**cmd.go:**
```go
func main() {
	flag.Parse()

	Version := proto.DumpVersion("Server")
	if *configVersion {
		fmt.Printf("%v", Version)
		os.Exit(0)
	}

	/*
	 * LoadConfigFile should be checked before start daemon, since it will
	 * call os.Exit() w/o notifying the parent process.
	 */
	cfg, err := config.LoadConfigFile(*configFile)
	if err != nil {
		daemonize.SignalOutcome(err)
		os.Exit(1)
	}

	if !*configForeground {
		if err := startDaemon(); err != nil {
			fmt.Printf("Server start failed: %v\n", err)
			os.Exit(1)
		}
		os.Exit(0)
	}

	/*
	 * We are in daemon from here.
	 * Must notify the parent process through SignalOutcome anyway.
	 */

	role := cfg.GetString(ConfigKeyRole)
	logDir := cfg.GetString(ConfigKeyLogDir)
	logLevel := cfg.GetString(ConfigKeyLogLevel)
	logRotateSize := cfg.GetInt64(ConfigKeyLogRotateSize)
	logRotateHeadRoom := cfg.GetInt64(ConfigKeyLogRotateHeadRoom)
	profPort := cfg.GetString(ConfigKeyProfPort)
	umpDatadir := cfg.GetString(ConfigKeyWarnLogDir)
	buffersTotalLimit := cfg.GetInt64(ConfigKeyBuffersTotalLimit)
	logLeftSpaceLimitStr := cfg.GetString(ConfigKeyLogLeftSpaceLimit)
	logLeftSpaceLimit, err := strconv.ParseInt(logLeftSpaceLimitStr, 10, 64)
	if err != nil || logLeftSpaceLimit == 0 {
		log.LogErrorf("logLeftSpaceLimit is not a legal int value: %v", err.Error())
		logLeftSpaceLimit = log.DefaultLogLeftSpaceLimit
	}
	// Init server instance with specified role configuration.
	var (
		server common.Server
		module string
	)
	switch role {
	case RoleMeta:
		server = metanode.NewServer()
		module = ModuleMeta
	case RoleMaster:
		server = master.NewServer()
		module = ModuleMaster
	case RoleData:
		server = datanode.NewServer()
		module = ModuleData
	case RoleAuth:
		server = authnode.NewServer()
		module = ModuleAuth
	case RoleObject:
		server = objectnode.NewServer()
		module = ModuleObject
	case RoleConsole:
		server = console.NewServer()
		module = ModuleConsole
	case RoleLifeCycle:
		server = lcnode.NewServer()
		module = ModuleLifeCycle
	default:
		err = errors.NewErrorf("Fatal: role mismatch: %s", role)
		fmt.Println(err)
		daemonize.SignalOutcome(err)
		os.Exit(1)
	}

	// Init logging
	var (
		level log.Level
	)
	switch strings.ToLower(logLevel) {
	case "debug":
		level = log.DebugLevel
	case "info":
		level = log.InfoLevel
	case "warn":
		level = log.WarnLevel
	case "error":
		level = log.ErrorLevel
	case "critical":
		level = log.CriticalLevel
	default:
		level = log.ErrorLevel
	}
	rotate := log.NewLogRotate()
	if logRotateSize > 0 {
		rotate.SetRotateSizeMb(logRotateSize)
	}
	if logRotateHeadRoom > 0 {
		rotate.SetHeadRoomMb(logRotateHeadRoom)
	}
	_, err = log.InitLog(logDir, module, level, rotate, logLeftSpaceLimit)
	if err != nil {
		err = errors.NewErrorf("Fatal: failed to init log - %v", err)
		fmt.Println(err)
		daemonize.SignalOutcome(err)
		os.Exit(1)
	}
	defer log.LogFlush()
	errors.AtPanic(func() {
		log.LogFlush()
	})
	go func() {

		log.LogErrorf("You should see me in log file")
		panic("I'm panic")
	}()
	time.Sleep(time.Second * 1)
        ...
}
```

Also see: [gohook](https://github.com/brahma-adshonor/gohook).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
