### PR TITLE
feat(master): [hybrid cloud] handle compatibility of master when older version upgrade to hybrid cloud

### DIFF
--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -406,6 +406,7 @@ func formatDataPartitionInfo(partition *proto.DataPartitionInfo) string {
 	sb.WriteString(fmt.Sprintf("volume name   : %v\n", partition.VolName))
 	sb.WriteString(fmt.Sprintf("volume ID     : %v\n", partition.VolID))
 	sb.WriteString(fmt.Sprintf("PartitionID   : %v\n", partition.PartitionID))
+	sb.WriteString(fmt.Sprintf("PartitionType : %v\n", partition.PartitionType))
 	sb.WriteString(fmt.Sprintf("Status        : %v\n", formatDataPartitionStatus(partition.Status)))
 	sb.WriteString(fmt.Sprintf("LastLoadedTime: %v\n", formatTime(partition.LastLoadedTime)))
 	sb.WriteString(fmt.Sprintf("OfflinePeerID : %v\n", partition.OfflinePeerID))

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -124,8 +124,9 @@ func createDefaultMasterServerForTest() *Server {
 		"walDir":"/tmp/cubefs/raft",
 		"storeDir":"/tmp/cubefs/rocksdbstore",
 		"clusterName":"cubefs",
-        "bStoreAddr":"127.0.0.1:8500",
-        "bStoreServicePath":"access"
+		"bStoreAddr":"127.0.0.1:8500",
+		"bStoreServicePath":"access",
+		"legacyDataMediaType": 1
 	}`
 
 	testServer, err := createMasterServer(cfgJSON)

--- a/master/config.go
+++ b/master/config.go
@@ -51,7 +51,7 @@ const (
 	intervalToScanS3Expiration          = "intervalToScanS3Expiration"
 	cfgVolForceDeletion                 = "volForceDeletion"
 	cfgVolDeletionDentryThreshold       = "volDeletionDentryThreshold"
-	cfgDefaultDataMediaType             = "defaultDataMediaType" //for hybrid cloud
+	cfgLegacyDataMediaType              = "legacyDataMediaType" //for hybrid cloud upgrade
 )
 
 // default value
@@ -143,6 +143,8 @@ type clusterConfig struct {
 
 	volForceDeletion           bool   // when delete a volume, ignore it's dentry count or not
 	volDeletionDentryThreshold uint64 // in case of volForceDeletion is set to false, define the dentry count threshold to allow volume deletion
+
+	legacyDataMediaType uint32 // used to upgrade master's meta to hybrid cloud version
 }
 
 func newClusterConfig() (cfg *clusterConfig) {

--- a/master/master_manager.go
+++ b/master/master_manager.go
@@ -120,15 +120,22 @@ func (m *Server) restoreIDAlloc() {
 
 // Load stored metadata into the memory
 func (m *Server) loadMetadata() {
+	var err error
+	var updatedDataNodes []*DataNode
+	var autoUpdatedZones []*Zone
+	var autoUpdatedLegacyVols []*Vol
+	var updatedDataPartitions []*DataPartition
+
 	log.LogInfo("action[loadMetadata] begin")
 	syslog.Println("action[loadMetadata] begin")
 	m.clearMetadata()
 	m.restoreIDAlloc()
 	m.cluster.fsm.restore()
-	var err error
+
 	if err = m.cluster.loadClusterValue(); err != nil {
 		panic(err)
 	}
+
 	var loadDomain bool
 	if m.cluster.FaultDomain { // try load exclude
 		if loadDomain, err = m.cluster.loadZoneDomain(); err != nil {
@@ -160,7 +167,7 @@ func (m *Server) loadMetadata() {
 		}
 	}
 
-	if err = m.cluster.loadDataNodes(); err != nil {
+	if err, updatedDataNodes = m.cluster.loadDataNodes(); err != nil {
 		panic(err)
 	}
 
@@ -168,18 +175,19 @@ func (m *Server) loadMetadata() {
 		panic(err)
 	}
 
-	if err = m.cluster.loadZoneValue(); err != nil {
+	if err, autoUpdatedZones = m.cluster.loadZoneValue(); err != nil {
 		panic(err)
 	}
 
-	if err = m.cluster.loadVols(); err != nil {
+	if err, autoUpdatedLegacyVols = m.cluster.loadVols(); err != nil {
 		panic(err)
 	}
 
 	if err = m.cluster.loadMetaPartitions(); err != nil {
 		panic(err)
 	}
-	if err = m.cluster.loadDataPartitions(); err != nil {
+
+	if err, updatedDataPartitions = m.cluster.loadDataPartitions(); err != nil {
 		panic(err)
 	}
 	if err = m.cluster.loadDecommissionDiskList(); err != nil {
@@ -188,7 +196,6 @@ func (m *Server) loadMetadata() {
 	if err = m.cluster.startDecommissionListTraverse(); err != nil {
 		panic(err)
 	}
-	log.LogInfo("action[loadMetadata] end")
 
 	log.LogInfo("action[loadUserInfo] begin")
 	if err = m.user.loadUserStore(); err != nil {
@@ -231,13 +238,48 @@ func (m *Server) loadMetadata() {
 		panic(err)
 	}
 	log.LogInfo("action[loadLcNodes] end")
-	syslog.Println("action[loadMetadata] end")
 
 	log.LogInfo("action[loadS3QoSInfo] begin")
 	if err = m.cluster.loadS3ApiQosInfo(); err != nil {
 		panic(err)
 	}
 	log.LogInfo("action[loadS3QoSInfo] end")
+
+	for _, dn := range updatedDataNodes {
+		log.LogInfof("action[loadVols] auto updated legacy datanode(%v), persist it", dn.Addr)
+		if err = m.cluster.syncUpdateDataNode(dn); err != nil {
+			log.LogCriticalf("action[loadVols] auto updated legacy datanode(%v), but persist failed: %v", dn.Addr, err.Error())
+			panic(err)
+		}
+	}
+
+	for _, z := range autoUpdatedZones {
+		log.LogInfof("action[loadVols] auto updated legacy zone(%v), persist it", z.name)
+		if err = m.cluster.sycnPutZoneInfo(z); err != nil {
+			log.LogCriticalf("action[loadVols] auto updated legacy zone(%v), but persist failed: %v", z.name, err.Error())
+			panic(err)
+		}
+	}
+
+	for _, v := range autoUpdatedLegacyVols {
+		log.LogInfof("action[loadVols] auto updated legacy vol(%v), persist it", v.Name)
+		if err = m.cluster.syncUpdateVol(v); err != nil {
+			log.LogCriticalf("action[loadVols] auto updated legacy vol(%v), but persist failed: %v", v.Name, err.Error())
+			panic(err)
+		}
+	}
+
+	for _, dp := range updatedDataPartitions {
+		log.LogInfof("action[loadVols] auto updated legacy dataPartition(%v), persist it", dp.PartitionID)
+		if err = m.cluster.syncUpdateDataPartition(dp); err != nil {
+			log.LogCriticalf("action[loadVols] auto updated legacy dataPartition(%v), but persist failed: %v",
+				dp.PartitionID, err.Error())
+			panic(err)
+		}
+	}
+
+	log.LogInfo("action[loadMetadata] end")
+	syslog.Println("action[loadMetadata] end")
 }
 
 func (m *Server) clearMetadata() {

--- a/master/server.go
+++ b/master/server.go
@@ -105,33 +105,32 @@ var (
 
 // Server represents the server in a cluster
 type Server struct {
-	id                   uint64
-	clusterName          string
-	ip                   string
-	bindIp               bool
-	port                 string
-	logDir               string
-	walDir               string
-	storeDir             string
-	bStoreAddr           string
-	servicePath          string
-	retainLogs           uint64
-	tickInterval         int
-	raftRecvBufSize      int
-	electionTick         int
-	leaderInfo           *LeaderInfo
-	config               *clusterConfig
-	cluster              *Cluster
-	user                 *User
-	rocksDBStore         *raftstore_db.RocksDBStore
-	raftStore            raftstore.RaftStore
-	fsm                  *MetadataFsm
-	partition            raftstore.Partition
-	wg                   sync.WaitGroup
-	reverseProxy         *httputil.ReverseProxy
-	metaReady            bool
-	apiServer            *http.Server
-	defaultDataMediaType uint32 // used to upgrade master's meta to hybrid cloud version
+	id              uint64
+	clusterName     string
+	ip              string
+	bindIp          bool
+	port            string
+	logDir          string
+	walDir          string
+	storeDir        string
+	bStoreAddr      string
+	servicePath     string
+	retainLogs      uint64
+	tickInterval    int
+	raftRecvBufSize int
+	electionTick    int
+	leaderInfo      *LeaderInfo
+	config          *clusterConfig
+	cluster         *Cluster
+	user            *User
+	rocksDBStore    *raftstore_db.RocksDBStore
+	raftStore       raftstore.RaftStore
+	fsm             *MetadataFsm
+	partition       raftstore.Partition
+	wg              sync.WaitGroup
+	reverseProxy    *httputil.ReverseProxy
+	metaReady       bool
+	apiServer       *http.Server
 }
 
 // NewServer creates a new server
@@ -371,9 +370,20 @@ func (m *Server) checkConfig(cfg *config.Config) (err error) {
 	}
 	m.config.volDeletionDentryThreshold = uint64(threshold)
 
-	//TODO:tangjingyu: deal compatibility, old version vol hot type convert to storageClass
-	m.defaultDataMediaType = cfg.GetUint32WithDefault(cfgDefaultDataMediaType, proto.MediaType_SSD)
-	syslog.Println("defaultDataMediaType=", m.defaultDataMediaType)
+	if !cfg.HasKey(cfgLegacyDataMediaType) {
+		m.config.legacyDataMediaType = proto.MediaType_Unspecified
+		syslog.Println("config [", cfgLegacyDataMediaType, "] not set")
+	} else {
+		err, m.config.legacyDataMediaType = cfg.GetUint32(cfgLegacyDataMediaType)
+		if err != nil || !proto.IsValidMediaType(m.config.legacyDataMediaType) {
+			err = fmt.Errorf("config [%v] invalid value: %v", cfgLegacyDataMediaType, m.config.legacyDataMediaType)
+			syslog.Println(err.Error())
+			return
+		}
+
+		syslog.Println("config [", cfgLegacyDataMediaType, "]: ", proto.MediaTypeString(m.config.legacyDataMediaType))
+	}
+
 	return
 }
 
@@ -405,6 +415,7 @@ func (m *Server) createRaftServer(cfg *config.Config) (err error) {
 	}
 	return
 }
+
 func (m *Server) initFsm() {
 	m.fsm = newMetadataFsm(m.rocksDBStore, m.retainLogs, m.raftStore.RaftServer())
 	m.fsm.registerLeaderChangeHandler(m.handleLeaderChange)

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1183,10 +1183,6 @@ func MediaTypeString(mediaType uint32) (value string) {
 	return
 }
 
-// const ForbiddenMigrationRenewalPeriod = 2 * time.Minute
-// TODO:chihe debug
-const ForbiddenMigrationRenewalPeriod = 10 * time.Second
-
 func IsValidMediaType(mediaType uint32) bool {
 	if mediaType >= MediaType_SSD && mediaType <= MediaType_HDD {
 		return true
@@ -1283,3 +1279,7 @@ func GetStorageClassByMediaType(mediaType uint32) (storageClass uint32) {
 
 	return
 }
+
+// const ForbiddenMigrationRenewalPeriod = 2 * time.Minute
+// TODO:chihe debug
+const ForbiddenMigrationRenewalPeriod = 10 * time.Second


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(master): [hybrid cloud] handle compatibility of master when older version upgrade to hybrid cloud
(1) auto set mediaType of datanode, zone, datapartiton by config legacy "legacyDataMediaType" and persist; 
(2) auto set storageClass of volume by config legacy "legacyDataMediaType" and persist; 
(3) if need to rollback master to older version, need to do nothing, just replace to old master and restart. because hybrid cloud master only add new fields to meta by not changed old fields.
