### PR TITLE
fix(master): in create vol procedure, update datapartition view cache right after the creation of datapartitions

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -3359,6 +3359,7 @@ func (c *Cluster) createVol(req *createVolReq) (vol *Vol, err error) {
 			req.name, readWriteDpCountOfMediaType, proto.MediaTypeString(chosenMediaType))
 	}
 
+	vol.dataPartitions.updateResponseCache(true, 0, vol.VolType)
 	vol.updateViewCache(c)
 	log.LogInfof("action[createVol] vol[%v], readableAndWritableCnt[%v]",
 		req.name, vol.dataPartitions.readableAndWritableCnt)

--- a/master/data_partition_map.go
+++ b/master/data_partition_map.go
@@ -244,6 +244,8 @@ func (dpMap *DataPartitionMap) updateResponseCache(needsUpdate bool, minPartitio
 			return
 		}
 		dpResps := dpMap.getDataPartitionsView(minPartitionID)
+		log.LogDebugf("[updateResponseCache] vol(%v) needsUpdate(%v) minPartitionID(%v) volType(%v)  dpNum(%v)",
+			dpMap.volName, needsUpdate, minPartitionID, volType, len(dpResps))
 		if len(dpResps) == 0 && proto.IsHot(volType) {
 			log.LogError(fmt.Sprintf("action[updateDpResponseCache],volName[%v] minPartitionID:%v,err:%v",
 				dpMap.volName, minPartitionID, proto.ErrNoAvailDataPartition))


### PR DESCRIPTION
… right after the creation of datapartitions

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fix(master): in create vol procedure, update datapartition view cache right after the creation of datapartitions.
to void backgroud goroutine trigger datapartition view cache update while creating datapartition and cause the view cache imcomplete

