### PR TITLE
fix(util): recycle audit logs when rolling

### DIFF
--- a/util/auditlog/auditlog.go
+++ b/util/auditlog/auditlog.go
@@ -582,14 +582,16 @@ func (a *Audit) shiftFiles() error {
 		a.logFile.Close()
 		a.writer = nil
 		a.logFile = nil
-
-		if os.Rename(a.logFileName, logNewFileName) != nil {
+		if err = os.Rename(a.logFileName, logNewFileName); err != nil {
 			log.LogErrorf("RenameFile failed, logFileName: %s, logNewFileName: %s, err: %v\n",
 				a.logFileName, logNewFileName, err)
 			return fmt.Errorf("action[shiftFiles] renameFile failed, logFileName %s, logNewFileName %s",
 				a.logFileName, logNewFileName)
 		}
 	}
+
+	// NOTE: try to recycle space when shift file
+	a.removeLogFile()
 
 	return a.newWriterSize(a.writerBufSize)
 }

--- a/util/auditlog/auditlog_test.go
+++ b/util/auditlog/auditlog_test.go
@@ -17,6 +17,8 @@ package auditlog_test
 import (
 	"os"
 	"path"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,13 +30,25 @@ const testLogModule = "test"
 
 const testLogMax = 1024
 
-const testLogCount = 1024
+const testLogCount = 1024000
 
 const testBufSize = 0
 
 const testResetBufSize = 1024
 
 const testPrefix = "test"
+
+const testSleepTime = 5 * time.Second
+
+func getFileSize(t *testing.T, file string) (size uint64) {
+	tmp, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	require.NoError(t, err)
+	size = uint64(tmp.Size())
+	return
+}
 
 func AuditLogTest(audit *auditlog.Audit, baseDir string, t *testing.T) {
 	audit.ResetWriterBufferSize(testBufSize)
@@ -43,19 +57,41 @@ func AuditLogTest(audit *auditlog.Audit, baseDir string, t *testing.T) {
 	require.Equal(t, path.Join(baseDir, testLogModule), dir)
 	require.Equal(t, testLogModule, module)
 	require.EqualValues(t, testLogMax, max)
+	auditLogName := path.Join(dir, "audit.log")
+	maxSize := uint64(0)
 	for i := 0; i < testLogCount; i++ {
 		audit.LogClientOp("nil", "nil", "nil", nil, 0, 0, 0)
+		curr := getFileSize(t, auditLogName)
+		if curr > maxSize {
+			maxSize = curr
+		}
 	}
 	// NOTE: wait for flush
-	time.Sleep(2 * time.Second)
+	token := int32(1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for atomic.LoadInt32(&token) == 1 {
+			curr := getFileSize(t, auditLogName)
+			if curr > maxSize {
+				maxSize = curr
+			}
+		}
+	}()
+	time.Sleep(testSleepTime)
+	atomic.StoreInt32(&token, 0)
+	wg.Wait()
 	dentries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	for _, dentry := range dentries {
-		t.Logf("log file %v\n", dentry.Name())
+		t.Logf("log file %v, size %v\n", dentry.Name(), getFileSize(t, dentry.Name()))
 	}
 	// NOTE: we have prefix, so shiftfile()
 	// must be invoked once
-	require.NotEqualValues(t, 1, len(dentries))
+	nowSize := getFileSize(t, auditLogName)
+	require.Less(t, nowSize, maxSize)
+	t.Logf("log file count %v", len(dentries))
 	audit.ResetWriterBufferSize(testResetBufSize)
 }
 
@@ -80,16 +116,38 @@ func TestGlobalAuditLog(t *testing.T) {
 	require.Equal(t, path.Join(tmpDir, testLogModule), dir)
 	require.Equal(t, testLogModule, module)
 	require.EqualValues(t, testLogMax, max)
+	auditLogName := path.Join(dir, "audit.log")
+	maxSize := uint64(0)
 	for i := 0; i < testLogCount; i++ {
 		auditlog.LogClientOp("nil", "nil", "nil", nil, 0, 0, 0)
+		size := getFileSize(t, auditLogName)
+		if size > maxSize {
+			maxSize = size
+		}
 	}
 	// NOTE: wait for flush
-	time.Sleep(2 * time.Second)
+	token := int32(1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for atomic.LoadInt32(&token) == 1 {
+			curr := getFileSize(t, auditLogName)
+			if curr > maxSize {
+				maxSize = curr
+			}
+		}
+	}()
+	time.Sleep(testSleepTime)
+	atomic.StoreInt32(&token, 0)
+	wg.Wait()
 	dentries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	for _, dentry := range dentries {
-		t.Logf("log file %v\n", dentry.Name())
+		t.Logf("log file %v, size %v\n", dentry.Name(), getFileSize(t, auditLogName))
 	}
-	require.NotEqualValues(t, 1, len(dentries))
+	nowSize := getFileSize(t, auditLogName)
+	require.Less(t, nowSize, maxSize)
+	t.Logf("log file count %v", len(dentries))
 	auditlog.ResetWriterBufferSize(testResetBufSize)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
<!-- *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: -->
fixes #3178

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
