### PR TITLE
feat(access): add volume allocation and lease retain functions for access

### DIFF
--- a/blobstore/access/controller/allocator_mock_test.go
+++ b/blobstore/access/controller/allocator_mock_test.go
@@ -32,9 +32,10 @@ import (
 
 func NewAllocatorMockCmCli(tb testing.TB) cm.ClientAPI {
 	cmCli := mocks.NewMockClientAPI(gomock.NewController(tb))
-	cmCli.EXPECT().RegisterService(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	cmCli.EXPECT().AllocBid(gomock.Any(), gomock.Any()).Return(&cm.BidScopeRet{StartBid: proto.BlobID(1), EndBid: proto.BlobID(10000)}, nil).AnyTimes()
-	cmCli.EXPECT().GetConfig(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, key string) (ret string, err error) {
+	A := gomock.Any()
+	cmCli.EXPECT().RegisterService(A, A, A, A, A).Return(nil).AnyTimes()
+	cmCli.EXPECT().AllocBid(A, A).Return(&cm.BidScopeRet{StartBid: proto.BlobID(1), EndBid: proto.BlobID(10000)}, nil).AnyTimes()
+	cmCli.EXPECT().GetConfig(A, A).DoAndReturn(func(ctx context.Context, key string) (ret string, err error) {
 		switch key {
 		case proto.CodeModeConfigKey:
 			policy := []codemode.Policy{
@@ -51,7 +52,7 @@ func NewAllocatorMockCmCli(tb testing.TB) cm.ClientAPI {
 			return
 		}
 	}).AnyTimes()
-	cmCli.EXPECT().AllocVolumeV2(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, args *cm.AllocVolumeV2Args) (ret cm.AllocatedVolumeInfos, err error) {
+	cmCli.EXPECT().AllocVolumeV2(A, A).DoAndReturn(func(ctx context.Context, args *cm.AllocVolumeV2Args) (ret cm.AllocatedVolumeInfos, err error) {
 		if !args.CodeMode.IsValid() {
 			return cm.AllocatedVolumeInfos{}, errors.New("alloc error")
 		}
@@ -76,7 +77,7 @@ func NewAllocatorMockCmCli(tb testing.TB) cm.ClientAPI {
 
 		return rets, nil
 	}).AnyTimes()
-	cmCli.EXPECT().RetainVolume(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, args *cm.RetainVolumeArgs) (ret cm.RetainVolumes, err error) {
+	cmCli.EXPECT().RetainVolume(A, A).DoAndReturn(func(ctx context.Context, args *cm.RetainVolumeArgs) (ret cm.RetainVolumes, err error) {
 		now := int64(1598000000)
 		ret = cm.RetainVolumes{}
 		vol := make([]cm.RetainVolume, 0)
@@ -90,6 +91,8 @@ func NewAllocatorMockCmCli(tb testing.TB) cm.ClientAPI {
 		ret.RetainVolTokens = vol
 		return ret, nil
 	}).AnyTimes()
+
+	cmCli.EXPECT().ReleaseVolume(A, A).Return(nil).AnyTimes()
 
 	return cmCli
 }

--- a/blobstore/access/controller/mock_test.go
+++ b/blobstore/access/controller/mock_test.go
@@ -104,6 +104,7 @@ func init() {
 
 	cli := mocks.NewMockClientAPI(C(&testing.T{}))
 	cli.EXPECT().GetConfig(A, A).AnyTimes().Return("abc", nil)
+	cli.EXPECT().AllocBid(A, A).Return(&cmapi.BidScopeRet{StartBid: proto.BlobID(1), EndBid: proto.BlobID(10000)}, nil).AnyTimes()
 	cli.EXPECT().GetService(A, A).AnyTimes().DoAndReturn(
 		func(ctx context.Context, args cmapi.GetServiceArgs) (cmapi.ServiceInfo, error) {
 			if val, ok := dataNodes[args.Name]; ok {

--- a/blobstore/access/controller_mock_test.go
+++ b/blobstore/access/controller_mock_test.go
@@ -110,6 +110,21 @@ func (mr *MockClusterControllerMockRecorder) GetServiceController(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceController", reflect.TypeOf((*MockClusterController)(nil).GetServiceController), arg0)
 }
 
+// GetVolumeAllocator mocks base method.
+func (m *MockClusterController) GetVolumeAllocator(arg0 proto.ClusterID) (controller.VolumeMgr, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAllocator", arg0)
+	ret0, _ := ret[0].(controller.VolumeMgr)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAllocator indicates an expected call of GetVolumeAllocator.
+func (mr *MockClusterControllerMockRecorder) GetVolumeAllocator(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAllocator", reflect.TypeOf((*MockClusterController)(nil).GetVolumeAllocator), arg0)
+}
+
 // GetVolumeGetter mocks base method.
 func (m *MockClusterController) GetVolumeGetter(arg0 proto.ClusterID) (controller.VolumeGetter, error) {
 	m.ctrl.T.Helper()

--- a/blobstore/access/stream_alloc_test.go
+++ b/blobstore/access/stream_alloc_test.go
@@ -34,24 +34,21 @@ func TestAccessStreamAllocBase(t *testing.T) {
 		require.Equal(t, codemode.EC6P6, loc.CodeMode)
 		require.Equal(t, uint64(1<<30), loc.Size)
 		require.Equal(t, uint32(1<<22), loc.BlobSize)
-		require.Equal(t, 2, len(loc.Blobs))
-		require.Equal(t, uint32(1), loc.Blobs[0].Count)
-		require.Equal(t, uint32((1<<8)-1), loc.Blobs[1].Count)
+		require.Equal(t, 1, len(loc.Blobs))
+		require.Equal(t, uint32(256), loc.Blobs[0].Count)
 	}
 	{
 		loc, err := streamer.Alloc(ctx(), (1<<30)+1, 0, 0, 0)
 		require.NoError(t, err)
-		require.Equal(t, 2, len(loc.Blobs))
-		require.Equal(t, uint32(1), loc.Blobs[0].Count)
-		require.Equal(t, uint32(1<<8), loc.Blobs[1].Count)
+		require.Equal(t, 1, len(loc.Blobs))
+		require.Equal(t, uint32(257), loc.Blobs[0].Count)
 	}
 	// 1M blobsize
 	{
 		loc, err := streamer.Alloc(ctx(), 1<<30, 1<<20, 0, 0)
 		require.NoError(t, err)
-		require.Equal(t, 2, len(loc.Blobs))
-		require.Equal(t, uint32(1), loc.Blobs[0].Count)
-		require.Equal(t, uint32((1<<10)-1), loc.Blobs[1].Count)
+		require.Equal(t, 1, len(loc.Blobs))
+		require.Equal(t, uint32(1<<10), loc.Blobs[0].Count)
 	}
 	// max size + 1
 	{

--- a/blobstore/api/clustermgr/volume.go
+++ b/blobstore/api/clustermgr/volume.go
@@ -169,8 +169,9 @@ func (c *Client) RetainVolume(ctx context.Context, args *RetainVolumeArgs) (ret 
 }
 
 type ReleaseVolumes struct {
-	NormalVids []proto.Vid `json:"normal_vids"`
-	SealedVids []proto.Vid `json:"sealed_vids"`
+	CodeMode   codemode.CodeMode `json:"code_mode"`
+	NormalVids []proto.Vid       `json:"normal_vids"`
+	SealedVids []proto.Vid       `json:"sealed_vids"`
 }
 
 func (c *Client) ReleaseVolume(ctx context.Context, args *ReleaseVolumes) (err error) {


### PR DESCRIPTION
…cess instead proxy

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In order to reduce the number of blobstore components, this PR will transplant the volume allocation and retain functions in proxy to access, and adapt the original logic
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
