### PR TITLE
fix(datanode): remove repeated crc

### DIFF
--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -568,7 +568,7 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 			loopTimes++
 
 			actualCrc := crc32.ChecksumIEEE(reply.Data[:reply.Size])
-			if reply.CRC != crc32.ChecksumIEEE(reply.Data[:reply.Size]) {
+			if reply.CRC != actualCrc {
 				err = fmt.Errorf("streamRepairExtent crc mismatch expectCrc(%v) actualCrc(%v) extent(%v_%v) start fix from (%v)"+
 					" remoteSize(%v) localSize(%v) request(%v) reply(%v) ", reply.CRC, actualCrc, dp.partitionID, remoteExtentInfo.String(),
 					remoteExtentInfo.Source, dstOffset, currFixOffset, request.GetUniqueLogId(), reply.GetUniqueLogId())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
 calculate crc repeatedly in streamRepairExtent，it is not necessary.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
