### PR TITLE
feat(shell): support deploy client and object in Standalone Mode

### DIFF
--- a/docs-zh/source/quick-start/node.md
+++ b/docs-zh/source/quick-start/node.md
@@ -10,16 +10,24 @@ $ git clone https://github.com/cubefs/cubefs.git
 ### 脚本部署
 
 #### 部署基础集群
-CubeFS 支持使用脚本一键部署基础集群，包含组件`Master`、`MetaNode`、`DataNode`，步骤如下：
+CubeFS 支持使用脚本一键部署基础集群，基础集群包含组件`Master`、`MetaNode`、`DataNode`，同时可额外选择启动`client`和`ObjectNode`。 步骤如下：
 ```bash
 cd ./cubefs
 # 编译
 make
-# 启动脚本
-sh ./shell/depoly.sh /home/data bond0
+# 生成配置文件并启动基础集群
+sh ./shell/deploy.sh /home/data bond0
+
+# 等待1分钟待集群就绪后，可选执行以下命令
+
+# 挂载文件系统（可选，如果想体验文件存储，则执行该条命令。默认挂载在/home/data/client/mnt）
+sh ./shell/deploy_client.sh /home/data
+
+# 启动对象存储（可选，如果想体验对象存储，则执行该条命令。默认监听端口为17410）
+sh ./shell/deploy_object.sh /home/data
 ```
 + `bond0`: 为本机网卡的名字, 根据实际填写
-+ `/home/data`: 为本地的一个目录,用于保存集群运行日志、数据及配置文件
++ `/home/data`: 为本地的一个目录,用于保存集群运行日志、数据及配置文件。三个`sh`命令的目录应当相同
 + 机器要求
   + 需root权限
   + 能使用`ifconfig`
@@ -31,24 +39,25 @@ sh ./shell/depoly.sh /home/data bond0
 [Cluster]
   Cluster name       : cfs_dev
   Master leader      : 172.16.1.101:17010
+  Master-1           : 172.16.1.101:17010
+  Master-2           : 172.16.1.102:17010
+  Master-3           : 172.16.1.103:17010
   Auto allocate      : Enabled
-  MetaNode count     : 4
-  MetaNode used      : 0 GB
-  MetaNode total     : 21 GB
-  DataNode count     : 4
-  DataNode used      : 191 GB
-  DataNode total     : 369 GB
+  MetaNode count (active/total)    : 4/4
+  MetaNode used                    : 0 GB
+  MetaNode available               : 21 GB
+  MetaNode total                   : 21 GB
+  DataNode count (active/total)    : 4/4
+  DataNode used                    : 44 GB
+  DataNode available               : 191 GB
+  DataNode total                   : 235 GB
   Volume count       : 2
 ...
 ```
 
-#### 部署对象网关
+文件系统的使用可参考[使用文件系统章节](../user-guide/file.md)
 
-::: tip 提示
-可选章节，如果需要使用对象存储服务，则需要部署对象网关（ObjectNode）
-:::
-
-参考[使用对象存储章节](../user-guide/objectnode.md)
+对象存储的使用可参考[使用对象存储章节](../user-guide/objectnode.md)
 
 #### 部署纠删码子系统
 

--- a/docs/source/quick-start/node.md
+++ b/docs/source/quick-start/node.md
@@ -10,16 +10,24 @@ $ git clone https://github.com/cubefs/cubefs.git
 ### Script Installation
 
 #### Install Basic Cluster
-CubeFS supports one-click deployment of the basic cluster using scripts, including components such as `Master`, `MetaNode`, and `DataNode`. The steps are as follows:
+CubeFS supports deploying a basic cluster with a single script. The basic cluster includes components such as `Master`, `MetaNode`, and `DataNode`, with the option to additionally start a `client` and `ObjectNode`. The steps are as follows:
 ```bash
 cd ./cubefs
 # Compile
 make
