### PR TITLE
bugfix(client): if file is stored in ebs, donot fetch extentkey list …

### DIFF
--- a/client/fs/inode.go
+++ b/client/fs/inode.go
@@ -54,6 +54,9 @@ func (s *Super) InodeGet(ino uint64) (*proto.InodeInfo, error) {
 			node.(*File).info = info
 		}
 	}
+	if proto.IsStorageClassBlobStore(info.StorageClass) {
+		return info, nil
+	}
 	err = s.ec.RefreshExtentsCache(ino)
 	return info, err
 }

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -622,6 +622,8 @@ func (p *Packet) GetOpMsg() (m string) {
 		m = "OpMetaReadDirOnly"
 	case OpMetaUpdateExtentKeyAfterMigration:
 		m = "OpMetaUpdateExtentKeyAfterMigration"
+	case OpMetaRenewalForbiddenMigration:
+		m = "OpMetaRenewalForbiddenMigration"
 	default:
 		m = fmt.Sprintf("op:%v not found", p.Opcode)
 	}


### PR DESCRIPTION
…from metanode in lookup operation

**What this PR does / why we need it**:
if file is stored in ebs, donot fetch extentkey list from metanode in lookup operation
