### PR TITLE
feat(master): minor code and comment refactoring

### DIFF
--- a/authtool/authtool.go
+++ b/authtool/authtool.go
@@ -203,8 +203,6 @@ func getTicket() {
 
 	ticketfile := getTicketFromAuth(&keyring)
 	ticketfile.dumpJSONFile(flaginfo.ticket.output)
-
-	return
 }
 
 func accessAuthServer() {
@@ -403,8 +401,6 @@ func accessAuthServer() {
 	default:
 		// do nothing
 	}
-
-	return
 }
 
 func accessAPI() {

--- a/depends/tiglabs/raft/proto/proto.go
+++ b/depends/tiglabs/raft/proto/proto.go
@@ -164,7 +164,7 @@ func (t MsgType) String() string {
 	case 15:
 		return "RespCheckQuorum"
 	}
-	return "unkown"
+	return "unknown"
 }
 
 func (t EntryType) String() string {
@@ -174,7 +174,7 @@ func (t EntryType) String() string {
 	case 1:
 		return "EntryConfChange"
 	}
-	return "unkown"
+	return "unknown"
 }
 
 func (t ConfChangeType) String() string {
@@ -186,7 +186,7 @@ func (t ConfChangeType) String() string {
 	case 2:
 		return "ConfUpdateNode"
 	}
-	return "unkown"
+	return "unknown"
 }
 
 func (t PeerType) String() string {
@@ -196,7 +196,7 @@ func (t PeerType) String() string {
 	case 1:
 		return "PeerArbiter"
 	}
-	return "unkown"
+	return "unknown"
 }
 
 func (p Peer) String() string {

--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -330,7 +330,7 @@ func (s *raft) run() {
 					s.raftFsm.Step(m)
 				}
 				var respErr = true
-				if m.Type == proto.RespMsgAppend && m.Reject != true {
+				if m.Type == proto.RespMsgAppend && !m.Reject {
 					respErr = false
 				}
 				s.maybeChange(respErr)
@@ -573,7 +573,7 @@ func (s *raft) maybeChange(respErr bool) {
 		updated = true
 		s.prevSoftSt.leader = s.raftFsm.leader
 		if s.raftFsm.leader != s.config.NodeID {
-			if respErr == true || preLeader != s.config.NodeID {
+			if respErr || preLeader != s.config.NodeID {
 				s.resetPending(ErrNotLeader)
 			}
 			s.stopSnapping()

--- a/depends/tiglabs/raft/util/io.go
+++ b/depends/tiglabs/raft/util/io.go
@@ -111,7 +111,7 @@ func (br *BufferReader) Grow(n int) {
 		}
 	}()
 
-	var buf []byte = nil
+	var buf []byte
 	if n > br.size {
 		buf = make([]byte, n)
 	} else {

--- a/deploy/cmd/cluster.go
+++ b/deploy/cmd/cluster.go
@@ -155,7 +155,7 @@ func removeDuplicates(slice []string) []string {
 	result := []string{}
 
 	for _, item := range slice {
-		if encountered[item] == true {
+		if encountered[item] {
 			continue
 		}
 		encountered[item] = true

--- a/fdstore/fdstore.go
+++ b/fdstore/fdstore.go
@@ -277,7 +277,6 @@ func doDump(filePathes string) {
 
 		rsize, err = nodeListFile.Read(data)
 		if rsize == 0 || err == io.EOF {
-			err = nil
 			break
 		}
 
@@ -300,7 +299,7 @@ func doDump(filePathes string) {
 
 	handleListFile, err := os.OpenFile(pathes[1], os.O_RDONLY, 0o644)
 	if err != nil {
-		err = fmt.Errorf("failed to open handles list file: %v\n", err)
+		fmt.Fprintf(os.Stderr, "failed to open handles list file: %v\n", err)
 		return
 	}
 	defer handleListFile.Close()

--- a/fsck/cmd/getInfo.go
+++ b/fsck/cmd/getInfo.go
@@ -523,7 +523,7 @@ func decodeDentry(raw []byte, d *Dentry) (err error) {
 	if err = binary.Read(keyBuff, binary.BigEndian, &d.ParentId); err != nil {
 		return
 	}
-	d.Name = string(keyBuff.Bytes())
+	d.Name = keyBuff.String()
 	if err = binary.Read(buff, binary.BigEndian, &valLen); err != nil {
 		return
 	}

--- a/raftstore/partition.go
+++ b/raftstore/partition.go
@@ -37,7 +37,7 @@ type Partition interface {
 	// Submit submits command data to raft log.
 	Submit(cmd []byte) (resp interface{}, err error)
 
-	// ChaneMember submits member change event and information to raft log.
+	// ChangeMember submits member change event and information to raft log.
 	ChangeMember(changeType proto.ConfChangeType, peer proto.Peer, context []byte) (resp interface{}, err error)
 
 	// Stop removes the raft partition from raft server and shuts down this partition.
@@ -49,7 +49,7 @@ type Partition interface {
 	// Status returns the current raft status.
 	Status() (status *PartitionStatus)
 
-	// Much faster then status().RestoringSnapshot.
+	// IsRestoring Much faster then status().RestoringSnapshot.
 	IsRestoring() bool
 
 	// LeaderTerm returns the current term of leader in the raft group. TODO what is term?
@@ -78,7 +78,7 @@ type partition struct {
 	config  *PartitionConfig
 }
 
-// ChaneMember submits member change event and information to raft log.
+// ChangeMember submits member change event and information to raft log.
 func (p *partition) ChangeMember(changeType proto.ConfChangeType, peer proto.Peer, context []byte) (
 	resp interface{}, err error) {
 	if !p.IsRaftLeader() {
@@ -136,7 +136,7 @@ func (p *partition) IsOfflinePeer() bool {
 	active := 0
 	sumPeers := 0
 	for _, peer := range status.Replicas {
-		if peer.Active == true {
+		if peer.Active {
 			active++
 		}
 		sumPeers++

--- a/sdk/data/manager/limiter.go
+++ b/sdk/data/manager/limiter.go
@@ -124,10 +124,10 @@ func (factor *LimitFactor) alloc(allocCnt uint32) (ret uint8, future *util.Futur
 			magnify: factor.magnify,
 		})
 
-		if grid.hitLimit == false {
+		if !grid.hitLimit {
 			factor.gidHitLimitCnt++
 			// 1s have several gird, gidHitLimitCnt is the count that gird count hit limit in latest 1s,
-			// if gidHitLimitCnt large than limit then request for enlarge factor limit
+			// if gidHitLimitCnt larger than limit then request for enlarge factor limit
 			// GetSimpleVolView will call back simpleClient function to get factor info and send to master
 			if factor.gidHitLimitCnt >= factor.mgr.HitTriggerCnt {
 				tmpTime := time.Now()
@@ -261,7 +261,7 @@ func (factor *LimitFactor) CheckGrid() {
 	}
 	factor.gridId++
 
-	if factor.mgr.enable == true && factor.mgr.lastTimeOfSetLimit.Add(time.Second*qosExpireTime).Before(newGrid.time) {
+	if factor.mgr.enable && factor.mgr.lastTimeOfSetLimit.Add(time.Second*qosExpireTime).Before(newGrid.time) {
 		log.LogWarnf("action[CheckGrid]. qos recv no command from master in long time, last time %v, grid time %v",
 			factor.mgr.lastTimeOfSetLimit, newGrid.time)
 	}
@@ -565,7 +565,6 @@ func (limitManager *LimitManager) WaitN(ctx context.Context, lim *LimitFactor, n
 
 func (limitManager *LimitManager) UpdateFlowInfo(limit *proto.LimitRsp2Client) {
 	limitManager.SetClientLimit(limit)
-	return
 }
 
 func (limitManager *LimitManager) SetClientID(id uint64) (err error) {

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -190,7 +190,7 @@ func (w *Wrapper) UpdateUidsView(view *proto.SimpleVolView) {
 	defer w.UidLock.Unlock()
 	w.Uids = make(map[uint32]*proto.UidSimpleInfo)
 	for _, uid := range view.Uids {
-		if uid.Limited == false {
+		if !uid.Limited {
 			continue
 		}
 		w.Uids[uid.UID] = &uid

--- a/util/smux_conn_pool.go
+++ b/util/smux_conn_pool.go
@@ -40,8 +40,7 @@ const (
 
 var ErrTooMuchSmuxStreams = errors.New("too much smux streams")
 
-// addr = ip:port
-// afterShift = ip:(port+shift)
+// ShiftAddrPort changes the addr(ip:port) to afterShift(ip:(port+shift)).
 func ShiftAddrPort(addr string, shift int) (afterShift string) {
 	pars := strings.Split(addr, ":")
 	if len(pars) != 2 {
@@ -56,7 +55,7 @@ func ShiftAddrPort(addr string, shift int) (afterShift string) {
 	return
 }
 
-// filter smux accept error
+// FilterSmuxAcceptError filter smux accept error
 func FilterSmuxAcceptError(err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- remove redundant 'return' state
- simplify conditional expressions
- remove ineffectual assignment
  - 'fdstore.go, line 280' It will not be referenced again in the 'for' loop it belongs to, and will then be overwritten with a new value in the 'os.OpenFile()' function.
  - 'fdstore.go, line 303' Handling of the 'fmt.Errorf()' function ends without processing
  - 'io.gok line 114' slice is initialized automatically, and since it is not a pointer, it does not use nil.
  - 'flag.go, line 740' This could directly return the return value of 'fmt.Errorf()' (actually it doesn't seem necessary, but I can't figure out the intent, so it preserves the meaning of the code)
  - 'serve.go, line 1840' It is continuously initialized within the for loop and will not be referenced beyond the line in use.
- fix replaceable functions
- fix return that doesn't reach
- fix typo
- edit comments

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #3097

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
