### PR TITLE
bugfix(metanode):Copy WriteGeneration and ForbiddenMigration when

### DIFF
--- a/metanode/partition_op_inode.go
+++ b/metanode/partition_op_inode.go
@@ -412,6 +412,9 @@ func (mp *metaPartition) UnlinkInode(req *UnlinkInoReq, p *Packet, remoteAddr st
 		return
 	} else {
 		ino.StorageClass = item.(*Inode).StorageClass
+		ino.HybridCouldExtents.sortedEks = item.(*Inode).HybridCouldExtents.sortedEks
+		ino.WriteGeneration = atomic.LoadUint64(&(item.(*Inode).WriteGeneration))
+		ino.ForbiddenMigration = atomic.LoadUint32(&(item.(*Inode).ForbiddenMigration))
 	}
 
 	if req.UniqID > 0 {
@@ -767,6 +770,9 @@ func (mp *metaPartition) EvictInode(req *EvictInodeReq, p *Packet, remoteAddr st
 		return
 	} else {
 		ino.StorageClass = item.(*Inode).StorageClass
+		ino.HybridCouldExtents.sortedEks = item.(*Inode).HybridCouldExtents.sortedEks
+		ino.WriteGeneration = atomic.LoadUint64(&(item.(*Inode).WriteGeneration))
+		ino.ForbiddenMigration = atomic.LoadUint32(&(item.(*Inode).ForbiddenMigration))
 	}
 	val, err := ino.Marshal()
 	if err != nil {
@@ -1055,6 +1061,9 @@ func (mp *metaPartition) RenewalForbiddenMigration(req *proto.RenewalForbiddenMi
 		return
 	} else {
 		ino.StorageClass = item.(*Inode).StorageClass
+		ino.HybridCouldExtents.sortedEks = item.(*Inode).HybridCouldExtents.sortedEks
+		ino.WriteGeneration = atomic.LoadUint64(&(item.(*Inode).WriteGeneration))
+		ino.ForbiddenMigration = atomic.LoadUint32(&(item.(*Inode).ForbiddenMigration))
 	}
 	val, err := ino.Marshal()
 	if err != nil {
@@ -1083,6 +1092,8 @@ func (mp *metaPartition) UpdateExtentKeyAfterMigration(req *proto.UpdateExtentKe
 	} else {
 		ino.StorageClass = item.(*Inode).StorageClass
 		ino.HybridCouldExtents.sortedEks = item.(*Inode).HybridCouldExtents.sortedEks
+		ino.WriteGeneration = atomic.LoadUint64(&(item.(*Inode).WriteGeneration))
+		ino.ForbiddenMigration = atomic.LoadUint32(&(item.(*Inode).ForbiddenMigration))
 	}
 	start := time.Now()
 	if mp.IsEnableAuditLog() {
@@ -1098,6 +1109,7 @@ func (mp *metaPartition) UpdateExtentKeyAfterMigration(req *proto.UpdateExtentKe
 		p.PacketErrorWithBody(proto.OpErr, []byte(err.Error()))
 		return
 	}
+
 	if atomic.LoadUint32(&ino.ForbiddenMigration) == ForbiddenToMigration {
 		err = fmt.Errorf("mp %v inode %v is forbidden to migration", mp.config.PartitionId, ino.Inode)
 		log.LogErrorf("action[UpdateExtentKeyAfterMigration] %v", err)

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -685,6 +685,8 @@ func (p *Packet) GetResultMsg() (m string) {
 		m = "OpTxRollbackErr"
 	case OpUploadPartConflictErr:
 		m = "OpUploadPartConflictErr"
+	case OpDismatchStorageClass:
+		m = "OpDismatchStorageClass"
 	default:
 		return fmt.Sprintf("Unknown ResultCode(%v)", p.ResultCode)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Copy WriteGeneration and ForbiddenMigration when getting inode from btree