### PR TITLE
fix(sdk): not check result of InodeGet_ll leadto panic in Truncate.

### DIFF
--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -473,6 +473,10 @@ func (client *ExtentClient) Truncate(mw *meta.MetaWrapper, parentIno uint64, ino
 	var oldSize uint64
 	if mw.EnableSummary {
 		info, err = mw.InodeGet_ll(inode)
+		if err != nil || info == nil {
+			log.LogErrorf("Truncate: InodeGet failed, fullPath(%s) inode(%d) err(%v)\n", fullPath, inode, err)
+			return err
+		}
 		oldSize = info.Size
 	}
 	err = s.IssueTruncRequest(size, fullPath)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
not check result of InodeGet_ll leadto panic in Truncate
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
