### PR TITLE
fix(blobnode): fix checkpoint file permission for inspectmgr of blobnode

### DIFF
--- a/blobstore/blobnode/datainspect.go
+++ b/blobstore/blobnode/datainspect.go
@@ -29,6 +29,9 @@ const (
 	slowDownRatio  = 2
 	speedUpCnt     = 2000
 	minRateLimit   = 64 * 1024 // 64 KB/s
+
+	defaultFilePerm os.FileMode = 0o644
+	defaultPathPerm os.FileMode = 0o744
 )
 
 var dataInspectMetric = prometheus.NewGaugeVec(
@@ -72,7 +75,7 @@ func NewDataInspectMgr(svr *Service, conf DataInspectConf, switchMgr *taskswitch
 	}
 	_, err = os.Stat(conf.CheckPoint)
 	if !os.IsExist(err) {
-		_ = os.MkdirAll(conf.CheckPoint, 0o644)
+		_ = os.MkdirAll(conf.CheckPoint, defaultPathPerm)
 	}
 	mgr := &DataInspectMgr{
 		conf:       conf,
@@ -379,7 +382,7 @@ func (mgr *DataInspectMgr) loadCheckpoint(path string, diskId proto.DiskID) (inf
 		}
 		return
 	}
-	file, err := os.OpenFile(path, os.O_RDONLY, 0o644)
+	file, err := os.OpenFile(path, os.O_RDONLY, defaultFilePerm)
 	if err != nil {
 		return
 	}
@@ -389,12 +392,12 @@ func (mgr *DataInspectMgr) loadCheckpoint(path string, diskId proto.DiskID) (inf
 }
 
 func (mgr *DataInspectMgr) saveCheckpoint(path string, info *CheckpointInfo) error {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0o644)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, defaultFilePerm)
 	if err != nil {
 		return err
 	}
 	err = json.NewEncoder(file).Encode(info)
-	_ = os.Chmod(path, 0o644)
+	_ = os.Chmod(path, defaultFilePerm)
 	_ = file.Close()
 
 	return err

--- a/blobstore/blobnode/datainspect_test.go
+++ b/blobstore/blobnode/datainspect_test.go
@@ -37,7 +37,7 @@ func TestDataInspect(t *testing.T) {
 	mgr, err := NewDataInspectMgr(svr, cfg, switchMgr)
 	svr.inspectMgr = mgr
 	require.NoError(t, err)
-	defer os.Remove(cfg.CheckPoint)
+	defer os.RemoveAll("/tmp/blobnode")
 	require.Equal(t, cfg.IntervalSec, mgr.conf.IntervalSec)
 
 	{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the blobnode inspection process creates a multi-level file directory, the directory requires execution permissions
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
