### PR TITLE
[Feature]: Support query disk decommission progress in cfs-cli

### DIFF
--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -27,6 +27,7 @@ const (
 	CliOpUpdate               = "update"
 	CliOpDecommission         = "decommission"
 	CliOpRecommission         = "recommission"
+	CliOpQueryProgress        = "query-progress"
 	CliOpMigrate              = "migrate"
 	CliOpDownloadZip          = "load"
 	CliOpMetaCompatibility    = "meta"

--- a/cli/cmd/disk.go
+++ b/cli/cmd/disk.go
@@ -24,6 +24,7 @@ func newDiskCmd(client *master.MasterClient) *cobra.Command {
 		newListBadDiskCmd(client),
 		newDecommissionDiskCmd(client),
 		newRecommissionDiskCmd(client),
+		newQueryDecommissionDiskCmd(client),
 	)
 	return cmd
 }
@@ -102,6 +103,30 @@ func newRecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
 				return
 			}
 			stdout("Mark disk %v:%v to be recommissioned", args[0], args[1])
+		},
+	}
+	return cmd
+}
+
+const (
+	cmdQueryDecommissionDiskProgressShort = "Query decommmission progress on datanode"
+)
+
+func newQueryDecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   CliOpQueryProgress + " [DATA NODE ADDR] [DISK]",
+		Short: cmdQueryDecommissionDiskProgressShort,
+		Args:  cobra.MinimumNArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			defer func() {
+				errout(err)
+			}()
+			progress, err := client.AdminAPI().QueryDecommissionDiskProgress(args[0], args[1])
+			if err != nil {
+				return
+			}
+			stdout("%v", formatDecommissionProgress(progress))
 		},
 	}
 	return cmd

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -872,3 +872,13 @@ func formatBadDiskInfoRow(disk proto.BadDiskInfo) string {
 	msgDpIdList := fmt.Sprintf("%v", disk.DiskErrPartitionList)
 	return fmt.Sprintf(badDiskDetailTableRowPattern, disk.Address, disk.Path, disk.TotalPartitionCnt, len(disk.DiskErrPartitionList), msgDpIdList)
 }
+
+func formatDecommissionProgress(progress *proto.DecommissionProgress) string {
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("Status:           %v\n", progress.StatusMessage))
+	sb.WriteString(fmt.Sprintf("Progress:         %v\n", progress.Progress))
+	if len(progress.FailedDps) != 0 {
+		sb.WriteString(fmt.Sprintf("Failed Dps:       %v\n", progress.FailedDps))
+	}
+	return sb.String()
+}

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -3857,8 +3857,9 @@ func (m *Server) queryDiskDecoProgress(w http.ResponseWriter, r *http.Request) {
 	status, progress := disk.updateDecommissionStatus(m.cluster, true)
 	progress, _ = FormatFloatFloor(progress, 4)
 	resp := &proto.DecommissionProgress{
-		Status:   status,
-		Progress: fmt.Sprintf("%.2f%%", progress*float64(100)),
+		Status:        status,
+		Progress:      fmt.Sprintf("%.2f%%", progress*float64(100)),
+		StatusMessage: GetDecommissionStatusMessage(status),
 	}
 	if status == DecommissionFail {
 		dps := disk.GetLatestDecommissionDP(m.cluster)
@@ -5305,8 +5306,9 @@ func (m *Server) queryDataNodeDecoProgress(w http.ResponseWriter, r *http.Reques
 	status, progress := dn.updateDecommissionStatus(m.cluster, true)
 	progress, _ = FormatFloatFloor(progress, 4)
 	resp := &proto.DecommissionProgress{
-		Status:   status,
-		Progress: fmt.Sprintf("%.2f%%", progress*float64(100)),
+		Status:        status,
+		Progress:      fmt.Sprintf("%.2f%%", progress*float64(100)),
+		StatusMessage: GetDecommissionStatusMessage(status),
 	}
 	if status == DecommissionFail {
 		err, dps := dn.GetDecommissionFailedDPByTerm(m.cluster)

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1029,6 +1029,25 @@ const (
 	defaultDecommissionDiskParallelFactor = 0
 )
 
+func GetDecommissionStatusMessage(status uint32) string {
+	switch status {
+	case DecommissionInitial:
+		return "Initial"
+	case markDecommission:
+		return "Marked"
+	case DecommissionPause:
+		return "Paused"
+	case DecommissionRunning:
+		return "Running"
+	case DecommissionSuccess:
+		return "Success"
+	case DecommissionFail:
+		return "Failed"
+	default:
+		return "Unknown"
+	}
+}
+
 func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk string, raftForce bool, term uint64, c *Cluster) bool {
 	if !partition.canMarkDecommission(term) {
 		log.LogWarnf("action[MarkDecommissionStatus] dp[%v] cannot make decommission:status[%v]",

--- a/proto/model.go
+++ b/proto/model.go
@@ -331,9 +331,10 @@ type MetaPartitionDiagnosis struct {
 }
 
 type DecommissionProgress struct {
-	Status    uint32
-	Progress  string
-	FailedDps []uint64
+	Status        uint32
+	Progress      string
+	FailedDps     []uint64
+	StatusMessage string
 }
 
 type BadDiskInfo struct {

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -853,6 +853,21 @@ func (api *AdminAPI) RecommissionDisk(addr string, disk string) (err error) {
 	return
 }
 
+func (api *AdminAPI) QueryDecommissionDiskProgress(addr string, disk string) (progress *proto.DecommissionProgress, err error) {
+	var data []byte
+	request := newAPIRequest(http.MethodPost, proto.QueryDiskDecoProgress)
+	request.params["addr"] = addr
+	request.params["disk"] = disk
+	if data, err = api.mc.serveRequest(request); err != nil {
+		return
+	}
+	progress = &proto.DecommissionProgress{}
+	if err = json.Unmarshal(data, progress); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) ListQuotaAll() (volsInfo []*proto.VolInfo, err error) {
 	var request = newAPIRequest(http.MethodGet, proto.QuotaListAll)
 	var data []byte


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
* Support query decommission disk progress in cli.

**It looks like:**

```bash
root@nature-Lenovo-XiaoXinAir-14ALC-2021:/home/nature/Workspace/cubefs# ./build/bin/cfs-cli disk query-progress 172.16.1.101:17310 /home/nature/disk/data1/disk
Status:           Success
Progress:         100.00%
```

**Help message:**

```
nature@nature-Lenovo-XiaoXinAir-14ALC-2021:~/Workspace/cubefs$ ./build/bin/cfs-cli disk -h
Manage cluster disks

Usage:
  cfs-cli disk [command]

Aliases:
  disk, disk

Available Commands:
  check          Check and list unhealthy disks
  decommission   Decommission disk on datanode
  query-progress Query decommmission progress on datanode
  recommission   Recommission disk on datanode

Flags:
  -h, --help   help for disk

Use "cfs-cli disk [command] --help" for more information about a command.
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
