### PR TITLE
fix(client): set usedSize as totalSize if usedSize > totalSize when queried from master, to avoid displaying anomalies such as cmd df

### DIFF
--- a/sdk/meta/view.go
+++ b/sdk/meta/view.go
@@ -160,6 +160,13 @@ func (mw *MetaWrapper) updateVolStatInfo() (err error) {
 		log.LogWarnf("updateVolStatInfo: get volume status fail: volume(%v) err(%v)", mw.volname, err)
 		return
 	}
+
+	if info.UsedSize > info.TotalSize {
+		log.LogInfof("volume(%v) queried usedSize(%v) is larger than totalSize(%v), force set usedSize as totalSize",
+			mw.volname, info.UsedSize, info.TotalSize)
+		info.UsedSize = info.TotalSize
+	}
+
 	atomic.StoreUint64(&mw.totalSize, info.TotalSize)
 	atomic.StoreUint64(&mw.usedSize, info.UsedSize)
 	atomic.StoreUint64(&mw.inodeCount, info.InodeCount)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(client): set usedSize as totalSize if usedSize > totalSize when queried from master, to avoid displaying anomalies such as cmd df