### PR TITLE
fix(libsdk): fix cfs_mkdirs bug when multi-thread call

### DIFF
--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -960,6 +960,13 @@ func cfs_mkdirs(id C.int64_t, path *C.char, mode C.mode_t) C.int {
 						gerr = err
 						return errorToStatus(err)
 					}
+					// if dir already exist, lookup and assign to child
+					child_ino, _, err := c.mw.Lookup_ll(pino, dir)
+					if err != nil {
+						gerr = err
+						return errorToStatus(err)
+					}
+					child = child_ino
 				} else {
 					child = info.Inode
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
libsdk cfs_mkdirs return ENOENT when multi-thread called

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
