### PR TITLE
fix(blobnode): reload config data qos. panic when conf normal mbps is zero

### DIFF
--- a/blobstore/blobnode/base/qos/config.go
+++ b/blobstore/blobnode/base/qos/config.go
@@ -27,14 +27,14 @@ const (
 )
 
 type Config struct {
-	StatGetter        flow.StatGetter `json:"-"` // Identify: a io flow
-	DiskViewer        iostat.IOViewer `json:"-"` // Identify: io viewer
-	ReadQueueDepth    int             `json:"-"` // equal $queueDepth of io pool: The number of elements in the queue
-	WriteQueueDepth   int             `json:"-"` // equal $queueDepth of io pool: The number of elements in the queue
-	WriteChanQueCnt   int             `json:"-"` // The number of chan queues, equal $chanCnt of write io pool
-	MaxWaitCount      int             `json:"max_wait_count"`
-	DiskBandwidthMBPS int64           `json:"disk_bandwidth_mbps"`
-	BackgroundMBPS    int64           `json:"background_mbps"`
+	StatGetter      flow.StatGetter `json:"-"` // Identify: a io flow
+	DiskViewer      iostat.IOViewer `json:"-"` // Identify: io viewer
+	ReadQueueDepth  int             `json:"-"` // equal $queueDepth of io pool: The number of elements in the queue, must not zero
+	WriteQueueDepth int             `json:"-"` // equal $queueDepth of io pool: The number of elements in the queue
+	WriteChanQueCnt int             `json:"-"` // The number of chan queues, equal $chanCnt of write io pool
+	MaxWaitCount    int             `json:"max_wait_count"`
+	NormalMBPS      int64           `json:"normal_mbps"`
+	BackgroundMBPS  int64           `json:"background_mbps"`
 }
 
 type ParaConfig struct {
@@ -45,10 +45,11 @@ type ParaConfig struct {
 type LevelConfig map[string]ParaConfig
 
 func InitAndFixQosConfig(raw *Config) {
+	defaulter.LessOrEqual(&raw.NormalMBPS, int64(defaultMaxBandwidthMBPS))
 	defaulter.LessOrEqual(&raw.BackgroundMBPS, int64(defaultBackgroundBandwidthMBPS))
 	defaulter.LessOrEqual(&raw.MaxWaitCount, defaultMaxWaitCount)
 
-	if raw.BackgroundMBPS > raw.DiskBandwidthMBPS && raw.DiskBandwidthMBPS > 0 {
-		raw.BackgroundMBPS = raw.DiskBandwidthMBPS // fix background
+	if raw.BackgroundMBPS > raw.NormalMBPS {
+		raw.BackgroundMBPS = raw.NormalMBPS // fix background
 	}
 }

--- a/blobstore/blobnode/datainspect.go
+++ b/blobstore/blobnode/datainspect.go
@@ -72,7 +72,7 @@ func NewDataInspectMgr(svr *Service, conf DataInspectConf, switchMgr *taskswitch
 
 func (mgr *DataInspectMgr) loopDataInspect() {
 	span, ctx := trace.StartSpanFromContext(mgr.svr.ctx, "")
-	t := time.NewTimer(time.Second * 5) // wait switch
+	t := time.NewTicker(time.Second * 5) // wait switch
 	defer t.Stop()
 
 	for {
@@ -82,7 +82,6 @@ func (mgr *DataInspectMgr) loopDataInspect() {
 				continue
 			}
 			mgr.inspectAllDisks(ctx)
-			t.Reset(time.Second * 5)
 
 		case <-mgr.svr.closeCh:
 			span.Warnf("loop inspect data closed.")

--- a/blobstore/blobnode/service.go
+++ b/blobstore/blobnode/service.go
@@ -120,7 +120,7 @@ func NewHandler(service *Service) *rpc.Router {
 	rpc.Use(service.requestCounter) // first interceptor
 	r.Handle(http.MethodGet, "/stat", service.Stat, rpc.OptArgsQuery())
 	r.Handle(http.MethodGet, "/debug/stat", service.DebugStat, rpc.OptArgsQuery())
-	r.Handle(http.MethodPost, "/config/reload", service.configReload, rpc.OptArgsQuery())
+	r.Handle(http.MethodPost, "/config/reload", service.ConfigReload, rpc.OptArgsQuery())
 
 	r.Handle(http.MethodGet, "/disk/stat/diskid/:diskid", service.DiskStat, rpc.OptArgsURI())
 	r.Handle(http.MethodPost, "/disk/probe", service.DiskProbe, rpc.OptArgsBody())

--- a/blobstore/common/proto/proxy.go
+++ b/blobstore/common/proto/proxy.go
@@ -23,7 +23,8 @@ var ErrInvalidMsg = errors.New("msg is invalid")
 type DeleteStage byte
 
 const (
-	DeleteStageMarkDelete = DeleteStage(iota + 1)
+	InitStage DeleteStage = iota
+	DeleteStageMarkDelete
 	DeleteStageDelete
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
merge blobstore-v1.2.4 feature branch to master
1. fix reload config data qos. panic when conf normal mbps is zero
2. fix blobnode datainspect switch
3. fix scheduler roll back to init stage, when err is shard not mark delete 653

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
