### PR TITLE
fix some bugs about wrong deletion duiring snapshot deletion and modification

### DIFF
--- a/master/filecheck.go
+++ b/master/filecheck.go
@@ -101,7 +101,14 @@ func (partition *DataPartition) checkExtentFile(fc *FileInCore, liveReplicas []*
 		return
 	}
 	fms, needRepair := fc.needCrcRepair(liveReplicas, getInfoCallback)
-
+	if !hasSameSize(fms) {
+		msg := fmt.Sprintf("CheckFileError size not match,cluster[%v],dpID[%v],", clusterID, partition.PartitionID)
+		for _, fm := range fms {
+			msg = msg + fmt.Sprintf("fm[%v]:size[%v]\n", fm.locIndex, fm.Size)
+		}
+		log.LogWarn(msg)
+		return
+	}
 	if len(fms) < len(liveReplicas) && (time.Now().Unix()-fc.LastModify) > intervalToCheckMissingReplica {
 		lastReportTime, ok := partition.FilesWithMissingReplica[fc.Name]
 		if len(partition.FilesWithMissingReplica) > 400 {

--- a/metanode/api_handler.go
+++ b/metanode/api_handler.go
@@ -632,7 +632,7 @@ func (m *MetaNode) getAllDentriesHandler(w http.ResponseWriter, r *http.Request)
 	)
 
 	mp.GetDentryTree().Ascend(func(i BtreeItem) bool {
-		den, _ := i.(*Dentry).getDentryFromVerList(verSeq)
+		den, _ := i.(*Dentry).getDentryFromVerList(verSeq, false)
 		if den == nil || den.isDeleted() {
 			return true
 		}

--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -343,7 +343,7 @@ func (d *Dentry) deleteVerSnapshot(delVerSeq uint64, mpVerSeq uint64, verlist []
 
 		log.LogDebugf("action[deleteVerSnapshotInList.inSnapList_del_%v] inode %v try drop multiVersion idx %v", delVerSeq, den.Inode, realIdx)
 		d.multiSnap.dentryList = append(d.multiSnap.dentryList[:realIdx], d.multiSnap.dentryList[realIdx+1:]...)
-		if d.cleanDeleteVersion(realIdx) {
+		if d.cleanDeletedVersion(realIdx) {
 			return den, true, true
 		}
 		return den, false, false

--- a/metanode/dentry.go
+++ b/metanode/dentry.go
@@ -203,7 +203,6 @@ func (d *Dentry) deleteVerSnapshot(delVerSeq uint64, mpVerSeq uint64, verlist []
 	log.LogDebugf("action[deleteVerSnapshot] enter.dentry %v delVerSeq %v mpVer %v verList %v", d, delVerSeq, mpVerSeq, verlist)
 	// create denParm version
 	if !isInitSnapVer(delVerSeq) && delVerSeq > mpVerSeq {
-
 		panic(fmt.Sprintf("Dentry version %v large than mp %v", delVerSeq, mpVerSeq))
 	}
 

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -152,11 +152,18 @@ func (i *Inode) insertEkRefMap(mpId uint64, ek *proto.ExtentKey) {
 	storeEkSplit(mpId, i.Inode, i.multiSnap.ekRefMap, ek)
 }
 
-func (i *Inode) getEkRefMap() *sync.Map {
+func (i *Inode) isEkInRefMap(mpId uint64, ek *proto.ExtentKey) (ok bool) {
 	if i.multiSnap == nil {
-		return nil
+		return
 	}
-	return i.multiSnap.ekRefMap
+	if i.multiSnap.ekRefMap == nil {
+		log.LogErrorf("[storeEkSplit] mpId [%v] inodeID %v ekRef nil", mpId, i.Inode)
+		return
+	}
+	log.LogDebugf("[storeEkSplit] mpId [%v] inode %v mp %v extent id %v ek %v", mpId, i.Inode, ek.PartitionId, ek.ExtentId, ek)
+	id := ek.PartitionId<<32 | ek.ExtentId
+	_, ok = i.multiSnap.ekRefMap.Load(id)
+	return
 }
 
 func (i *Inode) getVer() uint64 {

--- a/metanode/multi_ver_test.go
+++ b/metanode/multi_ver_test.go
@@ -808,7 +808,7 @@ func TestDentry(t *testing.T) {
 
 	testDelDirSnapshotVersion(t, seq0, dirIno, dirDen)
 	rspReadDir = testReadDirAll(t, seq0, dirIno.Inode)
-	assert.True(t, len(rspReadDir.Children) == 1)
+	assert.True(t, len(rspReadDir.Children) == 0)
 
 	testPrintAllDentry(t)
 	//---------------------------------------------
@@ -829,7 +829,7 @@ func TestDentry(t *testing.T) {
 
 	rspReadDir = testReadDirAll(t, seq1, dirIno.Inode)
 	t.Logf("after  testDelDirSnapshotVersion %v can see file %v %v", seq1, len(rspReadDir.Children), rspReadDir.Children)
-	assert.True(t, len(rspReadDir.Children) == 2)
+	assert.True(t, len(rspReadDir.Children) == 0)
 	testPrintAllSysVerList(t)
 
 	//---------------------------------------------

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -103,7 +103,11 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 			if d.getVerSeq() == dentry.getVerSeq() {
 				d.setVerSeq(dentry.getSeqFiled())
 			} else {
-				d.addVersion(dentry.getSeqFiled())
+				if d.getSnapListLen() > 0 && d.multiSnap.dentryList[0].isDeleted() {
+					d.setVerSeq(dentry.getSeqFiled())
+				} else {
+					d.addVersion(dentry.getSeqFiled())
+				}
 			}
 			d.Type = dentry.Type
 			d.ParentId = dentry.ParentId
@@ -387,7 +391,7 @@ func (mp *metaPartition) getDentryTree() *BTree {
 }
 
 func (mp *metaPartition) getDentryByVerSeq(dy *Dentry, verSeq uint64) (d *Dentry) {
-	d, _ = dy.getDentryFromVerList(verSeq)
+	d, _ = dy.getDentryFromVerList(verSeq, false)
 	return
 }
 

--- a/metanode/sorted_extents.go
+++ b/metanode/sorted_extents.go
@@ -356,6 +356,7 @@ func (se *SortedExtents) AppendWithCheck(inodeID uint64, ek proto.ExtentKey, add
 
 	if lastKey.FileOffset == ek.FileOffset &&
 		lastKey.PartitionId == ek.PartitionId &&
+		lastKey.ExtentId == ek.ExtentId &&
 		lastKey.ExtentOffset == ek.ExtentOffset && lastKey.Size < ek.Size &&
 		lastKey.GetSeq() < ek.GetSeq() {
 		if len(discard) > 0 {

--- a/sdk/data/stream/extent_cache.go
+++ b/sdk/data/stream/extent_cache.go
@@ -405,7 +405,7 @@ func (cache *ExtentCache) GetEndForAppendWrite(offset uint64, verSeq uint64, nee
 				}
 				//?? should not have the neighbor extent in the next
 				if lastExistEk != nil && ek.IsFileInSequence(lastExistEk) {
-					log.LogErrorf("action[ExtentCache.GetEndForAppendWrite] exist sequence extent %v", lastExistEk)
+					log.LogErrorf("action[ExtentCache.GetEndForAppendWrite] ek %v is InSequence exist sequence extent %v", ek, lastExistEk)
 					ret = nil
 					return false
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix(metanode):append key in sequnce jugement didn't include extent id
fix(metanode):snapshot. dentry deletion on top layer with no snapshotlist then update toplayer to deletion and store version to list althrough no version in mp verlist
    
    version of inode exist identify that it's snapshot version not do deletion  on this node, no matter mplist exist or not, because mpVerlist update while recive master's command of
    version deletion,but real deletion may do deletion aysncronus and may not reach the inode, but user can do deletion on top layer at the same time.
