### PR TITLE
fix(master): When updating a volume, ebsBlockSize can be modified if allowedStorageClass contains blobstore.

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -250,7 +250,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 	s.mw.VerReadSeq = s.ec.GetReadVer()
 
-	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+	if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 		s.ebsc, err = blobstore.NewEbsClient(access.Config{
 			ConnMode: access.NoLimitConnMode,
 			Consul: access.ConsulConfig{
@@ -276,7 +276,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 
 	s.suspendCh = make(chan interface{})
-	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+	if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 		go s.scheduleFlush()
 	}
 	if s.mw.EnableSummary {

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -352,7 +352,7 @@ func main() {
 	}
 
 	proto.InitBufferPool(opt.BuffersTotalLimit)
-	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+	if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 		buf.InitCachePool(opt.EbsBlockSize)
 	}
 	if opt.EnableBcache {
@@ -661,7 +661,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 			}
 			super.SetTransaction(volumeInfo.EnableTransaction, volumeInfo.TxTimeout, volumeInfo.TxConflictRetryNum, volumeInfo.TxConflictRetryInterval)
 
-			if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+			if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 				super.EbsBlockSize = volumeInfo.ObjBlockSize
 			}
 			if proto.IsStorageClassBlobStore(opt.VolStorageClass) {

--- a/master/vol.go
+++ b/master/vol.go
@@ -1530,7 +1530,7 @@ func setVolFromArgs(args *VolVarargs, vol *Vol) {
 	vol.txOpLimit = args.txOpLimit
 	vol.dpReplicaNum = args.dpReplicaNum
 
-	if proto.IsCold(vol.VolType) {
+	if proto.IsVolSupportStorageClass(vol.allowedStorageClass, proto.StorageClass_BlobStore) {
 		coldArgs := args.coldArgs
 		vol.CacheLRUInterval = coldArgs.cacheLRUInterval
 		vol.CacheLowWater = coldArgs.cacheLowWater

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -756,7 +756,7 @@ func (mp *metaPartition) onStart(isCreate bool) (err error) {
 
 	mp.volType = volumeInfo.VolType
 
-	if clusterInfo.EbsAddr != "" && proto.VolSupportsBlobStore(volumeInfo.AllowedStorageClass) {
+	if clusterInfo.EbsAddr != "" && proto.IsVolSupportStorageClass(volumeInfo.AllowedStorageClass, proto.StorageClass_BlobStore) {
 		var ebsClient *blobstore.BlobStoreClient
 		ebsClient, err = blobstore.NewEbsClient(
 			access.Config{

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1232,9 +1232,9 @@ func IsStorageClassBlobStore(storageClass uint32) bool {
 	return storageClass == StorageClass_BlobStore
 }
 
-func VolSupportsBlobStore(allowedStorageClass []uint32) bool {
+func IsVolSupportStorageClass(allowedStorageClass []uint32, storeClass uint32) bool {
 	for _, storageClass := range allowedStorageClass {
-		if storageClass == StorageClass_BlobStore {
+		if storageClass == storeClass {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(master): When updating a volume, ebsBlockSize can be modified if allowedStorageClass contains blobstore.