### PR TITLE
feat(data): if IO errors make disk status change to unavailable, not set all datapartitions of the disk as unavailable except the datapartition related to the if IO errors.

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -421,7 +421,7 @@ func (d *Disk) CheckDiskError(err error, rwFlag uint8) {
 
 func (d *Disk) doDiskError() {
 	d.Status = proto.Unavailable
-	d.ForceExitRaftStore()
+	//d.ForceExitRaftStore()
 }
 
 func (d *Disk) triggerDiskError(rwFlag uint8, dpId uint64) {
@@ -442,10 +442,10 @@ func (d *Disk) triggerDiskError(rwFlag uint8, dpId uint64) {
 
 	diskErrCnt := d.getTotalErrCnt()
 	diskErrPartitionCnt := d.GetDiskErrPartitionCount()
-	if diskErrCnt >= d.dataNode.diskUnavailableErrorCount || diskErrPartitionCnt >= d.dataNode.diskUnavailablePartitionErrorCount {
+	if diskErrPartitionCnt >= d.dataNode.diskUnavailablePartitionErrorCount {
 		msg := fmt.Sprintf("set disk unavailable for too many disk error, "+
-			"disk path(%v), ip(%v), diskErrCnt(%v) threshold(%v), diskErrPartitionCnt(%v) threshold(%v)",
-			d.Path, LocalIP, diskErrCnt, d.dataNode.diskUnavailableErrorCount, diskErrPartitionCnt, d.dataNode.diskUnavailablePartitionErrorCount)
+			"disk path(%v), ip(%v), diskErrCnt(%v), diskErrPartitionCnt(%v) threshold(%v)",
+			d.Path, LocalIP, diskErrCnt, diskErrPartitionCnt, d.dataNode.diskUnavailablePartitionErrorCount)
 		exporter.Warning(msg)
 		log.LogWarnf(msg)
 		d.doDiskError()
@@ -462,7 +462,7 @@ func (d *Disk) updateSpaceInfo() (err error) {
 		mesg := fmt.Sprintf("disk path %v error on %v", d.Path, LocalIP)
 		log.LogErrorf(mesg)
 		exporter.Warning(mesg)
-		d.ForceExitRaftStore()
+		//d.ForceExitRaftStore()
 	} else if d.Available <= 0 {
 		d.Status = proto.ReadOnly
 	} else {

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -600,9 +600,9 @@ func (dp *DataPartition) statusUpdate() {
 		dp.partitionStatus = proto.Unavailable
 	}
 
-	log.LogInfof("action[statusUpdate] dp %v raft status %v dp.status %v, status %v, disk status %v, res:%v",
-		dp.partitionID, dp.raftStatus, dp.Status(), status, float64(dp.disk.Status), int(math.Min(float64(status), float64(dp.disk.Status))))
-	dp.partitionStatus = int(math.Min(float64(status), float64(dp.disk.Status)))
+	log.LogInfof("action[statusUpdate] dp %v raft status %v dp.status %v, status %v, disk status %v",
+		dp.partitionID, dp.raftStatus, dp.Status(), status, float64(dp.disk.Status))
+	//dp.partitionStatus = int(math.Min(float64(status), float64(dp.disk.Status)))
 }
 
 func (dp *DataPartition) computeUsage() {

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -119,8 +119,6 @@ const (
 
 	ConfigServiceIDKey = "serviceIDKey"
 
-	// disk status becomes unavailable if disk error count reaches this value
-	ConfigKeyDiskUnavailableErrorCount = "diskUnavailableErrorCount"
 	// disk status becomes unavailable if disk error partition count reaches this value
 	ConfigKeyDiskUnavailablePartitionErrorCount = "diskUnavailablePartitionErrorCount"
 )
@@ -181,7 +179,6 @@ type DataNode struct {
 	cpuUtil                 atomicutil.Float64
 	cpuSamplerDone          chan struct{}
 
-	diskUnavailableErrorCount          uint64 // disk status becomes unavailable when disk error count reaches this value
 	diskUnavailablePartitionErrorCount uint64 // disk status becomes unavailable when disk error partition count reaches this value
 }
 
@@ -350,15 +347,6 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 	s.metricsDegrade = cfg.GetInt64(CfgMetricsDegrade)
 
 	s.serviceIDKey = cfg.GetString(ConfigServiceIDKey)
-
-	diskUnavailableErrorCount := cfg.GetInt64(ConfigKeyDiskUnavailableErrorCount)
-	if diskUnavailableErrorCount <= 0 || diskUnavailableErrorCount > 100 {
-		diskUnavailableErrorCount = DefaultDiskUnavailableErrorCount
-		log.LogDebugf("action[parseConfig] ConfigKeyDiskUnavailableErrorCount(%v) out of range, set as default(%v)",
-			diskUnavailableErrorCount, DefaultDiskUnavailableErrorCount)
-	}
-	s.diskUnavailableErrorCount = uint64(diskUnavailableErrorCount)
-	log.LogDebugf("action[parseConfig] load diskUnavailableErrorCount(%v)", s.diskUnavailableErrorCount)
 
 	diskUnavailablePartitionErrorCount := cfg.GetInt64(ConfigKeyDiskUnavailablePartitionErrorCount)
 	if diskUnavailablePartitionErrorCount <= 0 || diskUnavailablePartitionErrorCount > 100 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(data): if IO errors make disk status change to unavailable, not set all datapartitions of the disk as unavailable except the datapartition related to the if IO errors.