### PR TITLE
fix(libsdk): fix bug, cfs_getattr return ENOENT after cfs_unlink, cfs…

### DIFF
--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -1055,6 +1055,7 @@ func cfs_unlink(id C.int64_t, path *C.char) C.int {
 	if info != nil {
 		_ = c.mw.Evict(info.Inode, absPath)
 		c.ic.Delete(info.Inode)
+		c.dc.Delete(absPath)
 	}
 	return 0
 }


### PR DESCRIPTION
…_open,cfs_write.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
cfs_getattr return ENOENT after cfs_unlink, cfs_open,cfs_write. Due to cfs_unlink not delete dc
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
