### PR TITLE
fix(docker): fix docker-compose yml #3100

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,8 +12,7 @@ x-define-env: &env
         - HTTPS_PROXY=
 
 x-define-servernode: &servernode
-    <<: *image
-    <<: *env
+    <<: [*image, *env]
     command: /bin/sh /cfs/script/start.sh
     restart: on-failure
     privileged: true
@@ -53,8 +52,7 @@ x-define-lcnode: &lcnode
         - 9500
 
 x-define-command: &command
-    <<: *image
-    <<: *env
+    <<: [*image, *env]
     volumes:
         - ../:${CFSROOT}
 
@@ -301,8 +299,7 @@ services:
             ipv4_address: 192.168.0.50
 
     client:
-        <<: *image
-        <<: *env
+        <<: [*image, *env]
         ports:
             - 9500
             - 17410:17410


### PR DESCRIPTION
double '<<' isn't allowed to new version of docker-compose, change to the new form.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->

fix #3100 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
