### PR TITLE
enhance(metanode):fix some bugs about ssd to ebs migration

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -241,7 +241,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		MinWriteAbleDataPartitionCnt: opt.MinWriteAbleDataPartitionCnt,
 		OnRenewalForbiddenMigration:  s.mw.RenewalForbiddenMigration,
 		CacheDpStorageClass:          s.cacheDpStorageClass,
-		VolStorageClass:              opt.VolStorageClass,
+		AllowedStorageClass:          opt.AllowedStorageClass,
 	}
 
 	s.ec, err = stream.NewExtentClient(extentConfig)
@@ -250,7 +250,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 	s.mw.VerReadSeq = s.ec.GetReadVer()
 
-	if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
+	if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
 		s.ebsc, err = blobstore.NewEbsClient(access.Config{
 			ConnMode: access.NoLimitConnMode,
 			Consul: access.ConsulConfig{
@@ -276,7 +276,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 
 	s.suspendCh = make(chan interface{})
-	if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
+	if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
 		go s.scheduleFlush()
 	}
 	if s.mw.EnableSummary {

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -352,7 +352,7 @@ func main() {
 	}
 
 	proto.InitBufferPool(opt.BuffersTotalLimit)
-	if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
+	if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
 		buf.InitCachePool(opt.EbsBlockSize)
 	}
 	if opt.EnableBcache {
@@ -660,7 +660,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 				continue
 			}
 			super.SetTransaction(volumeInfo.EnableTransaction, volumeInfo.TxTimeout, volumeInfo.TxConflictRetryNum, volumeInfo.TxConflictRetryInterval)
-			if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
+			if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
 				super.CacheAction = volumeInfo.CacheAction
 				super.CacheThreshold = volumeInfo.CacheThreshold
 				super.EbsBlockSize = volumeInfo.ObjBlockSize

--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -243,7 +243,7 @@ type client struct {
 	cluster             string
 	dirChildrenNumLimit uint32
 	enableAudit         bool
-	volStorageClass     uint32
+	allowedStorageClass []uint32
 
 	// runtime context
 	cwd    string // current working directory
@@ -617,11 +617,11 @@ func cfs_write(id C.int64_t, fd C.int, buf unsafe.Pointer, size C.size_t, off C.
 	var wait bool
 
 	if f.flags&uint32(C.O_DIRECT) != 0 || f.flags&uint32(C.O_SYNC) != 0 || f.flags&uint32(C.O_DSYNC) != 0 {
-		if proto.IsHot(c.volType) || proto.IsStorageClassReplica(f.storageClass) {
+		if proto.IsStorageClassReplica(f.storageClass) {
 			wait = true
 		}
 	}
-	if f.flags&uint32(C.O_APPEND) != 0 || proto.IsCold(c.volType) || proto.IsStorageClassBlobStore(f.storageClass) {
+	if f.flags&uint32(C.O_APPEND) != 0 || proto.IsStorageClassBlobStore(f.storageClass) {
 		flags |= proto.FlagsAppend
 		flags |= proto.FlagsSyncWrite
 	}
@@ -1214,20 +1214,20 @@ func (c *client) start() (err error) {
 	}
 	var ec *stream.ExtentClient
 	if ec, err = stream.NewExtentClient(&stream.ExtentConfig{
-		Volume:            c.volName,
-		VolumeType:        c.volType,
-		Masters:           masters,
-		FollowerRead:      c.followerRead,
-		OnAppendExtentKey: mw.AppendExtentKey,
-		OnSplitExtentKey:  mw.SplitExtentKey,
-		OnGetExtents:      mw.GetExtents,
-		OnTruncate:        mw.Truncate,
-		BcacheEnable:      c.enableBcache,
-		OnLoadBcache:      c.bc.Get,
-		OnCacheBcache:     c.bc.Put,
-		OnEvictBcache:     c.bc.Evict,
-		DisableMetaCache:  true,
-		VolStorageClass:   c.volStorageClass,
+		Volume:              c.volName,
+		VolumeType:          c.volType,
+		Masters:             masters,
+		FollowerRead:        c.followerRead,
+		OnAppendExtentKey:   mw.AppendExtentKey,
+		OnSplitExtentKey:    mw.SplitExtentKey,
+		OnGetExtents:        mw.GetExtents,
+		OnTruncate:          mw.Truncate,
+		BcacheEnable:        c.enableBcache,
+		OnLoadBcache:        c.bc.Get,
+		OnCacheBcache:       c.bc.Put,
+		OnEvictBcache:       c.bc.Evict,
+		DisableMetaCache:    true,
+		AllowedStorageClass: c.allowedStorageClass,
 	}); err != nil {
 		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
 		return
@@ -1285,7 +1285,7 @@ func (c *client) allocFD(ino uint64, flags, mode uint32, fileCache bool, fileSiz
 	if flags&0x0f != syscall.O_RDONLY {
 		f.openForWrite = true
 	}
-	if proto.IsCold(c.volType) || proto.IsStorageClassBlobStore(storageClass) {
+	if proto.IsStorageClassBlobStore(storageClass) {
 		clientConf := blobstore.ClientConfig{
 			VolName:         c.volName,
 			VolType:         c.volType,
@@ -1302,6 +1302,7 @@ func (c *client) allocFD(ino uint64, flags, mode uint32, fileCache bool, fileSiz
 			FileCache:       fileCache,
 			FileSize:        fileSize,
 			CacheThreshold:  c.cacheThreshold,
+			StorageClass:    storageClass,
 		}
 		f.fileWriter.FreeCache()
 		switch flags & 0xff {
@@ -1404,7 +1405,7 @@ func (c *client) closeStream(f *file) {
 }
 
 func (c *client) flush(f *file) error {
-	if proto.IsHot(c.volType) || proto.IsStorageClassReplica(f.storageClass) {
+	if proto.IsStorageClassReplica(f.storageClass) {
 		return c.ec.Flush(f.ino)
 	} else {
 		if f.fileWriter != nil {
@@ -1423,7 +1424,7 @@ func (c *client) truncate(f *file, size int) error {
 }
 
 func (c *client) write(f *file, offset int, data []byte, flags int) (n int, err error) {
-	if proto.IsHot(c.volType) || proto.IsStorageClassReplica(f.storageClass) {
+	if proto.IsStorageClassReplica(f.storageClass) {
 		c.ec.GetStreamer(f.ino).SetParentInode(f.pino) // set the parent inode
 		checkFunc := func() error {
 			if !c.mw.EnableQuota {
@@ -1450,7 +1451,7 @@ func (c *client) write(f *file, offset int, data []byte, flags int) (n int, err 
 }
 
 func (c *client) read(f *file, offset int, data []byte) (n int, err error) {
-	if proto.IsHot(c.volType) || proto.IsStorageClassReplica(f.storageClass) {
+	if proto.IsStorageClassReplica(f.storageClass) {
 		n, err = c.ec.Read(f.ino, data, offset, len(data), f.storageClass, false)
 	} else {
 		n, err = f.fileReader.Read(c.ctx(c.id, f.ino), data, offset, len(data))
@@ -1478,7 +1479,7 @@ func (c *client) loadConfFromMaster(masters []string) (err error) {
 	c.cacheAction = volumeInfo.CacheAction
 	c.cacheRuleKey = volumeInfo.CacheRule
 	c.cacheThreshold = volumeInfo.CacheThreshold
-	c.volStorageClass = volumeInfo.VolStorageClass
+	c.allowedStorageClass = volumeInfo.AllowedStorageClass
 
 	var clusterInfo *proto.ClusterInfo
 	clusterInfo, err = mc.AdminAPI().GetClusterInfo()

--- a/metanode/inode.go
+++ b/metanode/inode.go
@@ -503,7 +503,7 @@ func (i *Inode) Copy() BtreeItem {
 	}
 	if i.HybridCouldExtentsMigration.sortedEks != nil {
 		newIno.HybridCouldExtentsMigration.storageClass = i.HybridCouldExtentsMigration.storageClass
-		if i.migrateToReplicaSystem() {
+		if proto.IsStorageClassReplica(i.HybridCouldExtentsMigration.storageClass) {
 			newIno.HybridCouldExtentsMigration.sortedEks =
 				i.HybridCouldExtentsMigration.sortedEks.(*SortedExtents).Clone()
 		} else {
@@ -544,7 +544,7 @@ func (i *Inode) CopyDirectly() BtreeItem {
 	}
 	if i.HybridCouldExtentsMigration.sortedEks != nil {
 		newIno.HybridCouldExtentsMigration.storageClass = i.HybridCouldExtentsMigration.storageClass
-		if i.migrateToReplicaSystem() {
+		if proto.IsStorageClassReplica(i.HybridCouldExtentsMigration.storageClass) {
 			newIno.HybridCouldExtentsMigration.sortedEks =
 				i.HybridCouldExtentsMigration.sortedEks.(*SortedExtents).Clone()
 		} else {
@@ -679,6 +679,15 @@ func (i *Inode) UnmarshalKey(k []byte) (err error) {
 // MarshalValue marshals the value to bytes.
 func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 	var err error
+	log.LogDebugf("MarshalInodeValue ino(%v) storageClass(%v) Reserved(%v)", i.Inode, i.StorageClass, i.Reserved)
+	//reset reserved, V4EBSExtentsFlag maybe changed after migration .eg
+	i.Reserved = 0
+	defer func() {
+		if err := recover(); err != nil {
+			log.LogErrorf("MarshalInodeValue ino(%v)  storageClass(%v) Recovered from panic:%v",
+				i.Inode, i.StorageClass, err)
+		}
+	}()
 	if err = binary.Write(buff, binary.BigEndian, &i.Type); err != nil {
 		panic(err)
 	}
@@ -725,18 +734,21 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 	i.Reserved |= V3EnableSnapInodeFlag
 	i.Reserved |= V4EnableHybridCloud
 	//to check flag
-	if i.StorageClass == proto.StorageClass_BlobStore {
+
+	if proto.IsStorageClassBlobStore(i.StorageClass) {
 		if i.HybridCouldExtents.sortedEks != nil {
 			ObjExtents := i.HybridCouldExtents.sortedEks.(*SortedObjExtents)
 			if ObjExtents != nil && len(ObjExtents.eks) > 0 {
 				i.Reserved |= V4EBSExtentsFlag
+				log.LogDebugf("MarshalInodeValue ino(%v) storageClass(%v) V4EBSExtentsFlag", i.Inode, i.StorageClass)
 			}
 		}
-	} else if i.storeInReplicaSystem() {
+	} else if proto.IsStorageClassReplica(i.StorageClass) {
 		if i.HybridCouldExtents.sortedEks != nil {
 			replicaExtents := i.HybridCouldExtents.sortedEks.(*SortedExtents)
 			if replicaExtents != nil && len(replicaExtents.eks) > 0 {
 				i.Reserved |= V4ReplicaExtentsFlag
+				log.LogDebugf("MarshalInodeValue ino(%v) storageClass(%v) V4ReplicaExtentsFlag", i.Inode, i.StorageClass)
 			}
 		}
 	} else {
@@ -744,8 +756,9 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 	}
 	if i.HybridCouldExtentsMigration != nil && i.HybridCouldExtentsMigration.storageClass != proto.MediaType_Unspecified {
 		i.Reserved |= V4MigrationExtentsFlag
+		log.LogDebugf("MarshalInodeValue ino(%v) V4MigrationExtentsFlag", i.Inode)
 	}
-	//log.LogInfof("action[MarshalInodeValue] inode %v Reserved %v", i.Inode, i.Reserved)
+	log.LogDebugf("MarshalInodeValue ino(%v) storageClass(%v) Reserved(%v)", i.Inode, i.StorageClass, i.Reserved)
 	if err = binary.Write(buff, binary.BigEndian, &i.Reserved); err != nil {
 		panic(err)
 	}
@@ -773,6 +786,8 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 
 	if i.Reserved&V4EBSExtentsFlag > 0 {
 		// marshal ObjExtentsKey
+		log.LogDebugf("MarshalInodeValue ino(%v)  storageClass(%v) marshall HybridCouldExtents V4EBSExtentsFlag Reserved(%v)",
+			i.Inode, i.StorageClass, i.Reserved)
 		ObjExtents := i.HybridCouldExtents.sortedEks.(*SortedObjExtents)
 		objExtData, err := ObjExtents.MarshalBinary()
 		if err != nil {
@@ -787,6 +802,8 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 	}
 
 	if i.Reserved&V4ReplicaExtentsFlag > 0 {
+		log.LogDebugf("MarshalInodeValue ino(%v) storageClass(%v) marshall HybridCouldExtents V4ReplicaExtentsFlag Reserved(%v)",
+			i.Inode, i.StorageClass, i.Reserved)
 		replicaExtents := i.HybridCouldExtents.sortedEks.(*SortedExtents)
 		extData, err := replicaExtents.MarshalBinary(true)
 		if err != nil {
@@ -813,6 +830,7 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 	//	}
 	//}
 	if i.Reserved&V4MigrationExtentsFlag > 0 {
+		log.LogDebugf("MarshalInodeValue ino(%v) marshall V4MigrationExtentsFlag Reserved(%v)", i.Inode, i.Reserved)
 		if err = binary.Write(buff, binary.BigEndian, &i.HybridCouldExtentsMigration.storageClass); err != nil {
 			panic(err)
 		}
@@ -820,7 +838,9 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 			panic(errors.New(fmt.Sprintf("MarshalInodeValue failed,HybridCouldExtentsMigration class %v ek should not be nil",
 				i.HybridCouldExtentsMigration.storageClass)))
 		}
-		if i.migrateToReplicaSystem() {
+		if proto.IsStorageClassReplica(i.HybridCouldExtentsMigration.storageClass) {
+			log.LogDebugf("MarshalInodeValue ino(%v) migrationStorageClass(%v) marshall V4MigrationExtentsFlag SortedExtents Reserved(%v)",
+				i.Inode, i.HybridCouldExtentsMigration.storageClass, i.Reserved)
 			replicaExtents := i.HybridCouldExtentsMigration.sortedEks.(*SortedExtents)
 			extData, err := replicaExtents.MarshalBinary(true)
 			if err != nil {
@@ -833,7 +853,9 @@ func (i *Inode) MarshalInodeValue(buff *bytes.Buffer) {
 				panic(err)
 			}
 
-		} else if i.HybridCouldExtentsMigration.storageClass == proto.StorageClass_BlobStore {
+		} else if proto.IsStorageClassBlobStore(i.HybridCouldExtentsMigration.storageClass) {
+			log.LogDebugf("MarshalInodeValue ino(%v)migrationStorageClass(%v)   marshall V4MigrationExtentsFlag SortedObjExtents Reserved(%v) ",
+				i.Inode, i.HybridCouldExtentsMigration.storageClass, i.Reserved)
 			ObjExtents := i.HybridCouldExtentsMigration.sortedEks.(*SortedObjExtents)
 			objExtData, err := ObjExtents.MarshalBinary()
 			if err != nil {
@@ -888,7 +910,6 @@ func (i *Inode) MarshalValue() (val []byte) {
 
 // UnmarshalValue unmarshals the value from bytes.
 func (i *Inode) UnmarshalInodeValue(buff *bytes.Buffer) (err error) {
-
 	if err = binary.Read(buff, binary.BigEndian, &i.Type); err != nil {
 		return
 	}
@@ -948,6 +969,7 @@ func (i *Inode) UnmarshalInodeValue(buff *bytes.Buffer) (err error) {
 	v3 := i.Reserved&V3EnableSnapInodeFlag > 0
 	v2 := i.Reserved&V2EnableColdInodeFlag > 0
 	v4 := i.Reserved&V4EnableHybridCloud > 0
+	log.LogDebugf("UnmarshalInodeValue ino(%v) v2(%v) v3(%v) v4(%v)", i.Inode, v2, v3, v4)
 	//hybridcloud format
 	if v4 {
 		if err = binary.Read(buff, binary.BigEndian, &i.StorageClass); err != nil {
@@ -959,6 +981,8 @@ func (i *Inode) UnmarshalInodeValue(buff *bytes.Buffer) (err error) {
 		if err = binary.Read(buff, binary.BigEndian, &i.WriteGeneration); err != nil {
 			return
 		}
+		log.LogDebugf("UnmarshalInodeValue ino(%v) StorageClass(%v) v2(%v) v3(%v) v4(%v)", i.Inode, i.StorageClass,
+			v2, v3, v4)
 		extSize := uint32(0)
 		//unmarshall extents cache
 		if err = binary.Read(buff, binary.BigEndian, &extSize); err != nil {
@@ -990,6 +1014,7 @@ func (i *Inode) UnmarshalInodeValue(buff *bytes.Buffer) (err error) {
 				return
 			}
 			fmt.Printf("ino %v extSize %v\n", i.Inode, extSize)
+			log.LogDebugf("UnmarshalInodeValue ino(%v) extSize(%v) ", i.Inode, extSize)
 			if extSize > 0 {
 				extBytes := make([]byte, extSize)
 				if _, err = io.ReadFull(buff, extBytes); err != nil {
@@ -1016,6 +1041,7 @@ func (i *Inode) UnmarshalInodeValue(buff *bytes.Buffer) (err error) {
 			if err = binary.Read(buff, binary.BigEndian, &ObjExtSize); err != nil {
 				return
 			}
+			log.LogDebugf("UnmarshalInodeValue ino(%v) ObjExtSize(%v) ", i.Inode, ObjExtSize)
 			if ObjExtSize > 0 {
 				objExtBytes := make([]byte, ObjExtSize)
 				if _, err = io.ReadFull(buff, objExtBytes); err != nil {
@@ -1035,7 +1061,7 @@ func (i *Inode) UnmarshalInodeValue(buff *bytes.Buffer) (err error) {
 			if err = binary.Read(buff, binary.BigEndian, &i.HybridCouldExtentsMigration.storageClass); err != nil {
 				return
 			}
-			if i.migrateToReplicaSystem() {
+			if proto.IsStorageClassReplica(i.HybridCouldExtentsMigration.storageClass) {
 				extSize = uint32(0)
 				if err = binary.Read(buff, binary.BigEndian, &extSize); err != nil {
 					return
@@ -2335,8 +2361,4 @@ func (i *Inode) updateStorageClass(storageClass uint32, isCache, isMigration boo
 	}
 
 	return nil
-}
-
-func (i *Inode) migrateToReplicaSystem() bool {
-	return i.HybridCouldExtentsMigration.storageClass == proto.MediaType_HDD || i.HybridCouldExtentsMigration.storageClass == proto.MediaType_SSD
 }

--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -2747,7 +2747,7 @@ func (m *metadataManager) opMetaUpdateExtentKeyAfterMigration(conn net.Conn, p *
 	mp.UpdateExtentKeyAfterMigration(req, p, remoteAddr)
 	m.updatePackRspSeq(mp, p)
 	m.respondToClientWithVer(conn, p)
-	log.LogDebugf("%s [opMetaRenewalForbiddenMigration] req: %d - %v, resp body: %v, "+
+	log.LogDebugf("%s [opMetaUpdateExtentKeyAfterMigration] req: %d - %v, resp body: %v, "+
 		"resp body: %s", remoteAddr, p.GetReqID(), req, p.GetResultMsg(), p.Data)
 	return
 }

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -755,7 +755,9 @@ func (mp *metaPartition) onStart(isCreate bool) (err error) {
 
 	mp.volType = volumeInfo.VolType
 	var ebsClient *blobstore.BlobStoreClient
-	if clusterInfo.EbsAddr != "" && proto.IsCold(mp.volType) {
+	//TODO: chihe
+	//if clusterInfo.EbsAddr != "" && proto.IsCold(mp.volType) {
+	if clusterInfo.EbsAddr != "" {
 		ebsClient, err = blobstore.NewEbsClient(
 			access.Config{
 				ConnMode: access.NoLimitConnMode,

--- a/metanode/partition_op_extent.go
+++ b/metanode/partition_op_extent.go
@@ -444,7 +444,7 @@ func (mp *metaPartition) ExtentsList(req *proto.GetExtentsRequest, p *Packet) (e
 		status = retMsg.Status
 	)
 
-	if !ino.storeInReplicaSystem() && (req.IsCache != true || req.IsMigration != true) {
+	if !ino.storeInReplicaSystem() && (req.IsCache != true && req.IsMigration != true) {
 		status = proto.OpErr
 		reply = []byte(fmt.Sprintf("ino %v storage type %v IsCache %v IsMigration %v do not support ExtentsList",
 			ino.Inode, ino.StorageClass, req.IsCache, req.IsMigration))
@@ -477,7 +477,7 @@ func (mp *metaPartition) ExtentsList(req *proto.GetExtentsRequest, p *Packet) (e
 					})
 				})
 			} else if req.IsMigration {
-				if !ino.migrateToReplicaSystem() {
+				if !proto.IsStorageClassReplica(ino.HybridCouldExtentsMigration.storageClass) {
 					status = proto.OpErr
 					reply = []byte(fmt.Sprintf("ino %v storage type %v not migrate to replica system",
 						ino.Inode, ino.StorageClass))

--- a/preload/sdk/preloadsdk.go
+++ b/preload/sdk/preloadsdk.go
@@ -147,15 +147,15 @@ func NewClient(config PreloadConfig) *PreLoadClient {
 	}
 
 	if ec, err = stream.NewExtentClient(&stream.ExtentConfig{
-		Volume:            config.Volume,
-		Masters:           config.Masters,
-		Preload:           true,
-		OnAppendExtentKey: mw.AppendExtentKey,
-		OnSplitExtentKey:  mw.SplitExtentKey,
-		OnGetExtents:      mw.GetExtents,
-		OnTruncate:        mw.Truncate,
-		VolumeType:        proto.VolumeTypeCold,
-		VolStorageClass:   view.VolStorageClass,
+		Volume:              config.Volume,
+		Masters:             config.Masters,
+		Preload:             true,
+		OnAppendExtentKey:   mw.AppendExtentKey,
+		OnSplitExtentKey:    mw.SplitExtentKey,
+		OnGetExtents:        mw.GetExtents,
+		OnTruncate:          mw.Truncate,
+		VolumeType:          proto.VolumeTypeCold,
+		AllowedStorageClass: view.AllowedStorageClass,
 	}); err != nil {
 		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
 		return nil

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1179,7 +1179,9 @@ func MediaTypeString(mediaType uint32) (value string) {
 	return
 }
 
-const ForbiddenMigrationRenewalPeriod = 2 * time.Minute
+// const ForbiddenMigrationRenewalPeriod = 2 * time.Minute
+// TODO:chihe debug
+const ForbiddenMigrationRenewalPeriod = 10 * time.Second
 
 func IsValidMediaType(mediaType uint32) bool {
 	if mediaType >= MediaType_SSD && mediaType <= MediaType_HDD {

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -1058,6 +1058,7 @@ type UpdateExtentKeyAfterMigrationRequest struct {
 type InodeGetWithEkResponse struct {
 	Info                     *InodeInfo     `json:"info"`
 	LayAll                   []InodeInfo    `json:"layerInfo"`
+	CacheExtents             []ExtentKey    `json:"cacheEks"`
 	HybridCloudExtents       []ExtentKey    `json:"eks"`
 	HybridCloudObjExtents    []ObjExtentKey `json:"objeks"`
 	MigrationExtents         []ExtentKey    `json:"migrationEks"`

--- a/sdk/data/blobstore/reader.go
+++ b/sdk/data/blobstore/reader.go
@@ -102,6 +102,7 @@ type ClientConfig struct {
 	FileCache       bool
 	FileSize        uint64
 	CacheThreshold  int
+	StorageClass    uint32
 }
 
 func NewReader(config ClientConfig) (reader *Reader) {
@@ -120,7 +121,7 @@ func NewReader(config ClientConfig) (reader *Reader) {
 	reader.fileCache = config.FileCache
 	reader.cacheThreshold = config.CacheThreshold
 
-	if proto.IsCold(reader.volType) {
+	if proto.IsStorageClassBlobStore(config.StorageClass) {
 		reader.ec.UpdateDataPartitionForColdVolume()
 	}
 

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -125,7 +125,7 @@ type ExtentConfig struct {
 	OnRenewalForbiddenMigration RenewalForbiddenMigrationFunc
 
 	CacheDpStorageClass uint32
-	VolStorageClass     uint32
+	AllowedStorageClass []uint32
 }
 
 type MultiVerMgr struct {
@@ -246,7 +246,7 @@ func NewExtentClient(config *ExtentConfig) (client *ExtentClient, err error) {
 retry:
 
 	client.dataWrapper, err = wrapper.NewDataPartitionWrapper(client, config.Volume, config.Masters,
-		config.Preload, config.MinWriteAbleDataPartitionCnt, config.VerReadSeq, config.VolStorageClass)
+		config.Preload, config.MinWriteAbleDataPartitionCnt, config.VerReadSeq, config.AllowedStorageClass)
 	if err != nil {
 		log.LogErrorf("NewExtentClient: new data partition wrapper failed: volume(%v) mayRetry(%v) err(%v)",
 			config.Volume, limit, err)
@@ -461,7 +461,11 @@ func (client *ExtentClient) RefreshExtentsCache(inode uint64) error {
 	if s == nil {
 		return nil
 	}
-	return s.GetExtents(false)
+	var isMigration = false
+	if s.isCache {
+		isMigration = true
+	}
+	return s.GetExtents(isMigration)
 }
 
 func (client *ExtentClient) ForceRefreshExtentsCache(inode uint64) error {

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -167,7 +167,7 @@ func (eh *ExtentHandler) write(data []byte, offset, size int, direct bool) (ek *
 	// If this write request is not continuous, and cannot be merged
 	// into the extent handler, just close it and return error.
 	// In this case, the caller should try to create a new extent handler.
-	if proto.IsHot(eh.stream.client.volumeType) || proto.IsStorageClassReplica(eh.storageClass) {
+	if proto.IsStorageClassReplica(eh.storageClass) {
 		if eh.fileOffset+eh.size != offset || eh.size+size > util.ExtentSize ||
 			(eh.storeMode == proto.TinyExtentType && eh.size+size > blksize) {
 
@@ -439,7 +439,7 @@ func (eh *ExtentHandler) cleanup() (err error) {
 func (eh *ExtentHandler) appendExtentKey() (err error) {
 	if eh.key != nil {
 		if eh.dirty {
-			if (proto.IsCold(eh.stream.client.volumeType) || proto.IsStorageClassBlobStore(eh.storageClass)) &&
+			if proto.IsStorageClassBlobStore(eh.storageClass) &&
 				eh.status == ExtentStatusError {
 				return
 			}
@@ -494,8 +494,7 @@ func (eh *ExtentHandler) waitForFlush() {
 
 func (eh *ExtentHandler) recoverPacket(packet *Packet) error {
 	packet.errCount++
-	if packet.errCount >= MaxPacketErrorCount || proto.IsCold(eh.stream.client.volumeType) ||
-		proto.IsStorageClassBlobStore(eh.storageClass) {
+	if packet.errCount >= MaxPacketErrorCount || proto.IsStorageClassBlobStore(eh.storageClass) {
 		return errors.New(fmt.Sprintf("recoverPacket failed: reach max error limit, eh(%v) packet(%v)", eh, packet))
 	}
 
@@ -675,7 +674,7 @@ func (eh *ExtentHandler) setRecovery() bool {
 
 func (eh *ExtentHandler) setError() bool {
 	//	log.LogDebugf("action[ExtentHandler.setError] stack (%v)", string(debug.Stack()))
-	if proto.IsHot(eh.stream.client.volumeType) || proto.IsStorageClassReplica(eh.storageClass) {
+	if proto.IsStorageClassReplica(eh.storageClass) {
 		atomic.StoreInt32(&eh.stream.status, StreamerError)
 	}
 	return atomic.CompareAndSwapInt32(&eh.status, ExtentStatusRecovery, ExtentStatusError)

--- a/sdk/data/stream/stream_reader.go
+++ b/sdk/data/stream/stream_reader.go
@@ -121,7 +121,7 @@ func (s *Streamer) GetExtentReader(ek *proto.ExtentKey, storageClass uint32) (*E
 	}
 
 	retryRead := true
-	if proto.IsCold(s.client.volumeType) || proto.IsStorageClassBlobStore(storageClass) {
+	if proto.IsStorageClassBlobStore(storageClass) {
 		retryRead = false
 	}
 

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -485,7 +485,7 @@ func (s *Streamer) doDirectWriteByAppend(req *ExtentRequest, direct bool, op uin
 	}
 
 	retry := true
-	if proto.IsCold(s.client.volumeType) || proto.IsStorageClassBlobStore(storageClass) {
+	if proto.IsStorageClassBlobStore(storageClass) {
 		retry = false
 	}
 	log.LogDebugf("action[doDirectWriteByAppend] inode %v  data process", s.inode)
@@ -640,7 +640,7 @@ func (s *Streamer) doOverwrite(req *ExtentRequest, direct bool, storageClass uin
 	}
 
 	retry := true
-	if proto.IsCold(s.client.volumeType) || proto.IsStorageClassBlobStore(storageClass) {
+	if proto.IsStorageClassBlobStore(storageClass) {
 		retry = false
 	}
 
@@ -814,7 +814,7 @@ func (s *Streamer) doAppendWrite(data []byte, offset, size int, direct bool, reU
 
 	log.LogDebugf("doAppendWrite enter: ino(%v) offset(%v) size(%v) storeMode(%v) storageClass(%v)",
 		s.inode, offset, size, storeMode, storageClass)
-	if proto.IsHot(s.client.volumeType) || proto.IsStorageClassReplica(storageClass) {
+	if proto.IsStorageClassReplica(storageClass) {
 		if reUseEk {
 			if isLastEkVerNotEqual := s.tryInitExtentHandlerByLastEk(offset, size, isMigration); isLastEkVerNotEqual {
 				log.LogDebugf("doAppendWrite enter: ino(%v) tryInitExtentHandlerByLastEk worked", s.inode)

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -82,7 +82,7 @@ type Wrapper struct {
 	verConfReadSeq               uint64
 	verReadSeq                   uint64
 	client                       *SimpleClientInfo
-	volStorageClass              uint32
+	allowedStorageClass          []uint32
 }
 
 func (w *Wrapper) GetMasterClient() *masterSDK.MasterClient {
@@ -91,7 +91,7 @@ func (w *Wrapper) GetMasterClient() *masterSDK.MasterClient {
 
 // NewDataPartitionWrapper returns a new data partition wrapper.
 func NewDataPartitionWrapper(client SimpleClientInfo, volName string, masters []string, preload bool,
-	minWriteAbleDataPartitionCnt int, verReadSeq uint64, volStorageClass uint32) (w *Wrapper, err error) {
+	minWriteAbleDataPartitionCnt int, verReadSeq uint64, allowedStorageClass []uint32) (w *Wrapper, err error) {
 	log.LogInfof("action[NewDataPartitionWrapper] verReadSeq %v", verReadSeq)
 
 	w = new(Wrapper)
@@ -102,7 +102,7 @@ func NewDataPartitionWrapper(client SimpleClientInfo, volName string, masters []
 	w.partitions = make(map[uint64]*DataPartition)
 	w.HostsStatus = make(map[string]bool)
 	w.preload = preload
-	w.volStorageClass = volStorageClass
+	w.allowedStorageClass = allowedStorageClass
 
 	w.minWriteAbleDataPartitionCnt = minWriteAbleDataPartitionCnt
 	if w.minWriteAbleDataPartitionCnt < 0 {
@@ -358,7 +358,7 @@ func (w *Wrapper) updateDataPartitionByRsp(isInit bool, DataPartitions []*proto.
 			ClientWrapper:         w,
 		}
 	}
-	if proto.IsStorageClassBlobStore(w.volStorageClass) {
+	if proto.VolSupportsBlobStore(w.allowedStorageClass) {
 		w.clearPartitions()
 	}
 	rwPartitionGroups := make([]*DataPartition, 0)
@@ -374,7 +374,7 @@ func (w *Wrapper) updateDataPartitionByRsp(isInit bool, DataPartitions []*proto.
 		log.LogInfof("updateDataPartition: dp(%v)", dp)
 		w.replaceOrInsertPartition(dp)
 		//do not insert preload dp in cold vol
-		if proto.IsStorageClassBlobStore(w.volStorageClass) && proto.IsPreLoadDp(dp.PartitionType) {
+		if proto.VolSupportsBlobStore(w.allowedStorageClass) && proto.IsPreLoadDp(dp.PartitionType) {
 			continue
 		}
 		if dp.Status == proto.ReadWrite {
@@ -387,8 +387,7 @@ func (w *Wrapper) updateDataPartitionByRsp(isInit bool, DataPartitions []*proto.
 
 	// isInit used to identify whether this call is caused by mount action
 	if isInit || len(rwPartitionGroups) >= w.minWriteAbleDataPartitionCnt ||
-		(proto.IsStorageClassBlobStore(w.volStorageClass) &&
-			(len(rwPartitionGroups) >= 1)) {
+		(proto.VolSupportsBlobStore(w.allowedStorageClass) && (len(rwPartitionGroups) >= 1)) {
 		log.LogInfof("updateDataPartition: refresh dpSelector of volume(%v) with %v rw partitions(%v all), isInit(%v), minWriteAbleDataPartitionCnt(%v)",
 			w.volName, len(rwPartitionGroups), len(DataPartitions), isInit, w.minWriteAbleDataPartitionCnt)
 		w.refreshDpSelector(rwPartitionGroups)
@@ -477,7 +476,7 @@ func (w *Wrapper) AllocatePreLoadDataPartition(volName string, count int, capaci
 	rwPartitionGroups := make([]*DataPartition, 0)
 	for _, partition := range dpv.DataPartitions {
 		dp := convert(partition)
-		if (proto.IsStorageClassBlobStore(w.volStorageClass)) && !proto.IsPreLoadDp(dp.PartitionType) {
+		if proto.VolSupportsBlobStore(w.allowedStorageClass) && !proto.IsPreLoadDp(dp.PartitionType) {
 			continue
 		}
 		log.LogInfof("updateDataPartition: dp(%v)", dp)
@@ -521,7 +520,7 @@ func (w *Wrapper) replaceOrInsertPartition(dp *DataPartition) {
 // GetDataPartition returns the data partition based on the given partition ID.
 func (w *Wrapper) GetDataPartition(partitionID uint64) (*DataPartition, error) {
 	dp, ok := w.tryGetPartition(partitionID)
-	if !ok && (!proto.IsStorageClassBlobStore(w.volStorageClass)) { // cache miss && hot volume
+	if !ok && !proto.VolSupportsBlobStore(w.allowedStorageClass) { // cache miss && hot volume
 		err := w.getDataPartitionFromMaster(false, partitionID)
 		if err == nil {
 			dp, ok = w.tryGetPartition(partitionID)


### PR DESCRIPTION
**What this PR does / why we need it**:
1.Simplify the logic of updating extent key after migration
2. reset inode reserved when excute marshall operation
3. initial ebs client in mp
4. remove cold vol or hot vol check in client and objectnode