### PR TITLE
feat(port): support multiple datanode/metanode instances using dif…

### DIFF
--- a/authnode/authnode_manager.go
+++ b/authnode/authnode_manager.go
@@ -63,6 +63,13 @@ func (m *Server) handlePeerChange(confChange *proto.ConfChange) (err error) {
 	case proto.ConfRemoveNode:
 		m.raftStore.DeleteNode(confChange.Peer.ID)
 		msg = fmt.Sprintf("clusterID[%v] peerID:%v,nodeAddr[%v] has been removed", m.clusterName, confChange.Peer.ID, addr)
+	case proto.ConfUpdatePeer:
+		var arr []string
+		if arr = strings.Split(addr, colonSplit); len(arr) < 2 {
+			msg = fmt.Sprintf("action[handlePeerChange] clusterID[%v] nodeAddr[%v] is invalid", m.clusterName, addr)
+			break
+		}
+		m.raftStore.UpdateNodeWithPort(confChange.Peer.ID, arr[0], int(m.config.heartbeatPort), int(m.config.replicaPort))
 	default:
 		// do nothing
 	}

--- a/datanode/const.go
+++ b/datanode/const.go
@@ -54,6 +54,7 @@ const (
 	ActionDecommissionPartition         = "ActionDecommissionPartition"
 	ActionAddDataPartitionRaftMember    = "ActionAddDataPartitionRaftMember"
 	ActionRemoveDataPartitionRaftMember = "ActionRemoveDataPartitionRaftMember"
+	ActionUpdateDataPartitionPeers      = "ActionUpdateDataPartitionPeers"
 	ActionDataPartitionTryToLeader      = "ActionDataPartitionTryToLeader"
 
 	ActionCreateDataPartition        = "ActionCreateDataPartition"

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -81,11 +81,7 @@ func (dp *DataPartition) StartRaft(isLoad bool) (err error) {
 		return nil
 	}
 
-	var (
-		heartbeatPort int
-		replicaPort   int
-		peers         []raftstore.PeerAddress
-	)
+	var peers []raftstore.PeerAddress
 	defer func() {
 		if r := recover(); r != nil {
 			mesg := fmt.Sprintf("StartRaft(%v)  Raft Panic (%v)", dp.partitionID, r)
@@ -99,11 +95,10 @@ func (dp *DataPartition) StartRaft(isLoad bool) (err error) {
 		}
 	}()
 
-	if heartbeatPort, replicaPort, err = dp.raftPort(); err != nil {
-		return
-	}
 	for _, peer := range dp.config.Peers {
 		addr := strings.Split(peer.Addr, ":")[0]
+		heartbeatPort, _ := strconv.Atoi(peer.HeartbeatPort)
+		replicaPort, _ := strconv.Atoi(peer.ReplicaPort)
 		rp := raftstore.PeerAddress{
 			Peer: raftproto.Peer{
 				ID: peer.ID,
@@ -362,9 +357,17 @@ func (dp *DataPartition) addRaftNode(req *proto.AddDataPartitionRaftMemberReques
 		heartbeatPort int
 		replicaPort   int
 	)
-	if heartbeatPort, replicaPort, err = dp.raftPort(); err != nil {
+
+	heartbeatPort, err = strconv.Atoi(req.AddPeer.HeartbeatPort)
+	if err != nil {
 		return
 	}
+
+	replicaPort, err = strconv.Atoi(req.AddPeer.ReplicaPort)
+	if err != nil {
+		return
+	}
+
 	log.LogInfof("action[addRaftNode] add raft node peer [%v]", req.AddPeer)
 	found := false
 	for _, peer := range dp.config.Peers {

--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -87,6 +87,13 @@ func (dp *DataPartition) ApplyMemberChange(confChange *raftproto.ConfChange, ind
 		}
 		log.LogInfof("action[ApplyMemberChange] ConfRemoveNode [%v], partitionId [%v]", req.RemovePeer, req.PartitionId)
 		isUpdated, err = dp.removeRaftNode(req, index)
+	case raftproto.ConfUpdatePeer:
+		req := &proto.UpdateDataPartitionPeerRequest{}
+		if err = json.Unmarshal(confChange.Context, req); err != nil {
+			return
+		}
+		log.LogInfof("action[ApplyMemberChange] ConfUpdatePeer [%v], partitionId [%v]", req.Peer, req.PartitionId)
+		isUpdated, err = dp.updateRaftPeer(req, index)
 	case raftproto.ConfUpdateNode:
 		log.LogDebugf("[updateRaftNode]: not support.")
 	default:

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -302,6 +302,8 @@ func (s *DataNode) parseConfig(cfg *config.Config) (err error) {
 	)
 	LocalIP = cfg.GetString(ConfigKeyLocalIP)
 	port = cfg.GetString(proto.ListenPort)
+	s.raftHeartbeat = cfg.GetString(proto.RaftHeartbeat)
+	s.raftReplica = cfg.GetString(proto.RaftReplica)
 	s.bindIp = cfg.GetBool(proto.BindIpKey)
 	serverPort = port
 	if regexpPort, err = regexp.Compile(`^(\d)+$`); err != nil {
@@ -531,7 +533,7 @@ func (s *DataNode) register(cfg *config.Config) {
 			// register this data node on the master
 			var nodeID uint64
 			if nodeID, err = MasterClient.NodeAPI().AddDataNodeWithAuthNode(fmt.Sprintf("%s:%v", LocalIP, s.port),
-				s.zoneName, s.serviceIDKey); err != nil {
+				s.zoneName, s.serviceIDKey, s.raftHeartbeat, s.raftReplica); err != nil {
 				log.LogErrorf("action[registerToMaster] cannot register this node to master[%v] err(%v).",
 					masterAddr, err)
 				timer.Reset(2 * time.Second)

--- a/depends/tiglabs/raft/proto/proto.go
+++ b/depends/tiglabs/raft/proto/proto.go
@@ -48,6 +48,7 @@ const (
 	ConfAddNode    ConfChangeType = 0
 	ConfRemoveNode ConfChangeType = 1
 	ConfUpdateNode ConfChangeType = 2
+	ConfUpdatePeer ConfChangeType = 3
 
 	EntryNormal     EntryType = 0
 	EntryConfChange EntryType = 1
@@ -185,6 +186,8 @@ func (t ConfChangeType) String() string {
 		return "ConfRemoveNode"
 	case 2:
 		return "ConfUpdateNode"
+	case 3:
+		return "ConfUpdatePeer"
 	}
 	return "unkown"
 }

--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -73,6 +73,8 @@ func (s *peerState) change(c *proto.ConfChange) {
 		delete(s.peers, c.Peer.ID)
 	case proto.ConfUpdateNode:
 		s.peers[c.Peer.ID] = c.Peer
+	case proto.ConfUpdatePeer:
+		s.peers[c.Peer.ID] = c.Peer
 	}
 	s.mu.Unlock()
 }

--- a/depends/tiglabs/raft/raft_fsm.go
+++ b/depends/tiglabs/raft/raft_fsm.go
@@ -20,9 +20,10 @@ import (
 	"math/rand"
 	"strings"
 
+	"time"
+
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/logger"
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
-	"time"
 )
 
 // CampaignType represents the type of campaigning
@@ -441,6 +442,8 @@ func (r *raftFsm) applyConfChange(cc *proto.ConfChange) (ok bool) {
 	case proto.ConfRemoveNode:
 		return r.removePeer(cc.Peer)
 	case proto.ConfUpdateNode:
+		r.updatePeer(cc.Peer)
+	case proto.ConfUpdatePeer:
 		r.updatePeer(cc.Peer)
 	}
 	return

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/raftstore"
 	"github.com/cubefs/cubefs/util"
 	"github.com/cubefs/cubefs/util/compressor"
 	"github.com/cubefs/cubefs/util/cryptoutil"
@@ -165,7 +166,7 @@ func parseRequestForUpdateMetaNode(r *http.Request) (nodeAddr string, id uint64,
 	return
 }
 
-func parseRequestForAddNode(r *http.Request) (nodeAddr, zoneName string, err error) {
+func parseRequestForAddNode(r *http.Request) (nodeAddr, zoneName, heartbeatPort, replicaPort string, err error) {
 	if err = r.ParseForm(); err != nil {
 		return
 	}
@@ -174,6 +175,12 @@ func parseRequestForAddNode(r *http.Request) (nodeAddr, zoneName string, err err
 	}
 	if zoneName = r.FormValue(zoneNameKey); zoneName == "" {
 		zoneName = DefaultZoneName
+	}
+	if heartbeatPort = r.FormValue(heartbeatPortKey); heartbeatPort == "" {
+		heartbeatPort = strconv.Itoa(raftstore.DefaultHeartbeatPort)
+	}
+	if replicaPort = r.FormValue(replicaPortKey); replicaPort == "" {
+		replicaPort = strconv.Itoa(raftstore.DefaultReplicaPort)
 	}
 	return
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2541,18 +2541,20 @@ func checkIpPort(addr string) bool {
 
 func (m *Server) addDataNode(w http.ResponseWriter, r *http.Request) {
 	var (
-		nodeAddr  string
-		zoneName  string
-		id        uint64
-		err       error
-		nodesetId uint64
+		nodeAddr      string
+		zoneName      string
+		heartbeatPort string
+		replicaPort   string
+		id            uint64
+		err           error
+		nodesetId     uint64
 	)
 	metric := exporter.NewTPCnt(apiToMetricsName(proto.AddDataNode))
 	defer func() {
 		doStatAndMetric(proto.AddDataNode, metric, err, nil)
 	}()
 
-	if nodeAddr, zoneName, err = parseRequestForAddNode(r); err != nil {
+	if nodeAddr, zoneName, heartbeatPort, replicaPort, err = parseRequestForAddNode(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
@@ -2569,7 +2571,7 @@ func (m *Server) addDataNode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if id, err = m.cluster.addDataNode(nodeAddr, zoneName, nodesetId); err != nil {
+	if id, err = m.cluster.addDataNode(nodeAddr, zoneName, heartbeatPort, replicaPort, nodesetId); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}
@@ -4038,18 +4040,20 @@ func (m *Server) handleDataNodeTaskResponse(w http.ResponseWriter, r *http.Reque
 
 func (m *Server) addMetaNode(w http.ResponseWriter, r *http.Request) {
 	var (
-		nodeAddr  string
-		zoneName  string
-		id        uint64
-		err       error
-		nodesetId uint64
+		nodeAddr      string
+		zoneName      string
+		heartbeatPort string
+		replicaPort   string
+		id            uint64
+		err           error
+		nodesetId     uint64
 	)
 	metric := exporter.NewTPCnt(apiToMetricsName(proto.AddMetaNode))
 	defer func() {
 		doStatAndMetric(proto.AddMetaNode, metric, err, nil)
 	}()
 
-	if nodeAddr, zoneName, err = parseRequestForAddNode(r); err != nil {
+	if nodeAddr, zoneName, heartbeatPort, replicaPort, err = parseRequestForAddNode(r); err != nil {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
@@ -4066,7 +4070,7 @@ func (m *Server) addMetaNode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if id, err = m.cluster.addMetaNode(nodeAddr, zoneName, nodesetId); err != nil {
+	if id, err = m.cluster.addMetaNode(nodeAddr, zoneName, heartbeatPort, replicaPort, nodesetId); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -381,7 +381,7 @@ func (c *Cluster) deleteMetaReplica(partition *MetaPartition, addr string, valid
 		return
 	}
 
-	removePeer := proto.Peer{ID: metaNode.ID, Addr: addr}
+	removePeer := proto.Peer{ID: metaNode.ID, Addr: addr, HeartbeatPort: metaNode.HeartbeatPort, ReplicaPort: metaNode.ReplicaPort}
 	if err = c.removeMetaPartitionRaftMember(partition, removePeer); err != nil {
 		return
 	}
@@ -497,7 +497,7 @@ func (c *Cluster) addMetaReplica(partition *MetaPartition, addr string) (err err
 	if err != nil {
 		return
 	}
-	addPeer := proto.Peer{ID: metaNode.ID, Addr: addr}
+	addPeer := proto.Peer{ID: metaNode.ID, Addr: addr, HeartbeatPort: metaNode.HeartbeatPort, ReplicaPort: metaNode.ReplicaPort}
 	if err = c.addMetaPartitionRaftMember(partition, addPeer); err != nil {
 		return
 	}

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -34,6 +34,8 @@ type DataNode struct {
 	ID                        uint64
 	ZoneName                  string `json:"Zone"`
 	Addr                      string
+	HeartbeatPort             string `json:"HeartbeatPort"`
+	ReplicaPort               string `json:"ReplicaPort"`
 	DomainAddr                string
 	ReportTime                time.Time
 	StartTime                 int64
@@ -71,10 +73,12 @@ type DataNode struct {
 	DecommissionDpTotal       int
 }
 
-func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
+func newDataNode(addr, zoneName, clusterID, heartbeatPort, replicaPort string) (dataNode *DataNode) {
 	dataNode = new(DataNode)
 	dataNode.Total = 1
 	dataNode.Addr = addr
+	dataNode.HeartbeatPort = heartbeatPort
+	dataNode.ReplicaPort = replicaPort
 	dataNode.ZoneName = zoneName
 	dataNode.LastUpdateTime = time.Now().Add(-time.Minute)
 	dataNode.TaskManager = newAdminTaskManager(dataNode.Addr, clusterID)
@@ -241,6 +245,18 @@ func (dataNode *DataNode) GetAddr() string {
 	dataNode.RLock()
 	defer dataNode.RUnlock()
 	return dataNode.Addr
+}
+
+func (dataNode *DataNode) GetHeartbeatPort() string {
+	dataNode.RLock()
+	defer dataNode.RUnlock()
+	return dataNode.HeartbeatPort
+}
+
+func (dataNode *DataNode) GetReplicaPort() string {
+	dataNode.RLock()
+	defer dataNode.RUnlock()
+	return dataNode.ReplicaPort
 }
 
 // SelectNodeForWrite implements "SelectNodeForWrite" in the Node interface

--- a/master/gapi_cluster.go
+++ b/master/gapi_cluster.go
@@ -433,10 +433,12 @@ func (s *ClusterService) metaNodeList(ctx context.Context, args struct{}) ([]*Me
 }
 
 func (m *ClusterService) addMetaNode(ctx context.Context, args struct {
-	NodeAddr string
-	ZoneName string
+	NodeAddr      string
+	ZoneName      string
+	HeartbeatPort string
+	ReplicaPort   string
 }) (uint64, error) {
-	if id, err := m.cluster.addMetaNode(args.NodeAddr, args.ZoneName, 0); err != nil {
+	if id, err := m.cluster.addMetaNode(args.NodeAddr, args.ZoneName, args.HeartbeatPort, args.ReplicaPort, 0); err != nil {
 		return 0, err
 	} else {
 		return id, nil

--- a/master/meta_node.go
+++ b/master/meta_node.go
@@ -28,6 +28,8 @@ import (
 type MetaNode struct {
 	ID                        uint64
 	Addr                      string
+	HeartbeatPort             string
+	ReplicaPort               string
 	DomainAddr                string
 	IsActive                  bool
 	Sender                    *AdminTaskManager `graphql:"-"`
@@ -50,11 +52,13 @@ type MetaNode struct {
 	CpuUtil                   atomicutil.Float64 `json:"-"`
 }
 
-func newMetaNode(addr, zoneName, clusterID string) (node *MetaNode) {
+func newMetaNode(addr, zoneName, heartbeatPort, replicaPort, clusterID string) (node *MetaNode) {
 	node = &MetaNode{
-		Addr:     addr,
-		ZoneName: zoneName,
-		Sender:   newAdminTaskManager(addr, clusterID),
+		Addr:          addr,
+		ZoneName:      zoneName,
+		HeartbeatPort: heartbeatPort,
+		ReplicaPort:   replicaPort,
+		Sender:        newAdminTaskManager(addr, clusterID),
 	}
 	node.CpuUtil.Store(0)
 	return
@@ -74,6 +78,18 @@ func (metaNode *MetaNode) GetAddr() string {
 	metaNode.RLock()
 	defer metaNode.RUnlock()
 	return metaNode.Addr
+}
+
+func (metaNode *MetaNode) GetHeartbeatPort() string {
+	metaNode.RLock()
+	defer metaNode.RUnlock()
+	return metaNode.HeartbeatPort
+}
+
+func (metaNode *MetaNode) GetReplicaPort() string {
+	metaNode.RLock()
+	defer metaNode.RUnlock()
+	return metaNode.ReplicaPort
 }
 
 // SelectNodeForWrite implements the Node interface

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -368,6 +368,8 @@ type dataNodeValue struct {
 	ID                       uint64
 	NodeSetID                uint64
 	Addr                     string
+	HeartbeatPort            string
+	ReplicaPort              string
 	ZoneName                 string
 	RdOnly                   bool
 	DecommissionedDisks      []string
@@ -387,6 +389,8 @@ func newDataNodeValue(dataNode *DataNode) *dataNodeValue {
 		ID:                       dataNode.ID,
 		NodeSetID:                dataNode.NodeSetID,
 		Addr:                     dataNode.Addr,
+		HeartbeatPort:            dataNode.HeartbeatPort,
+		ReplicaPort:              dataNode.ReplicaPort,
 		ZoneName:                 dataNode.ZoneName,
 		RdOnly:                   dataNode.RdOnly,
 		DecommissionedDisks:      dataNode.getDecommissionedDisks(),
@@ -403,20 +407,24 @@ func newDataNodeValue(dataNode *DataNode) *dataNodeValue {
 }
 
 type metaNodeValue struct {
-	ID        uint64
-	NodeSetID uint64
-	Addr      string
-	ZoneName  string
-	RdOnly    bool
+	ID            uint64
+	NodeSetID     uint64
+	Addr          string
+	ZoneName      string
+	HeartbeatPort string
+	ReplicaPort   string
+	RdOnly        bool
 }
 
 func newMetaNodeValue(metaNode *MetaNode) *metaNodeValue {
 	return &metaNodeValue{
-		ID:        metaNode.ID,
-		NodeSetID: metaNode.NodeSetID,
-		Addr:      metaNode.Addr,
-		ZoneName:  metaNode.ZoneName,
-		RdOnly:    metaNode.RdOnly,
+		ID:            metaNode.ID,
+		NodeSetID:     metaNode.NodeSetID,
+		Addr:          metaNode.Addr,
+		ZoneName:      metaNode.ZoneName,
+		HeartbeatPort: metaNode.HeartbeatPort,
+		ReplicaPort:   metaNode.ReplicaPort,
+		RdOnly:        metaNode.RdOnly,
 	}
 }
 
@@ -1353,7 +1361,7 @@ func (c *Cluster) loadDataNodes() (err error) {
 		if dnv.ZoneName == "" {
 			dnv.ZoneName = DefaultZoneName
 		}
-		dataNode := newDataNode(dnv.Addr, dnv.ZoneName, c.Name)
+		dataNode := newDataNode(dnv.Addr, dnv.ZoneName, c.Name, dnv.HeartbeatPort, dnv.ReplicaPort)
 		dataNode.DpCntLimit = newDpCountLimiter(&c.cfg.MaxDpCntLimit)
 		dataNode.ID = dnv.ID
 		dataNode.NodeSetID = dnv.NodeSetID
@@ -1398,7 +1406,7 @@ func (c *Cluster) loadMetaNodes() (err error) {
 		if mnv.ZoneName == "" {
 			mnv.ZoneName = DefaultZoneName
 		}
-		metaNode := newMetaNode(mnv.Addr, mnv.ZoneName, c.Name)
+		metaNode := newMetaNode(mnv.Addr, mnv.ZoneName, mnv.HeartbeatPort, mnv.ReplicaPort, c.Name)
 		metaNode.ID = mnv.ID
 		metaNode.NodeSetID = mnv.NodeSetID
 		metaNode.RdOnly = mnv.RdOnly

--- a/master/mocktest/data_server.go
+++ b/master/mocktest/data_server.go
@@ -70,7 +70,7 @@ func (mds *MockDataServer) register() {
 	var nodeID uint64
 	var retry int
 	for retry < 3 {
-		nodeID, err = mds.mc.NodeAPI().AddDataNode(mds.TcpAddr, mds.zoneName)
+		nodeID, err = mds.mc.NodeAPI().AddDataNodeWithPort(mds.TcpAddr, mds.zoneName, "", "")
 		if err == nil {
 			break
 		}

--- a/master/mocktest/meta_server.go
+++ b/master/mocktest/meta_server.go
@@ -56,7 +56,7 @@ func (mms *MockMetaServer) register() {
 	var nodeID uint64
 	var retry int
 	for retry < 3 {
-		nodeID, err = mms.mc.NodeAPI().AddMetaNode(mms.TcpAddr, mms.ZoneName)
+		nodeID, err = mms.mc.NodeAPI().AddMetaNodeWithPort(mms.TcpAddr, mms.ZoneName, "", "")
 		if err == nil {
 			break
 		}

--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -65,6 +65,8 @@ type Node interface {
 	SelectNodeForWrite()
 	GetID() uint64
 	GetAddr() string
+	GetHeartbeatPort() string
+	GetReplicaPort() string
 }
 
 // SortedWeightedNodes defines an array sorted by carry
@@ -303,7 +305,7 @@ func (s *CarryWeightNodeSelector) Select(ns *nodeSet, excludeHosts []string, rep
 		node := weightedNodes[i].Ptr
 		s.selectNodeForWrite(node)
 		orderHosts = append(orderHosts, node.GetAddr())
-		peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr()}
+		peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr(), HeartbeatPort: node.GetHeartbeatPort(), ReplicaPort: node.GetReplicaPort()}
 		peers = append(peers, peer)
 	}
 	log.LogInfof("action[%vNodeSelector::Select] peers[%v]", s.GetName(), peers)

--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -389,7 +389,7 @@ func (s *AvailableSpaceFirstNodeSelector) Select(ns *nodeSet, excludeHosts []str
 			node := sortedNodes[selectedIndex]
 			node.SelectNodeForWrite()
 			orderHosts = append(orderHosts, node.GetAddr())
-			peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr()}
+			peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr(), HeartbeatPort: node.GetHeartbeatPort(), ReplicaPort: node.GetReplicaPort()}
 			peers = append(peers, peer)
 		}
 	}
@@ -468,7 +468,7 @@ func (s *RoundRobinNodeSelector) Select(ns *nodeSet, excludeHosts []string, repl
 			node := sortedNodes[(selectedIndex+s.index)%len(sortedNodes)]
 			orderHosts = append(orderHosts, node.GetAddr())
 			node.SelectNodeForWrite()
-			peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr()}
+			peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr(), HeartbeatPort: node.GetHeartbeatPort(), ReplicaPort: node.GetReplicaPort()}
 			peers = append(peers, peer)
 		}
 	}
@@ -561,7 +561,7 @@ func (s *StrawNodeSelector) Select(ns *nodeSet, excludeHosts []string, replicaNu
 		}
 		orderHosts = append(orderHosts, node.GetAddr())
 		node.SelectNodeForWrite()
-		peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr()}
+		peer := proto.Peer{ID: node.GetID(), Addr: node.GetAddr(), HeartbeatPort: node.GetHeartbeatPort(), ReplicaPort: node.GetReplicaPort()}
 		peers = append(peers, peer)
 	}
 	// if we cannot get enough writable nodes, return error

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -55,6 +55,14 @@ func newDeleteDataPartitionRequest(ID uint64) (req *proto.DeleteDataPartitionReq
 	return
 }
 
+func newUpdateDataPartitionPeerRequest(ID uint64, peer proto.Peer) (req *proto.UpdateDataPartitionPeerRequest) {
+	req = &proto.UpdateDataPartitionPeerRequest{
+		PartitionId: ID,
+		Peer:        peer,
+	}
+	return
+}
+
 func newAddDataPartitionRaftMemberRequest(ID uint64, addPeer proto.Peer) (req *proto.AddDataPartitionRaftMemberRequest) {
 	req = &proto.AddDataPartitionRaftMemberRequest{
 		PartitionId: ID,

--- a/master/topology_test.go
+++ b/master/topology_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func createDataNodeForTopo(addr, zoneName string, ns *nodeSet) (dn *DataNode) {
-	dn = newDataNode(addr, zoneName, "test")
+	dn = newDataNode(addr, zoneName, "test", "", "")
 	dn.ZoneName = zoneName
 	dn.Total = 1024 * util.GB
 	dn.Used = 10 * util.GB

--- a/master/vol.go
+++ b/master/vol.go
@@ -550,7 +550,7 @@ func (vol *Vol) checkDataPartitions(c *Cluster) (cnt int) {
 		dp.checkLeader(c.Name, c.cfg.DataPartitionTimeOutSec)
 		dp.checkMissingReplicas(c.Name, c.leaderInfo.addr, c.cfg.MissingDataPartitionInterval, c.cfg.IntervalToAlarmMissingDataPartition)
 		dp.checkReplicaNum(c, vol)
-
+		dp.checkDpPeers(c)
 		if time.Now().Unix()-vol.createTime < defaultIntervalToCheckHeartbeat*3 && !vol.Forbidden {
 			dp.setReadWrite()
 		}

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -462,7 +462,7 @@ func (m *MetaNode) register() (err error) {
 			step++
 		}
 		var nodeID uint64
-		if nodeID, err = masterClient.NodeAPI().AddMetaNodeWithAuthNode(nodeAddress, m.zoneName, m.serviceIDKey); err != nil {
+		if nodeID, err = masterClient.NodeAPI().AddMetaNodeWithAuthNode(nodeAddress, m.zoneName, m.serviceIDKey, m.raftHeartbeatPort, m.raftReplicatePort); err != nil {
 			log.LogErrorf("register: register to master fail: address(%v) err(%s)", nodeAddress, err)
 			time.Sleep(3 * time.Second)
 			continue

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -799,15 +799,17 @@ func (mp *metaPartition) onStop() {
 }
 
 func (mp *metaPartition) startRaft() (err error) {
-	var (
-		heartbeatPort int
-		replicaPort   int
-		peers         []raftstore.PeerAddress
-	)
-	if heartbeatPort, replicaPort, err = mp.getRaftPort(); err != nil {
-		return
-	}
+	var peers []raftstore.PeerAddress
+
 	for _, peer := range mp.config.Peers {
+		heartbeatPort, err := strconv.Atoi(peer.HeartbeatPort)
+		if err != nil {
+			return err
+		}
+		replicaPort, err := strconv.Atoi(peer.ReplicaPort)
+		if err != nil {
+			return err
+		}
 		addr := strings.Split(peer.Addr, ":")[0]
 		rp := raftstore.PeerAddress{
 			Peer: raftproto.Peer{
@@ -1261,7 +1263,8 @@ func (mp *metaPartition) GetBaseConfig() MetaPartitionConfig {
 
 // UpdatePartition updates the meta partition. TODO remove? no usage?
 func (mp *metaPartition) UpdatePartition(req *UpdatePartitionReq,
-	resp *UpdatePartitionResp) (err error) {
+	resp *UpdatePartitionResp,
+) (err error) {
 	reqData, err := json.Marshal(req)
 	if err != nil {
 		resp.Status = proto.TaskFailed

--- a/metanode/partition_fsmop.go
+++ b/metanode/partition_fsmop.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -97,7 +98,14 @@ func (mp *metaPartition) confAddNode(req *proto.AddMetaPartitionRaftMemberReques
 		heartbeatPort int
 		replicaPort   int
 	)
-	if heartbeatPort, replicaPort, err = mp.getRaftPort(); err != nil {
+
+	heartbeatPort, err = strconv.Atoi(req.AddPeer.HeartbeatPort)
+	if err != nil {
+		return
+	}
+
+	replicaPort, err = strconv.Atoi(req.AddPeer.ReplicaPort)
+	if err != nil {
 		return
 	}
 
@@ -177,7 +185,6 @@ func (mp *metaPartition) delOldExtentFile(buf []byte) (err error) {
 	return
 }
 
-//
 func (mp *metaPartition) setExtentDeleteFileCursor(buf []byte) (err error) {
 	str := string(buf)
 	var (

--- a/metanode/raft_server.go
+++ b/metanode/raft_server.go
@@ -45,8 +45,15 @@ func (m *MetaNode) startRaftServer(cfg *config.Config) (err error) {
 		}
 	}
 
-	heartbeatPort, _ := strconv.Atoi(m.raftHeartbeatPort)
-	replicaPort, _ := strconv.Atoi(m.raftReplicatePort)
+	heartbeatPort, err := strconv.Atoi(m.raftHeartbeatPort)
+	if err != nil {
+		return fmt.Errorf("strconv.Atoi(%v) failed: %v", m.raftHeartbeatPort, err)
+	}
+
+	replicaPort, err := strconv.Atoi(m.raftReplicatePort)
+	if err != nil {
+		return fmt.Errorf("strconv.Atoi(%v) failed: %v", m.raftReplicatePort, err)
+	}
 
 	raftConf := &raftstore.Config{
 		NodeID:            m.nodeId,

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -540,6 +540,12 @@ type DeleteDataPartitionResponse struct {
 	PartitionId uint64
 }
 
+// UpdateDataPartitionPeersRequest defines the request to update peers information of datapartition
+type UpdateDataPartitionPeerRequest struct {
+	PartitionId uint64
+	Peer        Peer
+}
+
 // DataPartitionDecommissionRequest defines the request of decommissioning a data partition.
 type DataPartitionDecommissionRequest struct {
 	PartitionId uint64

--- a/proto/meta_proto.go
+++ b/proto/meta_proto.go
@@ -29,8 +29,10 @@ type CreateNameSpaceResponse struct {
 
 // Peer defines the peer of the node id and address.
 type Peer struct {
-	ID   uint64 `json:"id"`
-	Addr string `json:"addr"`
+	ID            uint64 `json:"id"`
+	Addr          string `json:"addr"`
+	HeartbeatPort string `json:"raftHeartbeat"`
+	ReplicaPort   string `json:"raftReplica"`
 }
 
 // CreateMetaPartitionRequest defines the request to create a meta partition.

--- a/proto/mount_options.go
+++ b/proto/mount_options.go
@@ -82,6 +82,8 @@ const (
 const (
 	MasterAddr       = "masterAddr"
 	ListenPort       = "listen"
+	RaftHeartbeat    = "raftHeartbeat"
+	RaftReplica      = "raftReplica"
 	ObjectNodeDomain = "objectNodeDomain"
 	BindIpKey        = "bindIp"
 )

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -140,6 +140,7 @@ const (
 	OpDataPartitionTryToLeader      uint8 = 0x69
 	OpQos                           uint8 = 0x6A
 	OpStopDataPartitionRepair       uint8 = 0x6B
+	OpUpdateDataPartitionPeer       uint8 = 0x6C
 
 	// Operations: MultipartInfo
 	OpCreateMultipart  uint8 = 0x70

--- a/raftstore/raftstore.go
+++ b/raftstore/raftstore.go
@@ -67,6 +67,11 @@ func (s *raftStore) DeleteNode(nodeID uint64) {
 	s.resolver.DeleteNode(nodeID)
 }
 
+// UpdateNodeWithPort update the node with the given port.
+func (s *raftStore) UpdateNodeWithPort(nodeID uint64, addr string, heartbeat int, replicate int) {
+	s.resolver.UpdateNodeWithPort(nodeID, addr, heartbeat, replicate)
+}
+
 // Stop stops the raft store server.
 func (s *raftStore) Stop() {
 	if s.raftServer != nil {

--- a/raftstore/resolver.go
+++ b/raftstore/resolver.go
@@ -43,6 +43,9 @@ type NodeManager interface {
 
 	// delete node address information
 	DeleteNode(nodeID uint64)
+
+	// update node address with specified port.
+	UpdateNodeWithPort(nodeID uint64, addr string, heartbeat int, replicate int)
 }
 
 // NodeResolver defines the methods for node address resolving and management.
@@ -105,6 +108,22 @@ func (r *nodeResolver) AddNodeWithPort(nodeID uint64, addr string, heartbeat int
 // DeleteNode deletes the node address information of the specified node ID from the NodeManager if possible.
 func (r *nodeResolver) DeleteNode(nodeID uint64) {
 	r.nodeMap.Delete(nodeID)
+}
+
+// UpdateNodeWithPort updates the node address with specified port.
+func (r *nodeResolver) UpdateNodeWithPort(nodeID uint64, addr string, heartbeat int, replicate int) {
+	if heartbeat == 0 {
+		heartbeat = DefaultHeartbeatPort
+	}
+	if replicate == 0 {
+		replicate = DefaultReplicaPort
+	}
+	if len(strings.TrimSpace(addr)) != 0 {
+		r.nodeMap.Store(nodeID, &nodeAddress{
+			Heartbeat: fmt.Sprintf("%s:%d", addr, heartbeat),
+			Replicate: fmt.Sprintf("%s:%d", addr, replicate),
+		})
+	}
 }
 
 // NewNodeResolver returns a new NodeResolver instance for node address management and resolving.

--- a/sdk/master/api_node.go
+++ b/sdk/master/api_node.go
@@ -37,10 +37,12 @@ func (api *NodeAPI) EncodingGzip() *NodeAPI {
 	return api.EncodingWith(encodingGzip)
 }
 
-func (api *NodeAPI) AddDataNode(serverAddr, zoneName string) (id uint64, err error) {
+func (api *NodeAPI) AddDataNodeWithPort(serverAddr, zoneName, heartbeatPort, replicaPort string) (id uint64, err error) {
 	request := newRequest(get, proto.AddDataNode).Header(api.h)
 	request.addParam("addr", serverAddr)
 	request.addParam("zoneName", zoneName)
+	request.addParam("heartbeatPort", heartbeatPort)
+	request.addParam("replicaPort", replicaPort)
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -49,11 +51,13 @@ func (api *NodeAPI) AddDataNode(serverAddr, zoneName string) (id uint64, err err
 	return
 }
 
-func (api *NodeAPI) AddDataNodeWithAuthNode(serverAddr, zoneName, clientIDKey string) (id uint64, err error) {
+func (api *NodeAPI) AddDataNodeWithAuthNode(serverAddr, zoneName, clientIDKey, heartbeatPort, replicaPort string) (id uint64, err error) {
 	request := newRequest(get, proto.AddDataNode).Header(api.h)
 	request.addParam("addr", serverAddr)
 	request.addParam("zoneName", zoneName)
 	request.addParam("clientIDKey", clientIDKey)
+	request.addParam("heartbeatPort", heartbeatPort)
+	request.addParam("replicaPort", replicaPort)
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -62,10 +66,12 @@ func (api *NodeAPI) AddDataNodeWithAuthNode(serverAddr, zoneName, clientIDKey st
 	return
 }
 
-func (api *NodeAPI) AddMetaNode(serverAddr, zoneName string) (id uint64, err error) {
+func (api *NodeAPI) AddMetaNodeWithPort(serverAddr, zoneName, heartbeatPort, replicaPort string) (id uint64, err error) {
 	request := newRequest(get, proto.AddMetaNode).Header(api.h)
 	request.addParam("addr", serverAddr)
 	request.addParam("zoneName", zoneName)
+	request.addParam("heartbeatPort", heartbeatPort)
+	request.addParam("replicaPort", replicaPort)
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return
@@ -74,11 +80,13 @@ func (api *NodeAPI) AddMetaNode(serverAddr, zoneName string) (id uint64, err err
 	return
 }
 
-func (api *NodeAPI) AddMetaNodeWithAuthNode(serverAddr, zoneName, clientIDKey string) (id uint64, err error) {
+func (api *NodeAPI) AddMetaNodeWithAuthNode(serverAddr, zoneName, clientIDKey, heartbeatPort, replicaPort string) (id uint64, err error) {
 	request := newRequest(get, proto.AddMetaNode).Header(api.h)
 	request.addParam("addr", serverAddr)
 	request.addParam("zoneName", zoneName)
 	request.addParam("clientIDKey", clientIDKey)
+	request.addParam("heartbeatPort", heartbeatPort)
+	request.addParam("replicaPort", replicaPort)
 	var data []byte
 	if data, err = api.mc.serveRequest(request); err != nil {
 		return


### PR DESCRIPTION
…ferent port on a single node

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support multiple datanode/metanode instances using different port on a single node.In the previous version, every datanode or metanode in the same raft group is required to be configured with the same raftHeartBeatPort and replicaPort because each node splices ports of peers through its own port.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes https://github.com/cubefs/cubefs/issues/3004

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
