### PR TITLE
fix(master):Cold volumes update cachecap greater than zero when dp re…

### DIFF
--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1982,7 +1982,10 @@ func (m *Server) checkReplicaNum(r *http.Request, vol *Vol, req *updateVolReq) (
 			return
 		}
 	} else {
-		if (req.replicaNum == 0 && req.coldArgs.cacheCap > 0) || !req.followerRead {
+		if req.replicaNum == 0 && req.coldArgs.cacheCap > 0 {
+			req.replicaNum = 1
+		}
+		if (req.replicaNum == 0 && req.replicaNum != int(vol.dpReplicaNum)) || !req.followerRead {
 			err = fmt.Errorf("replica or follower read status error")
 			return
 		}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cold volumes update cachecap greater than zero when dp replicaNum is zero, set dp dp replicaNum to one.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
