### PR TITLE
feat(blobnode): add checkpoint for inspectmgr of blobnode

### DIFF
--- a/blobstore/access/controller/cluster_test.go
+++ b/blobstore/access/controller/cluster_test.go
@@ -259,7 +259,7 @@ func newCC() controller.ClusterController {
 func newCCStop() (controller.ClusterController, func()) {
 	cfg := controller.ClusterConfig{
 		Region:            region,
-		ClusterReloadSecs: 0,
+		ClusterReloadSecs: 1000,
 		ConsulAgentAddr:   hostAddr,
 	}
 	cfg.CMClientConfig.LbConfig.Config.Tc = rpc.TransportConfig{

--- a/blobstore/access/controller/service_test.go
+++ b/blobstore/access/controller/service_test.go
@@ -86,7 +86,7 @@ func TestAccessServicePunishService(t *testing.T) {
 	stop := closer.New()
 	defer stop.Close()
 	sc, err := controller.NewServiceController(
-		controller.ServiceConfig{IDC: idc, ReloadSec: 1}, cmcli, proxycli, stop.Done())
+		controller.ServiceConfig{IDC: idc, ReloadSec: 2}, cmcli, proxycli, stop.Done())
 	require.NoError(t, err)
 
 	{
@@ -105,8 +105,7 @@ func TestAccessServicePunishService(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, host == "proxy-1")
 	}
-
-	time.Sleep(time.Millisecond * 1200)
+	time.Sleep(time.Millisecond * 2200)
 	{
 		keys := make(hostSet)
 		for range [100]struct{}{} {

--- a/blobstore/blobnode/config.go
+++ b/blobstore/blobnode/config.go
@@ -44,6 +44,8 @@ const (
 
 	DefaultDeleteQpsLimitPerDisk = 128
 	DefaultInspectRate           = 4 * 1024 * 1024 // rate limit 4MB per second
+
+	defaultInspectCheckpointPath = "/tmp/blobnode/checkpoint"
 )
 
 var (
@@ -108,6 +110,11 @@ func configInit(config *Config) {
 	if config.DeleteQpsLimitPerDisk <= 0 {
 		config.DeleteQpsLimitPerDisk = DefaultDeleteQpsLimitPerDisk
 	}
+
+	if config.InspectConf.CheckPoint == "" {
+		config.InspectConf.CheckPoint = defaultInspectCheckpointPath
+	}
+
 	defaulter.LessOrEqual(&config.InspectConf.IntervalSec, DefaultChunkInspectIntervalSec)
 	defaulter.LessOrEqual(&config.InspectConf.RateLimit, DefaultInspectRate)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Blobnode is slow to inspect large-capacity disks and needs to save the current inspection progress through checkpoint.
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
