### PR TITLE
fix(meta): create dentry concurrency cause orphan inodes

### DIFF
--- a/sdk/meta/api.go
+++ b/sdk/meta/api.go
@@ -333,10 +333,8 @@ create_dentry:
 		}
 		return nil, statusToErrno(status)
 	} else if status != statusOK {
-		if status != statusExist {
-			mw.iunlink(mp, info.Inode, mw.Client.GetLatestVer(), 0, fullPath)
-			mw.ievict(mp, info.Inode, fullPath)
-		}
+		mw.iunlink(mp, info.Inode, mw.Client.GetLatestVer(), 0, fullPath)
+		mw.ievict(mp, info.Inode, fullPath)
 		return nil, statusToErrno(status)
 	}
 	if mw.EnableSummary {
@@ -1927,9 +1925,7 @@ func (mw *MetaWrapper) link(parentID uint64, name string, ino uint64, fullPath s
 	if err != nil {
 		return nil, statusToErrno(status)
 	} else if status != statusOK {
-		if status != statusExist {
-			mw.iunlink(mp, ino, mw.Client.GetLatestVer(), 0, fullPath)
-		}
+		mw.iunlink(mp, ino, mw.Client.GetLatestVer(), 0, fullPath)
 		return nil, statusToErrno(status)
 	}
 	return info, nil


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

### Motivation

when concurrency create dentries with same parent and name will cause orphan inodes.

### Modifications

when create dentry with same parent and name: 
- if inodes are same, it will return status OpOk to client, we can treat it as successful  (fixed here: https://github.com/cubefs/cubefs/commit/f55846af3c2522b4773e5e2dd2c2871b88f80267)
- if inodes are not same, it will return proto.OpExistErr

so when we get OpExistErr, it means dentry must create failed, so we should unlink this inode to avoid orphan inode

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the testing checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [x] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection

- [ ] `in-two-days`
- [x] `weeks`
- [ ] `free-time`
- [ ] `whenever`

<!-- Thanks for contributing, best days! -->
