### PR TITLE
fix(client):  snapshot issue trigger by version update && update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Some key features of CubeFS include:
 - Mailing list: users@cubefs.groups.io
 - Slack: [cubefs.slack.com](https://cubefs.slack.com/)
 - WeChat: detail see [here](https://github.com/cubefs/cubefs/issues/604)
-- Twitter: [cubefs_storge](https://twitter.com/cubefs_storage)
+- Twitter: [cubefs_storage](https://twitter.com/cubefs_storage)
 
 ## Partners and Users
 

--- a/master/multi_ver_snapshot.go
+++ b/master/multi_ver_snapshot.go
@@ -55,6 +55,7 @@ type VolVersionManager struct {
 	checkStrategy    int32
 	checkStatus      int32
 	c                *Cluster
+	enableMiddleOp   bool
 	sync.RWMutex
 }
 
@@ -541,9 +542,11 @@ func (verMgr *VolVersionManager) initVer2PhaseTask(verSeq uint64, op uint8) (ver
 			found bool
 		)
 
-		if ver, status := verMgr.getOldestVer(); ver != verSeq || status != proto.VersionNormal {
-			err = fmt.Errorf("oldest is %v, status %v", ver, status)
-			return
+		if verMgr.enableMiddleOp {
+			if ver, status := verMgr.getOldestVer(); ver != verSeq || status != proto.VersionNormal {
+				err = fmt.Errorf("oldest is %v, status %v", ver, status)
+				return
+			}
 		}
 
 		if idx, found = verMgr.getLayInfo(verSeq); !found {

--- a/sdk/data/stream/extent_handler.go
+++ b/sdk/data/stream/extent_handler.go
@@ -362,7 +362,7 @@ func (eh *ExtentHandler) processReply(packet *Packet) {
 	if verUpdate {
 		fileOffset = reply.KernelOffset
 	}
-	if eh.key == nil {
+	if eh.key == nil || verUpdate {
 		eh.key = &proto.ExtentKey{
 			FileOffset:   fileOffset,
 			PartitionId:  packet.PartitionID,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When processing the return from the datanode, if the sequence changes and the extent key is no longer consecutive,
the key inside the extent handler needs to be initialized.The current initialization only changes the file offset and nothing else,
which actually pollutes the extent cache and leads to anomalies in subsequent modifications based on this cache information.
