### PR TITLE
enhance(metanode): Metadata update failure due to forbidden migration…

### DIFF
--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -398,6 +398,13 @@ func (client *ExtentClient) OpenStream(inode uint64, openForWrite, isCache bool)
 	if !ok {
 		s = NewStreamer(client, inode, openForWrite, isCache)
 		client.streamers[inode] = s
+	} else {
+		//If you open a file in write mode first and then open the same file
+		//in read mode without modifying any attributes, maintaining the file's immutability status.
+		if !s.openForWrite {
+			s.openForWrite = openForWrite
+		}
+		//TODO: update isCache?
 	}
 	return s.IssueOpenRequest()
 }


### PR DESCRIPTION
… or mismatched writeGen will not trigger a retry
**What this PR does / why we need it**:
Metadata update failure due to forbidden migration or mismatched writeGen will not trigger a retry
