### PR TITLE
client append ek which seq may be updated by metanode,add ref for consistent

### DIFF
--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -926,7 +926,7 @@ func (dp *DataPartition) canRemoveSelf() (canRemove bool, err error) {
 		if partition, err = MasterClient.AdminAPI().GetDataPartition(dp.volumeID, dp.partitionID); err != nil {
 			log.LogErrorf("action[canRemoveSelf] err[%v]", err)
 			retry++
-			if retry > 5 {
+			if retry > 60 {
 				return
 			}
 		} else {

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -971,7 +971,7 @@ func (i *Inode) mergeExtentArr(mpId uint64, extentKeysLeft []proto.ExtentKey, ex
 
 	doWork := func(keyArr *[]proto.ExtentKey, pos int) {
 		mLen := len(sortMergedExts)
-		if mLen > 0 && sortMergedExts[mLen-1].IsSequence(&(*keyArr)[pos]) {
+		if mLen > 0 && sortMergedExts[mLen-1].IsSequenceWithSameSeq(&(*keyArr)[pos]) {
 			sortMergedExts[mLen-1].Size += (*keyArr)[pos].Size
 			log.LogDebugf("[mergeExtentArr] mpId[%v]. ek left %v right %v", mpId, sortMergedExts[mLen-1], (*keyArr)[pos])
 			if !sortMergedExts[mLen-1].IsSplit() || !(*keyArr)[pos].IsSplit() {

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2543,7 +2543,7 @@ func (m *metadataManager) checkMultiVersionStatus(mp MetaPartition, p *Packet) (
 	}
 	// meta node do not need to check verSeq as strictly as datanode,file append or modAppendWrite on meta node is invisible to other files.
 	// only need to guarantee the verSeq wrote on meta nodes grow up linearly on client's angle
-	log.LogDebugf("action[checkmultiSnap.multiVersionstatus] mp %v ver %v, packet ver %v", mp.GetBaseConfig().PartitionId, mp.GetVerSeq(), p.VerSeq)
+	log.LogDebugf("action[checkmultiSnap.multiVersionstatus] mp %v ver %v, packet ver %v reqId %v", mp.GetBaseConfig().PartitionId, mp.GetVerSeq(), p.VerSeq, p.ReqID)
 	if mp.GetVerSeq() >= p.VerSeq {
 		if mp.GetVerSeq() > p.VerSeq {
 			log.LogDebugf("action[checkmultiSnap.multiVersionstatus] mp ver %v, packet ver %v", mp.GetVerSeq(), p.VerSeq)

--- a/proto/extent_key.go
+++ b/proto/extent_key.go
@@ -180,8 +180,7 @@ func (k *ExtentKey) IsEqual(rightKey *ExtentKey) bool {
 		k.FileOffset == rightKey.FileOffset
 }
 
-func (k *ExtentKey) IsSequence(rightKey *ExtentKey) bool {
-	//	return false
+func (k *ExtentKey) IsSequenceWithSameSeq(rightKey *ExtentKey) bool {
 	return k.PartitionId == rightKey.PartitionId &&
 		k.ExtentId == rightKey.ExtentId &&
 		k.GetSeq() == rightKey.GetSeq() &&
@@ -189,8 +188,12 @@ func (k *ExtentKey) IsSequence(rightKey *ExtentKey) bool {
 		k.FileOffset+uint64(k.Size) == rightKey.FileOffset
 }
 
+func (k *ExtentKey) IsSameExtent(rightKey *ExtentKey) bool {
+	return k.PartitionId == rightKey.PartitionId &&
+		k.ExtentId == rightKey.ExtentId
+}
+
 func (k *ExtentKey) IsSequenceWithDiffSeq(rightKey *ExtentKey) bool {
-	//	return false
 	return k.PartitionId == rightKey.PartitionId &&
 		k.ExtentId == rightKey.ExtentId &&
 		!(k.GetSeq() == rightKey.GetSeq()) &&
@@ -199,7 +202,6 @@ func (k *ExtentKey) IsSequenceWithDiffSeq(rightKey *ExtentKey) bool {
 }
 
 func (k *ExtentKey) IsFileInSequence(rightKey *ExtentKey) bool {
-	//	return false
 	return k.PartitionId == rightKey.PartitionId &&
 		k.ExtentId == rightKey.ExtentId &&
 		k.ExtentOffset+uint64(k.Size) == rightKey.ExtentOffset

--- a/sdk/data/stream/extent_cache.go
+++ b/sdk/data/stream/extent_cache.go
@@ -181,7 +181,7 @@ func (cache *ExtentCache) SplitExtentKey(inodeID uint64, ekPivot *proto.ExtentKe
 		ek.Size = ek.Size - ekPivot.Size
 		ek.FileOffset = ek.FileOffset + uint64(ekPivot.Size)
 		ek.ExtentOffset = ek.ExtentOffset + uint64(ekPivot.Size)
-		if ekLeft != nil && ekLeft.IsSequence(ekPivot) {
+		if ekLeft != nil && ekLeft.IsSequenceWithSameSeq(ekPivot) {
 			log.LogDebugf("SplitExtentKey.merge.begin. ekLeft %v and %v", ekLeft, ekPivot)
 			ekLeft.Size += ekPivot.Size
 			log.LogDebugf("action[SplitExtentKey] inode %v ek [%v], ekPivot[%v] ekLeft[%v]", inodeID, ek, ekPivot, ekLeft)
@@ -194,7 +194,7 @@ func (cache *ExtentCache) SplitExtentKey(inodeID uint64, ekPivot *proto.ExtentKe
 	} else if ek.FileOffset+uint64(ek.Size) == ekPivot.FileOffset+uint64(ekPivot.Size) { // end
 		ek.Size = ek.Size - ekPivot.Size
 		log.LogDebugf("action[SplitExtentKey] inode %v ek [%v]", inodeID, ek)
-		if ekRight != nil && ekPivot.IsSequence(ekRight) {
+		if ekRight != nil && ekPivot.IsSequenceWithSameSeq(ekRight) {
 			cache.root.Delete(ekRight)
 			ekRight.FileOffset = ekPivot.FileOffset
 			ekRight.ExtentOffset = ekPivot.ExtentOffset

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -89,7 +89,7 @@ var (
 	NormalExtentFilter = func() ExtentFilter {
 		now := time.Now()
 		return func(ei *ExtentInfo) bool {
-			return !IsTinyExtent(ei.FileID) && now.Unix()-ei.ModifyTime > RepairInterval && !ei.IsDeleted && ei.TotalSize() > 0
+			return !IsTinyExtent(ei.FileID) && now.Unix()-ei.ModifyTime > RepairInterval && !ei.IsDeleted
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
    in append ek process,if do neigbor ek merge together of the same extent,the client may have different view of eks,
    then the client opertion will not consistent with metanode,and may trigger conflicts.so just add ref for this scenrio,
    because the verseq update not always happen