-# Start the script
-sh ./shell/depoly.sh /home/data bond0
+# Generate configuration files and start the basic cluster
+sh ./shell/deploy.sh /home/data bond0
+
+# Wait a minute for cluster to prepare state, and optionally execute the following command
+
+# Mount the file system (optional, execute this command if you want to experience file storage. By default, it is mounted at /home/data/client/mnt)
+sh ./shell/deploy_client.sh /home/data
+
+# Start object storage (optional, execute this command if you want to experience object storage. The default listening port is 17410)
+sh ./shell/deploy_object.sh /home/data
 ```
 + `bond0`: The name of the local network card, fill in according to the actual situation
-+ `/home/data`: A local directory used to store cluster running logs, data, and configuration files
++ `/home/data`: A local directory used to store cluster running logs, data, and configuration files. The directory should be the same for all three `sh` commands.
 + Machine requirements
   + Need root permission
   + Able to use `ifconfig`
@@ -31,24 +39,25 @@ sh ./shell/depoly.sh /home/data bond0
 [Cluster]
   Cluster name       : cfs_dev
   Master leader      : 172.16.1.101:17010
+  Master-1           : 172.16.1.101:17010
+  Master-2           : 172.16.1.102:17010
+  Master-3           : 172.16.1.103:17010
   Auto allocate      : Enabled
-  MetaNode count     : 4
-  MetaNode used      : 0 GB
-  MetaNode total     : 21 GB
-  DataNode count     : 4
-  DataNode used      : 191 GB
-  DataNode total     : 369 GB
+  MetaNode count (active/total)    : 4/4
+  MetaNode used                    : 0 GB
+  MetaNode available               : 21 GB
+  MetaNode total                   : 21 GB
+  DataNode count (active/total)    : 4/4
+  DataNode used                    : 44 GB
+  DataNode available               : 191 GB
+  DataNode total                   : 235 GB
   Volume count       : 2
 ...
 ```
 
-#### Install Object Gateway
+For using the file system, refer to the [File System Usage section](../user-guide/file.md).
 
-::: tip Note
-Optional section. If you need to use the object storage service, you need to deploy the object gateway (ObjectNode).
-:::
-
-Refer to [Object Storage Section](../user-guide/objectnode.md)
+For using object storage, refer to the [Object Storage Usage section](../user-guide/objectnode.md).
 
 #### Install Erasure Code Subsystem
 

--- a/shell/deploy.sh
+++ b/shell/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $# -ne 2 ]; then
-    echo "usage: start cluster: ./shell/depoly.sh <baseDir>  <bond0>"
+    echo "usage: start cluster: $0 <baseDir> <bond0>"
     exit 1
 fi
 

--- a/shell/deploy_client.sh
+++ b/shell/deploy_client.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "usage: start client: $0 <baseDir>"
+    exit 1
+fi
+
+confFile=${1}/conf/client.conf
+mntDir=${1}/client/mnt
+
+if [ ! -f "${confFile}" ]; then
+  echo "Error: ${confFile} not exist. Ensure 'sh ./shell/deploy.sh <baseDir> <bond0>' is run before 'sh ./shell/deploy_client.sh <baseDir>', with the same <baseDir> in both commands."
+  exit 1
+fi
+
+echo "mkdir -p $mntDir"
+mkdir -p $mntDir
+
+echo "start checking whether the volume exists"
+if ./build/bin/cfs-cli volume list | grep -q "ltptest"; then
+  echo "volume 'ltptest' exists, skipping creation"
+else
+  echo "begin create volume 'ltptest'"
+  ./build/bin/cfs-cli volume create ltptest ltp -y
+fi
+
+echo "begin start client"
+./build/bin/cfs-client -c ${confFile}
+echo "start client success"
+

