### PR TITLE
fix(client): [hybrid cloud] Fix some places where the original condition "vol allowedStorage supports blobstore" should be changed to "vol storageClass is blobstore"

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -214,7 +214,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		s.bc = bcache.NewBcacheClient()
 	}
 
-	s.cacheDpStorageClass = opt.CacheDpStorageClass
+	s.cacheDpStorageClass = opt.VolCacheDpStorageClass
 
 	extentConfig := &stream.ExtentConfig{
 		Volume:            opt.Volname,
@@ -223,7 +223,6 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		NearRead:          opt.NearRead,
 		ReadRate:          opt.ReadRate,
 		WriteRate:         opt.WriteRate,
-		VolumeType:        opt.VolType,
 		BcacheEnable:      opt.EnableBcache,
 		BcacheDir:         opt.BcacheDir,
 		MaxStreamerLimit:  opt.MaxStreamerLimit,
@@ -240,8 +239,9 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 		DisableMetaCache:             DisableMetaCache,
 		MinWriteAbleDataPartitionCnt: opt.MinWriteAbleDataPartitionCnt,
 		OnRenewalForbiddenMigration:  s.mw.RenewalForbiddenMigration,
-		CacheDpStorageClass:          s.cacheDpStorageClass,
-		AllowedStorageClass:          opt.AllowedStorageClass,
+		VolStorageClass:              opt.VolStorageClass,
+		VolAllowedStorageClass:       opt.VolAllowedStorageClass,
+		VolCacheDpStorageClass:       s.cacheDpStorageClass,
 	}
 
 	s.ec, err = stream.NewExtentClient(extentConfig)
@@ -250,7 +250,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 	s.mw.VerReadSeq = s.ec.GetReadVer()
 
-	if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
 		s.ebsc, err = blobstore.NewEbsClient(access.Config{
 			ConnMode: access.NoLimitConnMode,
 			Consul: access.ConsulConfig{
@@ -276,7 +276,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 
 	s.suspendCh = make(chan interface{})
-	if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
 		go s.scheduleFlush()
 	}
 	if s.mw.EnableSummary {

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -352,7 +352,7 @@ func main() {
 	}
 
 	proto.InitBufferPool(opt.BuffersTotalLimit)
-	if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
 		buf.InitCachePool(opt.EbsBlockSize)
 	}
 	if opt.EnableBcache {
@@ -660,10 +660,13 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 				continue
 			}
 			super.SetTransaction(volumeInfo.EnableTransaction, volumeInfo.TxTimeout, volumeInfo.TxConflictRetryNum, volumeInfo.TxConflictRetryInterval)
-			if proto.VolSupportsBlobStore(opt.AllowedStorageClass) {
+
+			if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+				super.EbsBlockSize = volumeInfo.ObjBlockSize
+			}
+			if proto.IsStorageClassBlobStore(opt.VolStorageClass) {
 				super.CacheAction = volumeInfo.CacheAction
 				super.CacheThreshold = volumeInfo.CacheThreshold
-				super.EbsBlockSize = volumeInfo.ObjBlockSize
 			}
 		}
 	}()
