### PR TITLE
bugfix(client): catch the error when the ExtentHandler encounters a p…

### DIFF
--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -138,7 +138,12 @@ func (eh *ExtentHandler) String() string {
 
 func (eh *ExtentHandler) write(data []byte, offset, size int, direct bool) (ek *proto.ExtentKey, err error) {
 	var total, write int
-
+	//TODO: eh.packet may be set to nil when ExtentHandler in error status
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.NewErrorf("ExtentHandler Write: Panic occurred: %v", r)
+		}
+	}()
 	status := eh.getStatus()
 	if status >= ExtentStatusClosed {
 		err = errors.NewErrorf("ExtentHandler Write: Full or Recover eh(%v) key(%v)", eh, eh.key)


### PR DESCRIPTION
…anic during the write operation
**What this PR does / why we need it**:
 catch the error when the ExtentHandler encounters a panic during the write operation