--- a/shell/deploy_object.sh
+++ b/shell/deploy_object.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "usage: start object: $0 <baseDir>"
+    exit 1
+fi
+
+confFile=${1}/conf/object.conf
+logDir=${1}/object/logs
+
+if [ ! -f "${confFile}" ]; then
+  echo "Error: ${confFile} not exist. Ensure 'sh ./shell/deploy.sh <baseDir> <bond0>' is run before 'sh ./shell/deploy_object.sh <baseDir>', with the same <baseDir> in both commands."
+  exit 1
+fi
+
+echo "mkdir -p $logDir"
+mkdir -p $logDir
+
+echo "start checking whether the volume exists"
+if ./build/bin/cfs-cli volume list | grep -q "objtest"; then
+  echo "volume 'objtest' exists, skipping creation"
+else
+  echo "begin create volume 'objtest'"
+  ./build/bin/cfs-cli volume create objtest obj -y
+fi
+
+echo "begin start objectnode service"
+./build/bin/cfs-server -c ${confFile}
+echo "start objectnode service success"
+

--- a/shell/genConf.sh
+++ b/shell/genConf.sh
@@ -87,18 +87,31 @@ genMeta 3 $ip3
 genMeta 4 $ip4
 
 masterHost="${ip1}:17010,${ip2}:17010,${ip3}:17010"
-mntDir=$baseDir/client/mnt
-if [ ! -d "$mntDir" ]; then
-    echo "mkdir -p $mntDir"
-    mkdir -p $mntDir
-fi
 
+genClient()
+{
+  confFile="${confDir}/client.conf"
+  echo "start gen client.conf"
+  if [ ! -f "$confFile" ]; then
+    sed "s|_master_host_|${masterHost}|g" ${tplDir}/client.tpl | sed "s|_dir_|${baseDir}|g" > "$confFile"
+    echo "gen client.conf success"
+  else
+    echo "client.conf already exists, skipping generation"
+  fi
+}
 
-confFile="${confDir}/client.conf"
-echo "start gen client.conf"
-if [ ! -f "$confFile" ]; then
-  sed "s/_master_host_/${masterHost}/g" ${tplDir}/client.tpl | sed "s|_dir_|${baseDir}|g" > "$confFile"
-  echo "gen client.conf success"
-else
-  echo "client.conf already exists, skipping generation"
-fi
+genClient
+
+genObject()
+{
+  confFile="${confDir}/object.conf"
+  echo "start gen object.conf"
+  if [ ! -f "$confFile" ]; then
+    sed "s|_master_addr_|${masterAddr}|g" ${tplDir}/object.tpl | sed "s|_dir_|${baseDir}|g" > "$confFile"
+    echo "gen object.conf success"
+  else
+    echo "object.conf already exists, skipping generation"
+  fi
+}
+
+genObject

--- a/shell/tpl/data.tpl
+++ b/shell/tpl/data.tpl
@@ -15,5 +15,5 @@
   "enableSmuxConnPool": "true",
   "masterAddr": [
       _master_addr_
-]
+  ]
 }

--- a/shell/tpl/meta.tpl
+++ b/shell/tpl/meta.tpl
@@ -13,5 +13,5 @@
   "raftDir": "_dir_/raft",
   "masterAddr": [
  	_master_addr_
-]
+  ]
 }

--- a/shell/tpl/object.tpl
+++ b/shell/tpl/object.tpl
@@ -1,0 +1,9 @@
+{
+  "role": "objectnode",
+  "listen": "17410",
+  "logDir": "_dir_/object/logs",
+  "logLevel": "debug",
+  "masterAddr": [
+    _master_addr_
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix typo: `depoly.sh` -> `deploy.sh`

support deploy client and object in Standalone Mode
```bash
cd ./cubefs
# Compile
make
# Generate configuration files and start the basic cluster
sh ./shell/deploy.sh /home/data bond0

# Wait a minute for cluster to prepare state, and optionally execute the following command

# Mount the file system (optional, execute this command if you want to experience file storage. By default, it is mounted at /home/data/client/mnt)
sh ./shell/deploy_client.sh /home/data

# Start object storage (optional, execute this command if you want to experience object storage. The default listening port is 17410)
sh ./shell/deploy_object.sh /home/data
```