### PR TITLE
feat(master): Open the volume deletion interface to freeze the volume…

### DIFF
--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -253,7 +253,7 @@ func parseGetVolParameter(r *http.Request) (p *getVolParameter, err error) {
 	return
 }
 
-func parseRequestToDeleteVol(r *http.Request) (name, authKey string, force bool, err error) {
+func parseRequestToDeleteVol(r *http.Request) (name, authKey string, status, force bool, err error) {
 	if err = r.ParseForm(); err != nil {
 		return
 	}
@@ -263,6 +263,10 @@ func parseRequestToDeleteVol(r *http.Request) (name, authKey string, force bool,
 	}
 
 	if authKey, err = extractAuthKey(r); err != nil {
+		return
+	}
+
+	if status, err = extractBoolWithDefault(r, deleteVolKey, true); err != nil {
 		return
 	}
 

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1800,6 +1800,7 @@ func (m *Server) markDeleteVol(w http.ResponseWriter, r *http.Request) {
 	var (
 		name    string
 		authKey string
+		status  bool
 		// force   bool
 		err error
 		msg string
@@ -1809,21 +1810,63 @@ func (m *Server) markDeleteVol(w http.ResponseWriter, r *http.Request) {
 		doStatAndMetric(proto.AdminDeleteVol, metric, err, map[string]string{exporter.Vol: name})
 	}()
 
-	if name, authKey, _, err = parseRequestToDeleteVol(r); err != nil {
+	if name, authKey, status, _, err = parseRequestToDeleteVol(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
-
-	if err = m.cluster.markDeleteVol(name, authKey, false); err != nil {
-		sendErrReply(w, r, newErrHTTPReply(err))
+	vol, err := m.cluster.getVol(name)
+	if err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeVolNotExists, Msg: err.Error()})
 		return
 	}
-	if err = m.user.deleteVolPolicy(name); err != nil {
-		sendErrReply(w, r, newErrHTTPReply(err))
-		return
+	if status {
+		oldForbiden := vol.Forbidden
+		vol.Forbidden = true
+		defer func() {
+			if err != nil {
+				vol.Forbidden = oldForbiden
+			}
+		}()
+		if err = m.cluster.syncUpdateVol(vol); err != nil {
+			sendErrReply(w, r, newErrHTTPReply(err))
+			return
+		}
+		vol.setDpRdOnly()
+		vol.setMpRdOnly()
+		m.cluster.delayDeleteVolsInfo = append(m.cluster.delayDeleteVolsInfo, &delayDeleteVolInfo{volName: name, authKey: authKey, execTime: time.Now().Add(time.Duration(m.config.volDelayDeleteTime) * time.Hour), user: m.user})
+		log.LogDebugf("delete vol[%v], slice[%v]", name, m.cluster.delayDeleteVolsInfo)
+		msg = fmt.Sprintf("delete vol: forbid vol[%v] successfully,from[%v]", name, r.RemoteAddr)
+		log.LogWarn(msg)
+	} else {
+		var index int
+		var value *delayDeleteVolInfo
+		for index, value = range m.cluster.delayDeleteVolsInfo {
+			if value.volName == name {
+				break
+			}
+		}
+		if index == len(m.cluster.delayDeleteVolsInfo)-1 && value.volName != name {
+			msg := fmt.Sprintf("vol[%v] was not previously deleted", name)
+			err = errors.New(msg)
+			sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeVolNotDelete, Msg: err.Error()})
+			return
+		}
+		m.cluster.delayDeleteVolsInfo = append(m.cluster.delayDeleteVolsInfo[:index], m.cluster.delayDeleteVolsInfo[index+1:]...)
+		log.LogDebugf("undelete vol[%v], slice[%v]", name, m.cluster.delayDeleteVolsInfo)
+		oldForbiden := vol.Forbidden
+		vol.Forbidden = false
+		defer func() {
+			if err != nil {
+				vol.Forbidden = oldForbiden
+			}
+		}()
+		if err = m.cluster.syncUpdateVol(vol); err != nil {
+			sendErrReply(w, r, newErrHTTPReply(err))
+			return
+		}
+		msg = fmt.Sprintf("undelete vol: unforbid vol[%v] successfully,from[%v]", name, r.RemoteAddr)
+		log.LogWarn(msg)
 	}
-	msg = fmt.Sprintf("delete vol[%v] successfully,from[%v]", name, r.RemoteAddr)
-	log.LogWarn(msg)
 	sendOkReply(w, r, newSuccessHTTPReply(msg))
 }
 

--- a/master/config.go
+++ b/master/config.go
@@ -52,6 +52,7 @@ const (
 
 	cfgVolForceDeletion           = "volForceDeletion"
 	cfgVolDeletionDentryThreshold = "volDeletionDentryThreshold"
+	cfgVolDeletionDelayTime       = "volDeletionDelayTime"
 )
 
 //default value
@@ -136,6 +137,7 @@ type clusterConfig struct {
 
 	volForceDeletion           bool   // when delete a volume, ignore it's dentry count or not
 	volDeletionDentryThreshold uint64 // in case of volForceDeletion is set to false, define the dentry count threshold to allow volume deletion
+	volDelayDeleteTime         int64
 }
 
 func newClusterConfig() (cfg *clusterConfig) {

--- a/master/const.go
+++ b/master/const.go
@@ -41,6 +41,7 @@ const (
 	cacheRuleKey          = "cacheRuleKey"
 	emptyCacheRuleKey     = "emptyCacheRule"
 	forbiddenKey          = "forbidden"
+	deleteVolKey          = "delete"
 
 	forceDelVolKey             = "forceDelVol"
 	ebsBlkSizeKey              = "ebsBlkSize"

--- a/master/server.go
+++ b/master/server.go
@@ -177,6 +177,9 @@ func (m *Server) Start(cfg *config.Config) (err error) {
 // Shutdown closes the server
 func (m *Server) Shutdown() {
 	var err error
+	if m.cluster.stopc != nil {
+		close(m.cluster.stopc)
+	}
 	if m.apiServer != nil {
 		if err = m.apiServer.Shutdown(context.Background()); err != nil {
 			log.LogErrorf("action[Shutdown] failed, err: %v", err)
@@ -343,6 +346,8 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 		return fmt.Errorf("volDeletionDentryThreshold can't be less than 0 ! ")
 	}
 	m.config.volDeletionDentryThreshold = uint64(threshold)
+
+	m.config.volDelayDeleteTime = cfg.GetInt64WithDefault(cfgVolDeletionDelayTime, 48)
 
 	return
 }

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -67,6 +67,7 @@ func TestVol(t *testing.T) {
 	getVol(name, t)
 	statVol(name, t)
 	delVol(name, t)
+	time.Sleep(5 * time.Second)
 	getSimpleVol(name, true, t)
 	vol.checkStatus(server.cluster)
 	err = vol.deleteVolFromStore(server.cluster)

--- a/proto/errors.go
+++ b/proto/errors.go
@@ -101,6 +101,7 @@ const (
 	ErrCodeMarshalData
 	ErrCodeUnmarshalData
 	ErrCodeVolNotExists
+	ErrCodeVolNotDelete
 	ErrCodeMetaPartitionNotExists
 	ErrCodeDataPartitionNotExists
 	ErrCodeDataNodeNotExists

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -262,6 +262,17 @@ func (api *AdminAPI) DeleteVolume(volName, authKey string) (err error) {
 	return
 }
 
+func (api *AdminAPI) UnDeleteVolume(volName, authKey string, status bool) (err error) {
+	var request = newAPIRequest(http.MethodGet, proto.AdminDeleteVol)
+	request.addParam("name", volName)
+	request.addParam("authKey", authKey)
+	request.addParam("delete", strconv.FormatBool(false))
+	if _, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) UpdateVolume(
 	vv *proto.SimpleVolView,
 	txTimeout int64,


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Open the volume deletion interface to freeze the volume when performing a volume deletion and then wait 48 hours before deleting the volume.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2922 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
