### PR TITLE
fix(lcnode): [hybrid cloud] DeleteMigrationExtentKey before migration

### DIFF
--- a/lcnode/lc_scanner.go
+++ b/lcnode/lc_scanner.go
@@ -378,6 +378,12 @@ func (s *LcScanner) handleFile(dentry *proto.ScanDentry) {
 
 	case proto.OpTypeStorageClassHDD:
 		s.limiter.Wait(context.Background())
+		if dentry.HasMek {
+			if err := s.mw.DeleteMigrationExtentKey(dentry.Inode, dentry.Path); err != nil {
+				log.LogErrorf("DeleteMigrationExtentKey err: %v, dentry: %+v", err, dentry)
+			}
+			return
+		}
 		err := s.transitionMgr.migrate(dentry)
 		if err != nil {
 			atomic.AddInt64(&s.currentStat.ErrorSkippedNum, 1)
@@ -395,6 +401,12 @@ func (s *LcScanner) handleFile(dentry *proto.ScanDentry) {
 
 	case proto.OpTypeStorageClassEBS:
 		s.limiter.Wait(context.Background())
+		if dentry.HasMek {
+			if err := s.mw.DeleteMigrationExtentKey(dentry.Inode, dentry.Path); err != nil {
+				log.LogErrorf("DeleteMigrationExtentKey err: %v, dentry: %+v", err, dentry)
+			}
+			return
+		}
 		oeks, err := s.transitionMgr.migrateToEbs(dentry)
 		if err != nil {
 			atomic.AddInt64(&s.currentStat.ErrorSkippedNum, 1)
@@ -431,6 +443,7 @@ func (s *LcScanner) batchHandleFile() {
 				d.Size = info.Size
 				d.StorageClass = info.StorageClass
 				d.WriteGen = info.WriteGen
+				d.HasMek = info.HasMigrationEk
 				s.fileChan.In <- d
 			}
 		}

--- a/lcnode/meta.go
+++ b/lcnode/meta.go
@@ -24,6 +24,7 @@ type MetaWrapper interface {
 	DeleteWithCond_ll(parentID, cond uint64, name string, isDir bool, fullPath string) (inode *proto.InodeInfo, err error)
 	Evict(inode uint64, fullPath string) error
 	UpdateExtentKeyAfterMigration(inode uint64, storageType uint32, extentKeys []proto.ObjExtentKey, writeGen uint64, fullPath string) error
+	DeleteMigrationExtentKey(inode uint64, fullPath string) error
 	ReadDirLimit_ll(parentID uint64, from string, limit uint64) ([]proto.Dentry, error)
 	Close() error
 }

--- a/lcnode/meta_test.go
+++ b/lcnode/meta_test.go
@@ -75,6 +75,10 @@ func (*MockMetaWrapper) UpdateExtentKeyAfterMigration(inode uint64, storageType 
 	return nil
 }
 
+func (*MockMetaWrapper) DeleteMigrationExtentKey(inode uint64, fullPath string) error {
+	return nil
+}
+
 func (*MockMetaWrapper) ReadDirLimit_ll(parentID uint64, from string, limit uint64) ([]proto.Dentry, error) {
 	// for handleDirLimitDepthFirst
 	if parentID == 4 {

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -1065,7 +1065,7 @@ func (mp *metaPartition) fsmUpdateExtentKeyAfterMigration(inoParam *Inode) (resp
 
 func logCurrentExtentKeys(storageClass uint32, sortedEks interface{}, inode uint64) {
 	if sortedEks == nil {
-		log.LogInfof("action[fsmUpdateExtentKeyAfterMigration] inode %v current ek empty", inode)
+		log.LogErrorf("action[fsmUpdateExtentKeyAfterMigration] inode %v current ek empty", inode)
 	} else {
 		if proto.IsStorageClassReplica(storageClass) {
 			log.LogInfof("action[fsmUpdateExtentKeyAfterMigration] inode %v current ek %v",

--- a/proto/lifecycle.go
+++ b/proto/lifecycle.go
@@ -330,6 +330,7 @@ type ScanDentry struct {
 	Size         uint64 `json:"size"`  // for migrate: size of the current dentry
 	StorageClass uint32 `json:"sc"`    // for migrate: storage class of the current dentry
 	WriteGen     uint64 `json:"gen"`   // for migrate: used to determine whether a file is modified
+	HasMek       bool   `json:"mek"`   // for migrate: if HasMek, call DeleteMigrationExtentKey instead of migrating
 }
 
 type BatchDentries struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DeleteMigrationExtentKey before migration 