### PR TITLE
fix(libsdk): cfs_close dir print error "stream is not opened yet".

### DIFF
--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -744,8 +744,20 @@ func cfs_close(id C.int64_t, fd C.int) {
 	if !exist {
 		return
 	}
-	f := c.releaseFD(uint(fd))
-	if f != nil {
+
+	f := c.getFile(uint(fd))
+	if f == nil {
+		return
+	}
+
+	info := c.ic.Get(f.ino)
+	if info == nil {
+		info, _ = c.mw.InodeGet_ll(f.ino)
+	}
+
+	f = c.releaseFD(uint(fd))
+	// Consistent with cfs open, do close and closeStream only if f is regular file
+	if f != nil && info != nil &&  proto.IsRegular(info.Mode){
 		c.flush(f)
 		c.closeStream(f)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
cfs_close dir print error "stream is not opened yet"
**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
