### PR TITLE
During the truncate process, the extent cache is forcefully refreshed, but it does not have any effect

### DIFF
--- a/sdk/data/stream/extent_cache.go
+++ b/sdk/data/stream/extent_cache.go
@@ -81,7 +81,7 @@ func (cache *ExtentCache) RefreshForce(inode uint64, getExtents GetExtentsFunc) 
 		return err
 	}
 	// log.LogDebugf("Local ExtentCache before update: ino(%v) gen(%v) size(%v) extents(%v)", inode, cache.gen, cache.size, cache.List())
-	cache.update(gen, size, extents)
+	cache.update(gen, size, true, extents)
 	log.LogDebugf("Local ExtentCache after update: ino(%v) gen(%v) size(%v) extents(%v)", inode, cache.gen, cache.size, cache.List())
 	return nil
 }
@@ -97,28 +97,17 @@ func (cache *ExtentCache) Refresh(inode uint64, getExtents GetExtentsFunc) error
 		return err
 	}
 	// log.LogDebugf("Local ExtentCache before update: ino(%v) gen(%v) size(%v) extents(%v)", inode, cache.gen, cache.size, cache.List())
-	cache.update(gen, size, extents)
+	cache.update(gen, size, false, extents)
 	log.LogDebugf("Local ExtentCache after update: ino(%v) gen(%v) size(%v)", inode, cache.gen, cache.size)
 	return nil
 }
 
-func (cache *ExtentCache) update(gen, size uint64, eks []proto.ExtentKey) {
+func (cache *ExtentCache) update(gen, size uint64, force bool, eks []proto.ExtentKey) {
 	cache.Lock()
 	defer cache.Unlock()
 
 	log.LogDebugf("ExtentCache update: ino(%v) cache.gen(%v) cache.size(%v) gen(%v) size(%v)", cache.inode, cache.gen, cache.size, gen, size)
-
-	//	cache.root.Ascend(func(bi btree.Item) bool {
-	//		ek := bi.(*proto.ExtentKey)
-	//		log.LogDebugf("ExtentCache update: local ino(%v) ek(%v)", cache.inode, ek)
-	//		return true
-	//	})
-	//
-	//	for _, ek := range eks {
-	//		log.LogDebugf("ExtentCache update: remote ino(%v) ek(%v)", cache.inode, ek)
-	//	}
-
-	if cache.gen != 0 && cache.gen >= gen {
+	if !force && cache.gen != 0 && cache.gen >= gen {
 		log.LogDebugf("ExtentCache update: no need to update, ino(%v) gen(%v) size(%v)", cache.inode, gen, size)
 		return
 	}

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -371,7 +371,7 @@ func (client *ExtentClient) UpdateLatestVer(verList *proto.VolVersionInfoList) (
 			oldVer := streamer.verSeq
 			streamer.verSeq = verSeq
 			streamer.extents.verSeq = verSeq
-			if err = streamer.GetExtents(); err != nil {
+			if err = streamer.GetExtentsForce(); err != nil {
 				log.LogErrorf("action[UpdateLatestVer] inode %v streamer %v", streamer.inode, streamer.verSeq)
 				streamer.verSeq = oldVer
 				streamer.extents.verSeq = oldVer

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -332,7 +332,7 @@ func (eh *ExtentHandler) processReply(packet *Packet) {
 		}
 		// todo(leonchang) need check safety
 		log.LogWarnf("processReply: get reply, eh(%v) packet(%v) reply(%v)", eh, packet, reply)
-		eh.stream.GetExtents()
+		eh.stream.GetExtentsForce()
 	}
 
 	if !packet.isValidWriteReply(reply) {
@@ -447,7 +447,7 @@ func (eh *ExtentHandler) appendExtentKey() (err error) {
 				discard = eh.stream.extents.Append(&ekey, true)
 				status, err = eh.stream.client.appendExtentKey(eh.stream.parentInode, eh.inode, ekey, discard)
 				if atomic.LoadInt32(&eh.stream.needUpdateVer) > 0 {
-					if errUpdateExtents := eh.stream.GetExtents(); errUpdateExtents != nil {
+					if errUpdateExtents := eh.stream.GetExtentsForce(); errUpdateExtents != nil {
 						log.LogErrorf("action[appendExtentKey] inode %v GetExtents err %v errUpdateExtents %v", eh.stream.inode, err, errUpdateExtents)
 						return
 					}

--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -356,7 +356,7 @@ begin:
 				writeSize, err = s.doOverwrite(req, direct)
 				if err == proto.ErrCodeVersionOp {
 					log.LogDebugf("action[streamer.write] write need version update")
-					if err = s.GetExtents(); err != nil {
+					if err = s.GetExtentsForce(); err != nil {
 						log.LogErrorf("action[streamer.write] err %v", err)
 						return
 					}
@@ -588,7 +588,7 @@ func (s *Streamer) doDirectWriteByAppend(req *ExtentRequest, direct bool, op uin
 		s.handler.key = extKey
 	}
 	if atomic.LoadInt32(&s.needUpdateVer) > 0 {
-		if err = s.GetExtents(); err != nil {
+		if err = s.GetExtentsForce(); err != nil {
 			log.LogErrorf("action[doDirectWriteByAppend] inode %v GetExtents err %v", s.inode, err)
 			return
 		}
@@ -1023,12 +1023,6 @@ func (s *Streamer) truncate(size int, fullPath string) error {
 func (s *Streamer) updateVer(verSeq uint64) (err error) {
 	log.LogInfof("action[stream.updateVer] ver %v update to %v", s.verSeq, verSeq)
 	if s.verSeq != verSeq {
-		//log.LogInfof("action[stream.updateVer] ver %v update to %v", s.verSeq, verSeq)
-		//if s.handler != nil {
-		//	s.handler.verUpdate<-verSeq
-		//} else {
-		//	log.LogInfof("action[stream.updateVer] ver %v update to %v", s.verSeq, verSeq)
-		//}
 		log.LogInfof("action[stream.updateVer] ver %v update to %v", s.verSeq, verSeq)
 		s.verSeq = verSeq
 		s.extents.verSeq = verSeq


### PR DESCRIPTION
…k reentrancy and other lock concurrency

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

During the truncate process, the extent cache is forcefully refreshed, but it does not have any effect

