### PR TITLE
amend that server.user.clearUserStore() may be invoked before server.user is initialized, in func handleLeaderChange(), to avoid panic

### DIFF
--- a/master/master_manager.go
+++ b/master/master_manager.go
@@ -246,9 +246,14 @@ func (m *Server) clearMetadata() {
 	m.cluster.clearMetaNodes()
 	m.cluster.clearLcNodes()
 	m.cluster.clearVols()
-	m.user.clearUserStore()
-	m.user.clearAKStore()
-	m.user.clearVolUsers()
+
+	if m.user != nil {
+		// leader change event may be before m.user initialization
+		m.user.clearUserStore()
+		m.user.clearAKStore()
+		m.user.clearVolUsers()
+	}
+
 	m.cluster.t = newTopology()
 	// m.cluster.apiLimiter.Clear()
 }

--- a/master/server.go
+++ b/master/server.go
@@ -410,8 +410,10 @@ func (m *Server) initFsm() {
 }
 
 func (m *Server) initCluster() {
+	log.LogInfo("action[initCluster] begin")
 	m.cluster = newCluster(m.clusterName, m.leaderInfo, m.fsm, m.partition, m.config)
 	m.cluster.retainLogs = m.retainLogs
+	log.LogInfo("action[initCluster] end")
 
 	// incase any limiter on follower
 	log.LogInfo("action[loadApiLimiterInfo] begin")
@@ -420,5 +422,7 @@ func (m *Server) initCluster() {
 }
 
 func (m *Server) initUser() {
+	log.LogInfo("action[initUser] begin")
 	m.user = newUser(m.fsm, m.partition)
+	log.LogInfo("action[initUser] end")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
amend that server.user.clearUserStore() may be invoked before server.user is initialized, in func handleLeaderChange(), to avoid panic