### PR TITLE
fix(sdk): when the stream's residual server coroutine exits, others s…

### DIFF
--- a/sdk/data/stream/stream_writer.go
+++ b/sdk/data/stream/stream_writer.go
@@ -194,9 +194,15 @@ func (s *Streamer) server() {
 			if s.refcnt <= 0 {
 				if s.idle >= streamWriterIdleTimeoutPeriod && len(s.request) == 0 {
 					if s.client.disableMetaCache || !s.needBCache {
-						delete(s.client.streamers, s.inode)
-						if s.client.evictIcache != nil {
-							s.client.evictIcache(s.inode)
+						// get current stream in map
+						current_s, _ := s.client.streamers[s.inode]
+						// one stream maybe has multi server coroutine
+						// when the stream's residual server coroutine exits, others stream maybe deleted
+						if &current_s == &s {
+							delete(s.client.streamers, s.inode)
+							if s.client.evictIcache != nil {
+								s.client.evictIcache(s.inode)
+							}
 						}
 					}
 


### PR DESCRIPTION
…tream maybe deleted.#2827

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #2827

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
