### PR TITLE
chore(build): fix go 1.21 build cache

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -45,7 +45,7 @@ has_go() {
 
 get_go_build_cache() {
     tmp=`go env | grep GOCACHE | awk -F= '{print $2}'`
-    echo ${tmp} | sed 's/\"//g'
+    echo ${tmp} | sed 's/\"//g' | sed "s/'//g"
 }
 
 check_is_podman() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

* It looks like the output of `go env` is different between 1.21 and 1.18.

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
