### PR TITLE
bugfix(metanode): copy storage class from HybridCouldExtentsMigration of inode when excuting migration

### DIFF
--- a/metanode/manager_op.go
+++ b/metanode/manager_op.go
@@ -1237,6 +1237,7 @@ func (m *metadataManager) opMetaExtentsList(conn net.Conn, p *Packet,
 		err = errors.NewErrorf("[%v] req: %v, resp: %v", p.GetOpMsgWithReqAndResult(), req, err.Error())
 		return
 	}
+	log.LogDebugf("opMetaExtentsList: req(%v) ", req)
 	mp, err := m.getPartition(req.PartitionID)
 	if err != nil {
 		p.PacketErrorWithBody(proto.OpErr, ([]byte)(err.Error()))

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -485,6 +485,7 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 		isCache     bool
 		isMigration bool
 	)
+	storageClass := ino.StorageClass
 	if len(ino.Extents.eks) != 0 {
 		isCache = true
 		eks = ino.Extents.CopyExtents()
@@ -493,10 +494,11 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 		eks = ino.HybridCouldExtents.sortedEks.(*SortedExtents).CopyExtents()
 	} else if ino.HybridCouldExtentsMigration.sortedEks != nil && len(ino.HybridCouldExtentsMigration.sortedEks.(*SortedExtents).eks) != 0 {
 		isMigration = true
+		storageClass = ino.HybridCouldExtentsMigration.storageClass
 		eks = ino.HybridCouldExtentsMigration.sortedEks.(*SortedExtents).CopyExtents()
 	}
 
-	if err := fsmIno.updateStorageClass(ino.StorageClass, isCache, isMigration); err != nil {
+	if err := fsmIno.updateStorageClass(storageClass, isCache, isMigration); err != nil {
 		log.LogErrorf("action[fsmAppendExtentsWithCheck] updateStorageClass inode %v isCache %v isMigration %v, failed %v",
 			ino.Inode, isCache, isMigration, err.Error())
 		status = proto.OpDismatchStorageClass
@@ -513,7 +515,7 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 	}
 
 	if status = mp.uidManager.addUidSpace(fsmIno.Uid, fsmIno.Inode, eks[:1]); status != proto.OpOk {
-		log.LogErrorf("fsmAppendExtentsWithCheck.mp %v addUidSpace status %v", mp.config.PartitionId, status)
+		log.LogErrorf("fsmAppendExtentsWithCh eck.mp %v addUidSpace status %v", mp.config.PartitionId, status)
 		return
 	}
 

--- a/proto/fs_proto.go
+++ b/proto/fs_proto.go
@@ -693,10 +693,10 @@ type GetExtentsRequest struct {
 	PartitionID  uint64 `json:"pid"`
 	Inode        uint64 `json:"ino"`
 	VerSeq       uint64 `json:"seq"`
-	VerAll       bool
-	IsCache      bool
-	OpenForWrite bool
-	IsMigration  bool
+	VerAll       bool   `json:"verAll"`
+	IsCache      bool   `json:"isCache"`
+	OpenForWrite bool   `json:"forWrite"`
+	IsMigration  bool   `json:"isMigration"`
 }
 
 // GetObjExtentsResponse defines the response to the request of getting obj extents.


### PR DESCRIPTION
**What this PR does / why we need it**:
copy storage class from HybridCouldExtentsMigration of inode when excuting migration
