### PR TITLE
fix(master): try sleep a second before close rocksdb to segmentation error.

### DIFF
--- a/master/lifecycle_manager.go
+++ b/master/lifecycle_manager.go
@@ -240,7 +240,7 @@ func (ns *lcNodeStatus) UpdateNode(nodeAddr string, count int) {
 	return
 }
 
-//-----------------------------------------------
+// -----------------------------------------------
 type lcRuleTaskStatus struct {
 	sync.RWMutex
 	ToBeScanned map[string]*proto.RuleTask

--- a/master/server.go
+++ b/master/server.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/raftstore"
@@ -196,9 +197,11 @@ func (m *Server) Shutdown() {
 	}
 
 	// then stop rocksDBStore
+	time.Sleep(time.Second)
 	if m.rocksDBStore != nil {
 		m.rocksDBStore.Close()
 	}
+
 	m.wg.Done()
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
try avoid segmentation when close service.

`[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x139877f]

runtime stack:
runtime.throw({0x18df1b9, 0x7f23ff7fe580})
        /usr/local/go/src/runtime/panic.go:1198 +0x71
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:719 +0x389

goroutine 220 [syscall]:
runtime.cgocall(0x130b969, 0xc00b12db58)
        /usr/local/go/src/runtime/cgocall.go:156 +0x5c fp=0xc00b12db30 sp=0xc00b12daf8 pc=0x4f4f1c
github.com/tecbot/gorocksdb._Cfunc_rocksdb_write(0x7f246001ced0, 0x7f23f03a5b80, 0x7f23f04f3f30, 0xc00b80f488)
        /tmp/go-build1895915678/b329/_cgo_gotypes.go:4798 +0x45 fp=0xc00b12db58 sp=0xc00b12db30 pc=0x1157665
github.com/tecbot/gorocksdb.(*DB).Write.func1(0x7f23f04f3f30, 0xc00cc1c5a0, 0xc00cc1c5b8, 0xc00b12dc18)
        vendor/github.com/tecbot/gorocksdb/db.go:488 +0xd2 fp=0xc00b12dba8 sp=0xc00b12db58 pc=0x115ecb2
github.com/tecbot/gorocksdb.(*DB).Write(0xc00b12dcd0, 0xc00cc1c5b8, 0x7)
        vendor/github.com/tecbot/gorocksdb/db.go:488 +0x66 fp=0xc00b12dc28 sp=0xc00b12dba8 pc=0x115ea06
github.com/cubefs/cubefs/raftstore/raftstore_db.(*RocksDBStore).BatchPut(0xc0001951a0, 0xc00cc46300, 0xba)
        raftstore/raftstore_db/store_rocksdb.go:225 +0x1c5 fp=0xc00b12dd48 sp=0xc00b12dc28 pc=0x11756c5
github.com/cubefs/cubefs/master.(*MetadataFsm).Apply(0xc000225310, {0xc00f90d6d1, 0xb9, 0xbd}, 0x3cd04d)
        master/metadata_fsm.go:155 +0x585 fp=0xc00b12de98 sp=0xc00b12dd48 pc=0x12ac965
github.com/cubefs/cubefs/depends/tiglabs/raft.(*raft).runApply(0xc000222700)
        depends/tiglabs/raft/raft.go:236 +0x1e4 fp=0xc00b12df88 sp=0xc00b12de98 pc=0xc8f244
github.com/cubefs/cubefs/depends/tiglabs/raft.(*raft).runApply-fm()
        depends/tiglabs/raft/raft.go:198 +0x26 fp=0xc00b12dfa0 sp=0xc00b12df88 pc=0xcad2a6
github.com/cubefs/cubefs/depends/tiglabs/raft/util.RunWorker.func1()
        depends/tiglabs/raft/util/runtime.go:51 +0x74 fp=0xc00b12dfe0 sp=0xc00b12dfa0 pc=0x83f534
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc00b12dfe8 sp=0xc00b12dfe0 pc=0x55cc41
created by github.com/cubefs/cubefs/depends/tiglabs/raft/util.RunWorker`
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
