### PR TITLE
feat(meta): skip extent deletion if all replicas of dp is discard

### DIFF
--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -41,6 +41,7 @@ const (
 	CliOpExpand               = "expand"
 	CliOpShrink               = "shrink"
 	CliOpGetDiscard           = "get-discard"
+	CliOpSetDiscard           = "set-discard"
 	CliOpForbidMpDecommission = "forbid-mp-decommission"
 
 	// Shorthand format of operation name

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -475,7 +475,10 @@ func (dp *DataPartition) Stop() {
 		// Close the store and raftstore.
 		dp.stopRaft()
 		dp.extentStore.Close()
-		_ = dp.storeAppliedID(atomic.LoadUint64(&dp.appliedID))
+		err := dp.storeAppliedID(atomic.LoadUint64(&dp.appliedID))
+		if err != nil {
+			log.LogErrorf("action[Stop]: failed to store applied index")
+		}
 	})
 }
 

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -681,7 +681,7 @@ func (s *DataNode) handleMarkDeletePacket(p *repl.Packet, c net.Conn) {
 				p.PartitionID, p.ExtentID, ext.ExtentOffset, ext.Size)
 			partition.disk.allocCheckLimit(proto.IopsWriteType, 1)
 			partition.disk.limitWrite.Run(0, func() {
-				partition.ExtentStore().MarkDelete(p.ExtentID, int64(ext.ExtentOffset), int64(ext.Size))
+				err = partition.ExtentStore().MarkDelete(p.ExtentID, int64(ext.ExtentOffset), int64(ext.Size))
 			})
 		}
 	} else {
@@ -689,7 +689,7 @@ func (s *DataNode) handleMarkDeletePacket(p *repl.Packet, c net.Conn) {
 			p.PartitionID, p.ExtentID)
 		partition.disk.allocCheckLimit(proto.IopsWriteType, 1)
 		partition.disk.limitWrite.Run(0, func() {
-			partition.ExtentStore().MarkDelete(p.ExtentID, 0, 0)
+			err = partition.ExtentStore().MarkDelete(p.ExtentID, 0, 0)
 		})
 	}
 }
@@ -719,7 +719,7 @@ func (s *DataNode) handleBatchMarkDeletePacket(p *repl.Packet, c net.Conn) {
 				log.LogInfof(fmt.Sprintf("recive DeleteExtent (%v) from (%v)", ext, c.RemoteAddr().String()))
 				partition.disk.allocCheckLimit(proto.IopsWriteType, 1)
 				partition.disk.limitWrite.Run(0, func() {
-					store.MarkDelete(ext.ExtentId, int64(ext.ExtentOffset), int64(ext.Size))
+					err = store.MarkDelete(ext.ExtentId, int64(ext.ExtentOffset), int64(ext.Size))
 				})
 			} else {
 				log.LogInfof("delete limiter reach(%v), remote (%v) try again.", deleteLimiteRater.Limit(), c.RemoteAddr().String())

--- a/docs-zh/source/tools/cfs-cli/datapartition.md
+++ b/docs-zh/source/tools/cfs-cli/datapartition.md
@@ -39,3 +39,9 @@ cfs-cli datapartition del-replica [Address] [Partition ID]
 ```bash
 cfs-cli datapartition check
 ```
+
+## 标记副本丢失
+
+```bash
+cfs-cli datapartition set-discard [DATA PARTITION ID] [DISCARD]
+```

--- a/docs/source/tools/cfs-cli/datapartition.md
+++ b/docs/source/tools/cfs-cli/datapartition.md
@@ -39,3 +39,9 @@ Fault diagnosis, find data partitions that are mostly unavailable and missing.
 ```bash
 cfs-cli datapartition check
 ```
+
+## Mark data partition discard
+
+```bash
+cfs-cli datapartition set-discard [DATA PARTITION ID] [DISCARD]
+```

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -5904,10 +5904,13 @@ func (m *Server) setDpDiscard(partitionID uint64, isDiscard bool) (err error) {
 	if dp, err = m.cluster.getDataPartitionByID(partitionID); err != nil {
 		return fmt.Errorf("[setDpDiacard] getDataPartitionByID err(%s)", err.Error())
 	}
-	dp.RLock()
+	dp.Lock()
+	defer dp.Unlock()
+	if dp.IsDiscard && !isDiscard {
+		log.LogWarnf("[setDpDiscard] usnet dp discard flag may cause some junk data")
+	}
 	dp.IsDiscard = isDiscard
 	m.cluster.syncUpdateDataPartition(dp)
-	dp.RUnlock()
 
 	return
 }

--- a/metanode/datapartition.go
+++ b/metanode/datapartition.go
@@ -29,6 +29,7 @@ type DataPartition struct {
 	ReplicaNum    uint8
 	PartitionType string
 	Hosts         []string
+	IsDiscard     bool
 }
 
 // GetAllAddrs returns all addresses of the data partition.

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -340,11 +340,16 @@ func (mp *metaPartition) deleteExtentsFromList(fileList *synclist.SyncList) {
 					panic(err)
 				}
 			}
