### PR TITLE
bugfix(client):only clear dp when volume storage class is blobstore

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -155,7 +155,7 @@ func formatSimpleVolView(svv *proto.SimpleVolView) string {
 	for _, asc := range svv.AllowedStorageClass {
 		allowedStorageClassStr = append(allowedStorageClassStr, proto.StorageClassString(asc))
 	}
-	sb.WriteString(fmt.Sprintf("  VolStorageClass                 : %v\n", proto.StorageClassString(svv.VolStorageClass)))
+	sb.WriteString(fmt.Sprintf("  volStorageClass                 : %v\n", proto.StorageClassString(svv.VolStorageClass)))
 	sb.WriteString(fmt.Sprintf("  AllowedStorageClass             : %v\n", allowedStorageClassStr))
 	sb.WriteString(fmt.Sprintf("  CacheDpStorageClass             : %v\n", proto.StorageClassString(svv.CacheDpStorageClass)))
 

--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -578,16 +578,16 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 
 			if optVolStorageClass != 0 {
 				if !proto.IsValidStorageClass(uint32(optVolStorageClass)) {
-					err = fmt.Errorf("invalid param VolStorageClass: %v\n", optVolStorageClass)
+					err = fmt.Errorf("invalid param volStorageClass: %v\n", optVolStorageClass)
 					return
 				}
 
 				isChange = true
-				confirmString.WriteString(fmt.Sprintf("  VolStorageClass : %v -> %v\n",
+				confirmString.WriteString(fmt.Sprintf("  volStorageClass : %v -> %v\n",
 					vv.VolStorageClass, optVolStorageClass))
 				vv.VolStorageClass = uint32(optVolStorageClass)
 			} else {
-				confirmString.WriteString(fmt.Sprintf("  VolStorageClass : %v\n",
+				confirmString.WriteString(fmt.Sprintf("  volStorageClass : %v\n",
 					proto.StorageClassString(vv.VolStorageClass)))
 			}
 

--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -241,7 +241,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		MinWriteAbleDataPartitionCnt: opt.MinWriteAbleDataPartitionCnt,
 		OnRenewalForbiddenMigration:  s.mw.RenewalForbiddenMigration,
 		CacheDpStorageClass:          s.cacheDpStorageClass,
-		AllowedStorageClass:          opt.AllowedStorageClass,
+		VolStorageClass:              opt.VolStorageClass,
 	}
 
 	s.ec, err = stream.NewExtentClient(extentConfig)
@@ -250,7 +250,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 	s.mw.VerReadSeq = s.ec.GetReadVer()
 
-	if proto.IsCold(opt.VolType) || proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+	if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
 		s.ebsc, err = blobstore.NewEbsClient(access.Config{
 			ConnMode: access.NoLimitConnMode,
 			Consul: access.ConsulConfig{
@@ -276,7 +276,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 
 	s.suspendCh = make(chan interface{})
-	if proto.IsCold(opt.VolType) || proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+	if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
 		go s.scheduleFlush()
 	}
 	if s.mw.EnableSummary {

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -352,7 +352,7 @@ func main() {
 	}
 
 	proto.InitBufferPool(opt.BuffersTotalLimit)
-	if proto.IsCold(opt.VolType) || proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+	if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
 		buf.InitCachePool(opt.EbsBlockSize)
 	}
 	if opt.EnableBcache {
@@ -660,7 +660,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 				continue
 			}
 			super.SetTransaction(volumeInfo.EnableTransaction, volumeInfo.TxTimeout, volumeInfo.TxConflictRetryNum, volumeInfo.TxConflictRetryInterval)
-			if proto.IsCold(opt.VolType) || proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+			if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
 				super.CacheAction = volumeInfo.CacheAction
 				super.CacheThreshold = volumeInfo.CacheThreshold
 				super.EbsBlockSize = volumeInfo.ObjBlockSize
@@ -903,6 +903,7 @@ func loadConfFromMaster(opt *proto.MountOptions) (err error) {
 	opt.TxConflictRetryInterval = volumeInfo.TxConflictRetryInterval
 	opt.CacheDpStorageClass = volumeInfo.CacheDpStorageClass
 	opt.AllowedStorageClass = volumeInfo.AllowedStorageClass
+	opt.VolStorageClass = volumeInfo.VolStorageClass
 
 	var clusterInfo *proto.ClusterInfo
 	clusterInfo, err = mc.AdminAPI().GetClusterInfo()

--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -243,6 +243,7 @@ type client struct {
 	cluster             string
 	dirChildrenNumLimit uint32
 	enableAudit         bool
+	volStorageClass     uint32
 
 	// runtime context
 	cwd    string // current working directory
@@ -1226,6 +1227,7 @@ func (c *client) start() (err error) {
 		OnCacheBcache:     c.bc.Put,
 		OnEvictBcache:     c.bc.Evict,
 		DisableMetaCache:  true,
+		VolStorageClass:   c.volStorageClass,
 	}); err != nil {
 		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
 		return
@@ -1476,6 +1478,7 @@ func (c *client) loadConfFromMaster(masters []string) (err error) {
 	c.cacheAction = volumeInfo.CacheAction
 	c.cacheRuleKey = volumeInfo.CacheRule
 	c.cacheThreshold = volumeInfo.CacheThreshold
+	c.volStorageClass = volumeInfo.VolStorageClass
 
 	var clusterInfo *proto.ClusterInfo
 	clusterInfo, err = mc.AdminAPI().GetClusterInfo()

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -3053,8 +3053,9 @@ func NewVolume(config *VolumeConfig) (*Volume, error) {
 		OnGetExtents:                metaWrapper.GetExtents,
 		OnTruncate:                  metaWrapper.Truncate,
 		OnRenewalForbiddenMigration: metaWrapper.RenewalForbiddenMigration,
+		VolStorageClass:             volumeInfo.VolStorageClass,
 	}
-	if proto.IsCold(volumeInfo.VolType) || proto.VolSupportsBlobStore(volumeInfo.AllowedStorageClass) {
+	if proto.IsStorageClassBlobStore(volumeInfo.VolStorageClass) {
 		if blockCache != nil {
 			extentConfig.BcacheEnable = true
 			extentConfig.OnLoadBcache = blockCache.Get

--- a/preload/preload.go
+++ b/preload/preload.go
@@ -84,6 +84,7 @@ func main() {
 		fmt.Println("Preload only work in cold volume")
 		os.Exit(1)
 	}
+
 	fmt.Printf("conf is %v\n", config)
 	action := cfg.GetString("action")
 	if action == "preload" {

--- a/preload/sdk/preloadsdk.go
+++ b/preload/sdk/preloadsdk.go
@@ -131,6 +131,12 @@ func NewClient(config PreloadConfig) *PreLoadClient {
 		return nil
 	}
 
+	var view *proto.SimpleVolView
+	if view, err = c.mc.AdminAPI().GetVolumeSimpleInfo(c.vol); err != nil {
+		log.LogErrorf("CheckVolumeInfoFromMaster: get volume simple info fail: volume(%v) err(%v)", c.vol, err)
+		return nil
+	}
+
 	if mw, err = meta.NewMetaWrapper(&meta.MetaConfig{
 		Volume:        config.Volume,
 		Masters:       config.Masters,
@@ -149,6 +155,7 @@ func NewClient(config PreloadConfig) *PreLoadClient {
 		OnGetExtents:      mw.GetExtents,
 		OnTruncate:        mw.Truncate,
 		VolumeType:        proto.VolumeTypeCold,
+		VolStorageClass:   view.VolStorageClass,
 	}); err != nil {
 		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
 		return nil

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -327,4 +327,5 @@ type MountOptions struct {
 	FileSystemName               string
 	VerReadSeq                   uint64
 	AllowedStorageClass          []uint32
+	VolStorageClass              uint32
 }

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -125,7 +125,7 @@ type ExtentConfig struct {
 	OnRenewalForbiddenMigration RenewalForbiddenMigrationFunc
 
 	CacheDpStorageClass uint32
-	AllowedStorageClass []uint32
+	VolStorageClass     uint32
 }
 
 type MultiVerMgr struct {
@@ -246,7 +246,7 @@ func NewExtentClient(config *ExtentConfig) (client *ExtentClient, err error) {
 retry:
 
 	client.dataWrapper, err = wrapper.NewDataPartitionWrapper(client, config.Volume, config.Masters,
-		config.Preload, config.MinWriteAbleDataPartitionCnt, config.VerReadSeq, config.AllowedStorageClass)
+		config.Preload, config.MinWriteAbleDataPartitionCnt, config.VerReadSeq, config.VolStorageClass)
 	if err != nil {
 		log.LogErrorf("NewExtentClient: new data partition wrapper failed: volume(%v) mayRetry(%v) err(%v)",
 			config.Volume, limit, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

bugfix(client):only clear dp when volume storage class is blobstore