### PR TITLE
fix(datanode): mark the extent as IsDeleted if it exist in deleteExtents map

### DIFF
--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -361,7 +361,6 @@ func (dp *DataPartition) prepareRepairTasks(repairTasks []*DataPartitionRepairTa
 		extentInfo := extentInfoMap[extentID]
 		if extentInfo != nil {
 			extentInfo.IsDeleted = true
-			extentInfoMap[extentID] = extentInfo
 		}
 	}
 	dp.buildExtentCreationTasks(repairTasks, extentInfoMap)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Mark the extent as 'IsDeleted' if it exist in deleteExtents map，no need to add it to deleteExtents.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
