### PR TITLE
feat(client): exit when volume has been marked delete

### DIFF
--- a/client/fuse.go
+++ b/client/fuse.go
@@ -657,7 +657,17 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 			volumeInfo, err = mc.AdminAPI().GetVolumeSimpleInfo(opt.Volname)
 			if err != nil {
 				log.LogErrorf("UpdateVolConf: get vol info from master failed, err %s", err.Error())
+				if err == proto.ErrVolNotExists {
+					daemonize.SignalOutcome(err)
+					os.Exit(1)
+				}
 				continue
+			}
+			if volumeInfo.Status == proto.VolStatusMarkDelete {
+				err = fmt.Errorf("vol [%s] has been deleted, stop client", volumeInfo.Name)
+				log.LogError(err)
+				daemonize.SignalOutcome(err)
+				os.Exit(1)
 			}
 			super.SetTransaction(volumeInfo.EnableTransaction, volumeInfo.TxTimeout, volumeInfo.TxConflictRetryNum, volumeInfo.TxConflictRetryInterval)
 			if proto.IsCold(opt.VolType) {

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -558,7 +558,7 @@ func delVol(name string, t *testing.T) {
 	vol, err := server.cluster.getVol(name)
 	assert.True(t, err == nil)
 
-	assert.True(t, vol.Status == markDelete)
+	assert.True(t, vol.Status == proto.VolStatusMarkDelete)
 }
 
 func setVolCapacity(capacity uint64, url string, t *testing.T) {

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -309,7 +309,7 @@ func (c *Cluster) checkReplicaMetaPartitions() (
 
 	vols := c.copyVols()
 	for _, vol := range vols {
-		if vol.Status == markDelete {
+		if vol.Status == proto.VolStatusMarkDelete {
 			markDeleteVolNames[vol.Name] = struct{}{}
 			continue
 		}
@@ -1091,7 +1091,7 @@ func (c *Cluster) updateDataNode(dataNode *DataNode, dps []*proto.DataPartitionR
 			if err != nil {
 				continue
 			}
-			if vol.Status == markDelete {
+			if vol.Status == proto.VolStatusMarkDelete {
 				continue
 			}
 			if dp, err := vol.getDataPartitionByID(vr.PartitionID); err == nil {
@@ -1122,7 +1122,7 @@ func (c *Cluster) updateMetaNode(metaNode *MetaNode, metaPartitions []*proto.Met
 				continue
 			}
 
-			if vol.Status == markDelete {
+			if vol.Status == proto.VolStatusMarkDelete {
 				continue
 			}
 

--- a/master/const.go
+++ b/master/const.go
@@ -204,12 +204,12 @@ const (
 )
 
 const (
-	normal               uint8 = 0
-	markDelete           uint8 = 1
-	normalZone                 = 0
-	unavailableZone            = 1
-	metaNodesUnAvailable       = 2
-	dataNodesUnAvailable       = 3
+	normal uint8 = 0
+
+	normalZone           = 0
+	unavailableZone      = 1
+	metaNodesUnAvailable = 2
+	dataNodesUnAvailable = 3
 )
 
 const (

--- a/master/gapi_volume.go
+++ b/master/gapi_volume.go
@@ -360,7 +360,7 @@ func (s *VolumeService) listVolume(ctx context.Context, args struct {
 			continue
 		}
 
-		if vol.Status == markDelete {
+		if vol.Status == proto.VolStatusMarkDelete {
 			continue
 		}
 

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -545,7 +545,7 @@ func (mm *monitorMetrics) setMpAndDpMetrics() {
 
 	vols := mm.cluster.copyVols()
 	for _, vol := range vols {
-		if vol.Status == markDelete {
+		if vol.Status == proto.VolStatusMarkDelete {
 			continue
 		}
 		var dps *DataPartitionMap
@@ -700,7 +700,7 @@ func (mm *monitorMetrics) setMpInconsistentErrorMetric() {
 	defer mm.cluster.volMutex.RUnlock()
 
 	for _, vol := range mm.cluster.vols {
-		if vol.Status == markDelete {
+		if vol.Status == proto.VolStatusMarkDelete {
 			continue
 		}
 		vol.mpsLock.RLock()

--- a/master/vol.go
+++ b/master/vol.go
@@ -277,7 +277,7 @@ func (mpsLock *mpsLockManager) CheckExceptionLock(interval time.Duration, expire
 	for {
 		select {
 		case <-ticker.C:
-			if mpsLock.vol.status() == markDelete || atomic.LoadInt32(&mpsLock.enable) == 0 {
+			if mpsLock.vol.status() == proto.VolStatusMarkDelete || atomic.LoadInt32(&mpsLock.enable) == 0 {
 				break
 			}
 			if !log.EnableDebug() {
@@ -307,7 +307,7 @@ func (vol *Vol) CheckStrategy(c *Cluster) {
 		waited := false
 		for {
 			time.Sleep(waitTime)
-			if vol.Status == markDelete {
+			if vol.Status == proto.VolStatusMarkDelete {
 				break
 			}
 			if c != nil && c.IsLeader() {
@@ -501,7 +501,7 @@ func (vol *Vol) initDataPartitions(c *Cluster) (err error) {
 }
 
 func (vol *Vol) checkDataPartitions(c *Cluster) (cnt int) {
-	if vol.getDataPartitionsCount() == 0 && vol.Status != markDelete && proto.IsHot(vol.VolType) {
+	if vol.getDataPartitionsCount() == 0 && vol.Status != proto.VolStatusMarkDelete && proto.IsHot(vol.VolType) {
 		c.batchCreateDataPartition(vol, 1, false)
 	}
 
@@ -828,7 +828,7 @@ func (vol *Vol) checkAutoDataPartitionCreation(c *Cluster) {
 		return
 	}
 
-	vol.setStatus(normal)
+	vol.setStatus(proto.VolStatusNormal)
 	log.LogInfof("action[autoCreateDataPartitions] vol[%v] before autoCreateDataPartitions", vol.Name)
 	if !c.DisableAutoAllocate && !vol.Forbidden {
 		vol.autoCreateDataPartitions(c)
@@ -859,7 +859,7 @@ func (vol *Vol) shouldInhibitWriteBySpaceFull() bool {
 func (vol *Vol) needCreateDataPartition() (ok bool, err error) {
 
 	ok = false
-	if vol.status() == markDelete {
+	if vol.status() == proto.VolStatusMarkDelete {
 		err = proto.ErrVolNotExists
 		return
 	}
@@ -1108,7 +1108,7 @@ func (vol *Vol) checkStatus(c *Cluster) {
 	vol.updateViewCache(c)
 	vol.volLock.Lock()
 	defer vol.volLock.Unlock()
-	if vol.Status != markDelete {
+	if vol.Status != proto.VolStatusMarkDelete {
 		return
 	}
 	log.LogInfof("action[volCheckStatus] vol[%v],status[%v]", vol.Name, vol.Status)

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -349,7 +349,7 @@ func TestVolMpsLock(t *testing.T) {
 	}
 	vol.mpsLock.Lock()
 	mpsLock := vol.mpsLock
-	assert.True(t, !(mpsLock.vol.status() == markDelete || atomic.LoadInt32(&mpsLock.enable) == 0))
+	assert.True(t, !(mpsLock.vol.status() == proto.VolStatusMarkDelete || atomic.LoadInt32(&mpsLock.enable) == 0))
 
 	assert.True(t, mpsLock.onLock == true)
 	time.Sleep(time.Microsecond * 100)

--- a/proto/status.go
+++ b/proto/status.go
@@ -21,3 +21,9 @@ const (
 	ReadWrite   = 2
 	Unavailable = -1
 )
+
+// volume status
+const (
+	VolStatusNormal     uint8 = 0
+	VolStatusMarkDelete uint8 = 1
+)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Exit the client when volume has been marked delete.
2. Use proto.VolStatusMarkDelete to substitute master.markDelete.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2940 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