-			// delete dataPartition
-			if err = mp.doDeleteMarkedInodes(&ek); err != nil {
-				errExts = append(errExts, ek)
-				log.LogWarnf("[deleteExtentsFromList] mp: %v, extent: %v, %s",
-					mp.config.PartitionId, ek.String(), err.Error())
+			// delete extent from dataPartition
+			dp := mp.vol.GetPartition(ek.PartitionId)
+			if !dp.IsDiscard {
+				if err = mp.doDeleteMarkedInodes(&ek); err != nil {
+					errExts = append(errExts, ek)
+					log.LogWarnf("[deleteExtentsFromList] mp: %v, extent: %v, %s",
+						mp.config.PartitionId, ek.String(), err.Error())
+				}
+			} else {
+				log.LogWarnf("action[deleteExtentsFromList] dp(%v) is discard, skip extent(%v)", ek.PartitionId, ek.ExtentId)
 			}
 			deleteCnt++
 		}

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -305,6 +305,8 @@ func (p *Packet) identificationErrorResultCode(errLog string, errMsg string) {
 		p.ResultCode = proto.OpNotExistErr
 	} else if strings.Contains(errMsg, storage.NoSpaceError.Error()) {
 		p.ResultCode = proto.OpDiskNoSpaceErr
+	} else if strings.Contains(errMsg, storage.BrokenDiskError.Error()) {
+		p.ResultCode = proto.OpDiskErr
 	} else if strings.Contains(errMsg, storage.TryAgainError.Error()) {
 		p.ResultCode = proto.OpAgain
 	} else if strings.Contains(errMsg, raft.ErrNotLeader.Error()) {

--- a/repl/repl_protocol.go
+++ b/repl/repl_protocol.go
@@ -18,6 +18,7 @@ import (
 	"container/list"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -368,21 +369,28 @@ func (rp *ReplProtocol) checkLocalResultAndReciveAllFollowerResponse() {
 	if e = rp.getNextPacket(); e == nil {
 		return
 	}
-	request := e.Value.(*Packet)
+	response := e.Value.(*Packet)
 	defer func() {
-		rp.deletePacket(request, e)
+		rp.deletePacket(response, e)
 	}()
-	if request.IsErrPacket() {
+	if response.IsErrPacket() {
 		return
 	}
-	for index := 0; index < len(request.followersAddrs); index++ {
-		followerPacket := request.followerPackets[index]
+	// NOTE: wait for all followers
+	for index := 0; index < len(response.followersAddrs); index++ {
+		followerPacket := response.followerPackets[index]
 		err := <-followerPacket.respCh
 		if err != nil {
-			request.PackErrorBody(ActionReceiveFromFollower, err.Error())
-			return
+			// NOTE: we meet timeout error
+			// set the request status to be timeout
+			if err == os.ErrDeadlineExceeded {
+				response.PackErrorBody(ActionReceiveFromFollower, err.Error())
+				return
+			}
+			// NOTE: other errors, continue to receive response from followers
+			response.PackErrorBody(ActionReceiveFromFollower, err.Error())
+			continue
 		}
-
 	}
 }
 

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -605,6 +605,17 @@ func (api *AdminAPI) GetDiscardDataPartition() (discardDpInfos *proto.DiscardDat
 	return
 }
 
+func (api *AdminAPI) SetDataPartitionDiscard(partitionId uint64, discard bool) (err error) {
+	request := newRequest(post, proto.AdminSetDpDiscard).
+		Header(api.h).
+		addParam("id", strconv.FormatUint(partitionId, 10)).
+		addParam("dpDiscard", strconv.FormatBool(discard))
+	if err = api.mc.request(request); err != nil {
+		return
+	}
+	return
+}
+
 func (api *AdminAPI) DeleteVersion(volName string, verSeq string) (err error) {
 	request := newRequest(get, proto.AdminDelVersion).Header(api.h)
 	request.addParam("name", volName)

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -517,14 +517,23 @@ func (s *ExtentStore) MarkDelete(extentID uint64, offset, size int64) (err error
 	extentFilePath := path.Join(s.dataPath, strconv.FormatUint(extentID, 10))
 	log.LogDebugf("action[MarkDelete] extentID %v offset %v size %v ei(size %v extentFilePath %v)",
 		extentID, offset, size, ei.Size, extentFilePath)
-	if err = os.Remove(extentFilePath); err != nil {
+	if err = os.Remove(extentFilePath); err != nil && !os.IsNotExist(err) {
+		// NOTE: if remove failed
+		// we meet a disk error
+		err = BrokenDiskError
 		return
 	}
-	s.PersistenceHasDeleteExtent(extentID)
+	if err = s.PersistenceHasDeleteExtent(extentID); err != nil {
+		err = BrokenDiskError
+		return
+	}
 	ei.IsDeleted = true
 	ei.ModifyTime = time.Now().Unix()
 	s.cache.Del(extentID)
-	s.DeleteBlockCrc(extentID)
+	if err = s.DeleteBlockCrc(extentID); err != nil {
+		err = BrokenDiskError
+		return
+	}
 	s.PutNormalExtentToDeleteCache(extentID)
 
 	s.eiMutex.Lock()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* Datanode return an error when failed to mark delete extent.
* Metanode skip extent deletion when all replicas of dp is broken.
* Cli support to set datapartition discard flag.

**Effect:**
```log
2024/01/25 19:59:44.309168 [WARN ] partition_delete_extents.go:352: action[deleteExtentsFromList] dp(10) is discard, skip extent(1025)
2024/01/25 19:59:44.309172 [WARN ] partition_delete_extents.go:352: action[deleteExtentsFromList] dp(9) is discard, skip extent(1025)
```

```log
nature@PS9054862:~/cubefs$ ./build/bin/cfs-cli datapartition set-discard -h
Set discard flag for data partition

Usage:
  cfs-cli datapartition set-discard [DATA PARTITION ID] [DISCARD] [flags]

Flags:
  -h, --help   help for set-discard
```

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