@@ -901,9 +904,9 @@ func loadConfFromMaster(opt *proto.MountOptions) (err error) {
 	opt.TxTimeout = volumeInfo.TxTimeout
 	opt.TxConflictRetryNum = volumeInfo.TxConflictRetryNum
 	opt.TxConflictRetryInterval = volumeInfo.TxConflictRetryInterval
-	opt.CacheDpStorageClass = volumeInfo.CacheDpStorageClass
-	opt.AllowedStorageClass = volumeInfo.AllowedStorageClass
 	opt.VolStorageClass = volumeInfo.VolStorageClass
+	opt.VolAllowedStorageClass = volumeInfo.AllowedStorageClass
+	opt.VolCacheDpStorageClass = volumeInfo.CacheDpStorageClass
 
 	var clusterInfo *proto.ClusterInfo
 	clusterInfo, err = mc.AdminAPI().GetClusterInfo()

--- a/lcnode/lc_scanner.go
+++ b/lcnode/lc_scanner.go
@@ -128,7 +128,8 @@ func NewS3Scanner(adminTask *proto.AdminTask, l *LcNode) (*LcScanner, error) {
 		OnGetExtents:                metaWrapper.GetExtents,
 		OnTruncate:                  metaWrapper.Truncate,
 		OnRenewalForbiddenMigration: metaWrapper.RenewalForbiddenMigration,
-		AllowedStorageClass:         volumeInfo.AllowedStorageClass,
+		VolStorageClass:             volumeInfo.VolStorageClass,
+		VolAllowedStorageClass:      volumeInfo.AllowedStorageClass,
 	}
 	var extentClient *stream.ExtentClient
 	if extentClient, err = stream.NewExtentClient(extentConfig); err != nil {

--- a/lcnode/server.go
+++ b/lcnode/server.go
@@ -460,7 +460,8 @@ func (l *LcNode) debugServiceGetFile(w http.ResponseWriter, r *http.Request) {
 		OnGetExtents:                metaWrapper.GetExtents,
 		OnTruncate:                  metaWrapper.Truncate,
 		OnRenewalForbiddenMigration: metaWrapper.RenewalForbiddenMigration,
-		AllowedStorageClass:         asc,
+		//TODO: chenyang: add VolStorageClass
+		VolAllowedStorageClass: asc,
 	}
 	var extentClient *stream.ExtentClient
 	if extentClient, err = stream.NewExtentClient(extentConfig); err != nil {

--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -220,30 +220,31 @@ type client struct {
 	id int64
 
 	// mount config
-	volName             string
-	masterAddr          string
-	followerRead        bool
-	logDir              string
-	logLevel            string
-	ebsEndpoint         string
-	servicePath         string
-	volType             int
-	cacheAction         int
-	ebsBlockSize        int
-	enableBcache        bool
-	readBlockThread     int
-	writeBlockThread    int
-	cacheRuleKey        string
-	cacheThreshold      int
-	enableSummary       bool
-	secretKey           string
-	accessKey           string
-	subDir              string
-	pushAddr            string
-	cluster             string
-	dirChildrenNumLimit uint32
-	enableAudit         bool
-	allowedStorageClass []uint32
+	volName                string
+	masterAddr             string
+	followerRead           bool
+	logDir                 string
+	logLevel               string
+	ebsEndpoint            string
+	servicePath            string
+	volType                int
+	cacheAction            int
+	ebsBlockSize           int
+	enableBcache           bool
+	readBlockThread        int
+	writeBlockThread       int
+	cacheRuleKey           string
+	cacheThreshold         int
+	enableSummary          bool
+	secretKey              string
+	accessKey              string
+	subDir                 string
+	pushAddr               string
+	cluster                string
+	dirChildrenNumLimit    uint32
+	enableAudit            bool
+	volStorageClass        uint32
+	volAllowedStorageClass []uint32
 
 	// runtime context
 	cwd    string // current working directory
@@ -1214,20 +1215,20 @@ func (c *client) start() (err error) {
 	}
 	var ec *stream.ExtentClient
 	if ec, err = stream.NewExtentClient(&stream.ExtentConfig{
-		Volume:              c.volName,
-		VolumeType:          c.volType,
-		Masters:             masters,
-		FollowerRead:        c.followerRead,
-		OnAppendExtentKey:   mw.AppendExtentKey,
-		OnSplitExtentKey:    mw.SplitExtentKey,
-		OnGetExtents:        mw.GetExtents,
-		OnTruncate:          mw.Truncate,
-		BcacheEnable:        c.enableBcache,
-		OnLoadBcache:        c.bc.Get,
-		OnCacheBcache:       c.bc.Put,
-		OnEvictBcache:       c.bc.Evict,
-		DisableMetaCache:    true,
-		AllowedStorageClass: c.allowedStorageClass,
+		Volume:                 c.volName,
+		Masters:                masters,
+		FollowerRead:           c.followerRead,
+		OnAppendExtentKey:      mw.AppendExtentKey,
+		OnSplitExtentKey:       mw.SplitExtentKey,
+		OnGetExtents:           mw.GetExtents,
+		OnTruncate:             mw.Truncate,
+		BcacheEnable:           c.enableBcache,
+		OnLoadBcache:           c.bc.Get,
+		OnCacheBcache:          c.bc.Put,
+		OnEvictBcache:          c.bc.Evict,
+		DisableMetaCache:       true,
+		VolStorageClass:        c.volStorageClass,
+		VolAllowedStorageClass: c.volAllowedStorageClass,
 	}); err != nil {
 		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
 		return
@@ -1479,7 +1480,8 @@ func (c *client) loadConfFromMaster(masters []string) (err error) {
 	c.cacheAction = volumeInfo.CacheAction
 	c.cacheRuleKey = volumeInfo.CacheRule
 	c.cacheThreshold = volumeInfo.CacheThreshold
-	c.allowedStorageClass = volumeInfo.AllowedStorageClass
+	c.volStorageClass = volumeInfo.VolStorageClass
+	c.volAllowedStorageClass = volumeInfo.AllowedStorageClass
 
 	var clusterInfo *proto.ClusterInfo
 	clusterInfo, err = mc.AdminAPI().GetClusterInfo()

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -1070,7 +1070,6 @@ func (mp *metaPartition) fsmUpdateExtentKeyAfterMigration(inoParam *Inode) (resp
 
 func (mp *metaPartition) fsmSetCreateTime(req *SetCreateTimeRequest) (err error) {
 	log.LogDebugf("[fsmSetCreateTime] req %v", req)
-	//ino := NewInode(req.Inode,  proto.Mode(os.ModePerm)) //TODO:tangjingyu
 	ino := NewInode(req.Inode, 0)
 	item := mp.inodeTree.CopyGet(ino)
 	if item == nil {

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -3053,9 +3053,11 @@ func NewVolume(config *VolumeConfig) (*Volume, error) {
 		OnGetExtents:                metaWrapper.GetExtents,
 		OnTruncate:                  metaWrapper.Truncate,
 		OnRenewalForbiddenMigration: metaWrapper.RenewalForbiddenMigration,
-		AllowedStorageClass:         volumeInfo.AllowedStorageClass,
+		VolStorageClass:             volumeInfo.VolStorageClass,
+		VolAllowedStorageClass:      volumeInfo.AllowedStorageClass,
 	}
-	if proto.VolSupportsBlobStore(volumeInfo.AllowedStorageClass) {
+
+	if proto.IsStorageClassBlobStore(volumeInfo.VolStorageClass) {
 		if blockCache != nil {
 			extentConfig.BcacheEnable = true
 			extentConfig.OnLoadBcache = blockCache.Get

--- a/preload/sdk/preloadsdk.go
+++ b/preload/sdk/preloadsdk.go
@@ -147,15 +147,15 @@ func NewClient(config PreloadConfig) *PreLoadClient {
 	}
 
 	if ec, err = stream.NewExtentClient(&stream.ExtentConfig{
-		Volume:              config.Volume,
-		Masters:             config.Masters,
-		Preload:             true,
-		OnAppendExtentKey:   mw.AppendExtentKey,
-		OnSplitExtentKey:    mw.SplitExtentKey,
-		OnGetExtents:        mw.GetExtents,
-		OnTruncate:          mw.Truncate,
-		VolumeType:          proto.VolumeTypeCold,
-		AllowedStorageClass: view.AllowedStorageClass,
+		Volume:                 config.Volume,
+		Masters:                config.Masters,
+		Preload:                true,
+		OnAppendExtentKey:      mw.AppendExtentKey,
+		OnSplitExtentKey:       mw.SplitExtentKey,
+		OnGetExtents:           mw.GetExtents,
+		OnTruncate:             mw.Truncate,
+		VolStorageClass:        view.VolStorageClass,
+		VolAllowedStorageClass: view.AllowedStorageClass,
 	}); err != nil {
 		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
 		return nil

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -301,7 +301,6 @@ type MountOptions struct {
 	TxTimeout                    int64
 	TxConflictRetryNum           int64
 	TxConflictRetryInterval      int64
-	CacheDpStorageClass          uint32
 	VolType                      int
 	EbsEndpoint                  string
 	EbsServicePath               string
@@ -326,6 +325,7 @@ type MountOptions struct {
 	MinWriteAbleDataPartitionCnt int
 	FileSystemName               string
 	VerReadSeq                   uint64
-	AllowedStorageClass          []uint32
 	VolStorageClass              uint32
+	VolAllowedStorageClass       []uint32
+	VolCacheDpStorageClass       uint32
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(client): [hybrid cloud] Fix some places where the original condition "vol allowedStorage supports blobstore" should be changed to "vol storageClass is blobstore"

- Adds field volStorageClass to ExtentClient for this purpose. 
- Remove field volumeType from ExtentClient by the way.