### PR TITLE
fix(metanode):Correct the type conversion error for logCurrentExtentKeys

### DIFF
--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -1069,10 +1069,10 @@ func logCurrentExtentKeys(storageClass uint32, sortedEks interface{}, inode uint
 	} else {
 		if proto.IsStorageClassReplica(storageClass) {
 			log.LogInfof("action[fsmUpdateExtentKeyAfterMigration] inode %v current ek %v",
-				inode, sortedEks.(*SortedObjExtents).eks)
+				inode, sortedEks.(*SortedExtents).eks)
 		} else if proto.IsStorageClassBlobStore(storageClass) {
 			log.LogInfof("action[fsmUpdateExtentKeyAfterMigration] inode %v current ek %v",
-				inode, sortedEks.(*SortedExtents).eks)
+				inode, sortedEks.(*SortedObjExtents).eks)
 		}
 	}
 }


### PR DESCRIPTION
function
**What this PR does / why we need it**:
Correct the type conversion error for logCurrentExtentKeys function
