### PR TITLE
fix(master): When updating a volume, ebsBlockSize can be modified if allowedStorageClass contains blobstore.

### DIFF
--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -361,8 +361,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  Allow follower read : %v\n", formatEnabledDisabled(vv.FollowerRead)))
 			}
 			if optEbsBlkSize > 0 {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("ebs-blk-size not support in hot vol\n")
+				if proto.IsVolSupportStorageClass(vv.AllowedStorageClass, proto.StorageClass_BlobStore) {
+					err = fmt.Errorf("ebs-blk-size can not be set because vol not support blobstore\n")
 					return
 				}
 				isChange = true
@@ -372,8 +372,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  EbsBlkSize          : %v byte\n", vv.ObjBlockSize))
 			}
 			if optCacheCap != "" {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-capacity not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-capacity can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true
@@ -485,8 +485,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 			}
 
 			if optCacheAction != "" {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-action not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-action can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true
@@ -499,8 +499,12 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  CacheAction         : %v \n", vv.CacheAction))
 			}
 			if optCacheRule != "" {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-rule not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-rule can not be set because vol storageClass is not blobstore\n")
+					return
+				}
+				if proto.IsVolSupportStorageClass(vv.AllowedStorageClass, proto.StorageClass_BlobStore) {
+					err = fmt.Errorf("ebs-blk-size can not be set because vol not support blobstore\n")
 					return
 				}
 				isChange = true
@@ -510,8 +514,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  CacheRule        : %v \n", vv.CacheAction))
 			}
 			if optCacheThreshold > 0 {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-threshold not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-threshold can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true
@@ -521,8 +525,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  CacheThreshold      : %v byte\n", vv.CacheThreshold))
 			}
 			if optCacheTTL > 0 {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-ttl not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-ttl can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true
@@ -532,8 +536,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  CacheTTL            : %v day\n", vv.CacheTtl))
 			}
 			if optCacheHighWater > 0 {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-high-water not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-high-water can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true
@@ -543,8 +547,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  CacheHighWater      : %v \n", vv.CacheHighWater))
 			}
 			if optCacheLowWater > 0 {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-low-water not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-low-water can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true
@@ -554,8 +558,8 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 				confirmString.WriteString(fmt.Sprintf("  CacheLowWater       : %v \n", vv.CacheLowWater))
 			}
 			if optCacheLRUInterval > 0 {
-				if vv.VolType == 0 {
-					err = fmt.Errorf("cache-lru-interval not support in hot vol\n")
+				if vv.VolStorageClass != proto.StorageClass_BlobStore {
+					err = fmt.Errorf("cache-lru-interval can not be set because vol storageClass is not blobstore\n")
 					return
 				}
 				isChange = true

--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -250,7 +250,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 	s.mw.VerReadSeq = s.ec.GetReadVer()
 
-	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+	if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 		s.ebsc, err = blobstore.NewEbsClient(access.Config{
 			ConnMode: access.NoLimitConnMode,
 			Consul: access.ConsulConfig{
@@ -276,7 +276,7 @@ func NewSuper(opt *proto.MountOptions) (s *Super, err error) {
 	}
 
 	s.suspendCh = make(chan interface{})
-	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+	if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 		go s.scheduleFlush()
 	}
 	if s.mw.EnableSummary {

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -352,7 +352,7 @@ func main() {
 	}
 
 	proto.InitBufferPool(opt.BuffersTotalLimit)
-	if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+	if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 		buf.InitCachePool(opt.EbsBlockSize)
 	}
 	if opt.EnableBcache {
@@ -661,7 +661,7 @@ func mount(opt *proto.MountOptions) (fsConn *fuse.Conn, super *cfs.Super, err er
 			}
 			super.SetTransaction(volumeInfo.EnableTransaction, volumeInfo.TxTimeout, volumeInfo.TxConflictRetryNum, volumeInfo.TxConflictRetryInterval)
 
-			if proto.VolSupportsBlobStore(opt.VolAllowedStorageClass) {
+			if proto.IsVolSupportStorageClass(opt.VolAllowedStorageClass, proto.StorageClass_BlobStore) {
 				super.EbsBlockSize = volumeInfo.ObjBlockSize
 			}
 			if proto.IsStorageClassBlobStore(opt.VolStorageClass) {

--- a/master/vol.go
+++ b/master/vol.go
@@ -1530,7 +1530,7 @@ func setVolFromArgs(args *VolVarargs, vol *Vol) {
 	vol.txOpLimit = args.txOpLimit
 	vol.dpReplicaNum = args.dpReplicaNum
 
-	if proto.IsCold(vol.VolType) {
+	if proto.IsVolSupportStorageClass(vol.allowedStorageClass, proto.StorageClass_BlobStore) {
 		coldArgs := args.coldArgs
 		vol.CacheLRUInterval = coldArgs.cacheLRUInterval
 		vol.CacheLowWater = coldArgs.cacheLowWater

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -756,7 +756,7 @@ func (mp *metaPartition) onStart(isCreate bool) (err error) {
 
 	mp.volType = volumeInfo.VolType
 
-	if clusterInfo.EbsAddr != "" && proto.VolSupportsBlobStore(volumeInfo.AllowedStorageClass) {
+	if clusterInfo.EbsAddr != "" && proto.IsVolSupportStorageClass(volumeInfo.AllowedStorageClass, proto.StorageClass_BlobStore) {
 		var ebsClient *blobstore.BlobStoreClient
 		ebsClient, err = blobstore.NewEbsClient(
 			access.Config{

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1232,9 +1232,9 @@ func IsStorageClassBlobStore(storageClass uint32) bool {
 	return storageClass == StorageClass_BlobStore
 }
 
-func VolSupportsBlobStore(allowedStorageClass []uint32) bool {
+func IsVolSupportStorageClass(allowedStorageClass []uint32, storeClass uint32) bool {
 	for _, storageClass := range allowedStorageClass {
-		if storageClass == StorageClass_BlobStore {
+		if storageClass == storeClass {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix(master): When updating a volume, ebsBlockSize can be modified if allowedStorageClass contains blobstore.