### PR TITLE
fix(client,metanode): remove duplicated logs for deleteMarkedInodes

### DIFF
--- a/client/fs/dir.go
+++ b/client/fs/dir.go
@@ -369,6 +369,7 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 			dummyChild := NewFile(d.super, dummyInodeInfo, DefaultFlag, d.info.Inode, req.Name)
 			return dummyChild, nil
 		}
+		break
 	}
 	mode := proto.OsMode(info.Mode)
 	d.super.fslock.Lock()

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -335,6 +335,7 @@ func (mp *metaPartition) deleteMarkedInodes(inoSlice []uint64) {
 			leftInodes = append(leftInodes, ino)
 		}
 	}
+	allInodes = make([]*Inode, 0)
 	allInodes = append(allInodes, leftInodes...)
 	if len(replicaInodes) > 0 {
 		shouldCommitReplicaInode, shouldRePushToFreeListReplicaInode :=


### PR DESCRIPTION
**What this PR does / why we need it**:
remove duplicated logs for deleteMarkedInodes