### PR TITLE
feat(data):if IO errors make disk status change to unavailable, not set all datapartitions of the disk as unavailable except the datapartition related to the if IO errors.

### DIFF
--- a/datanode/disk.go
+++ b/datanode/disk.go
@@ -322,7 +322,7 @@ func (d *Disk) triggerDiskError(err error) {
 		mesg := fmt.Sprintf("disk path %v error on %v", d.Path, LocalIP)
 		exporter.Warning(mesg)
 		log.LogErrorf(mesg)
-		d.ForceExitRaftStore()
+		//d.ForceExitRaftStore()
 		d.Status = proto.Unavailable
 	}
 	return
@@ -339,8 +339,7 @@ func (d *Disk) updateSpaceInfo() (err error) {
 		mesg := fmt.Sprintf("disk path %v error on %v", d.Path, LocalIP)
 		log.LogErrorf(mesg)
 		exporter.Warning(mesg)
-		d.ForceExitRaftStore()
-
+		//d.ForceExitRaftStore()
 	} else if d.Available <= 0 {
 		d.Status = proto.ReadOnly
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -585,9 +585,9 @@ func (dp *DataPartition) statusUpdate() {
 		status = proto.Unavailable
 	}
 
-	log.LogInfof("action[statusUpdate] dp %v raft status %v dp.status %v, status %v, dis status %v, res:%v",
-		dp.partitionID, dp.raftStatus, dp.Status(), status, float64(dp.disk.Status), int(math.Min(float64(status), float64(dp.disk.Status))))
-	dp.partitionStatus = int(math.Min(float64(status), float64(dp.disk.Status)))
+	log.LogInfof("action[statusUpdate] dp %v, raft status %v, dp.status %v, status %v, disk status %v",
+		dp.partitionID, dp.raftStatus, dp.Status(), status, float64(dp.disk.Status))
+	dp.partitionStatus = status
 }
 
 func parseFileName(filename string) (extentID uint64, isExtent bool) {
@@ -648,7 +648,7 @@ func (dp *DataPartition) checkIsDiskError(err error) (diskError bool) {
 		dp.disk.incWriteErrCnt()
 		dp.disk.Status = proto.Unavailable
 		dp.statusUpdate()
-		dp.disk.ForceExitRaftStore()
+		//dp.disk.ForceExitRaftStore()
 		diskError = true
 	}
 	return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
feat(data):if IO errors make disk status change to unavailable, not set all datapartitions of the disk as unavailable except the datapartition related to the if IO errors.