### PR TITLE
fix(blobnode): when drop a disk, it is necessary to verify that the chunk files under the disk/data path are emptied.

### DIFF
--- a/blobstore/access/stream_mock_test.go
+++ b/blobstore/access/stream_mock_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"strconv"
@@ -238,7 +237,7 @@ var storageAPIRangeGetShard = func(ctx context.Context, host string, args *blobn
 
 	buff = buff[int(args.Offset):int(args.Offset+args.Size)]
 	shardCrc = crc32.ChecksumIEEE(buff)
-	body = ioutil.NopCloser(bytes.NewReader(buff))
+	body = io.NopCloser(bytes.NewReader(buff))
 	return
 }
 

--- a/blobstore/api/access/client_test.go
+++ b/blobstore/api/access/client_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -928,7 +927,7 @@ func TestAccessClientRPCConfig(t *testing.T) {
 }
 
 func TestAccessClientLogger(t *testing.T) {
-	file, err := ioutil.TempFile(os.TempDir(), "TestAccessClientLogger")
+	file, err := os.CreateTemp(os.TempDir(), "TestAccessClientLogger")
 	require.NoError(t, err)
 	require.NoError(t, file.Close())
 	defer func() {

--- a/blobstore/api/blobnode/client_test.go
+++ b/blobstore/api/blobnode/client_test.go
@@ -17,7 +17,7 @@ package blobnode
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -108,7 +108,7 @@ func TestNewBlobNodeClient(t *testing.T) {
 	body, _, err := cli.RangeGetShard(ctx, mockServer.URL, getShardArgs)
 	require.NoError(t, err)
 	if body != nil {
-		b, _ := ioutil.ReadAll(body)
+		b, _ := io.ReadAll(body)
 		span.Infof("body: %s\n", b)
 	}
 

--- a/blobstore/blobnode/base/qos/limitio_test.go
+++ b/blobstore/blobnode/base/qos/limitio_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -134,7 +133,7 @@ func TestRateLimiter_Error(t *testing.T) {
 
 func TestRateLimiter_WriteAt(t *testing.T) {
 	bpsLimiter := rate.NewLimiter(rate.Limit(2*_mb), 2*(2*_mb))
-	workDir, err := ioutil.TempDir(os.TempDir(), "workDir")
+	workDir, err := os.MkdirTemp(os.TempDir(), "workDir")
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 

--- a/blobstore/blobnode/base/qos/qos_test.go
+++ b/blobstore/blobnode/base/qos/qos_test.go
@@ -3,7 +3,6 @@ package qos
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -60,7 +59,7 @@ func TestNewQosManager(t *testing.T) {
 	require.NoError(t, err)
 	defer qos.Close()
 
-	f, err := ioutil.TempFile(os.TempDir(), "TestQos")
+	f, err := os.CreateTemp(os.TempDir(), "TestQos")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()
@@ -96,7 +95,7 @@ func TestNewQosManager(t *testing.T) {
 	}
 
 	{
-		wf, err := ioutil.TempFile(os.TempDir(), "TestQosReader")
+		wf, err := os.CreateTemp(os.TempDir(), "TestQosReader")
 		require.NoError(t, err)
 		defer os.Remove(wf.Name())
 		r := qos.Reader(ctx, bnapi.NormalIO, f)
@@ -143,7 +142,7 @@ func TestQosTryAcquire(t *testing.T) {
 	require.NoError(t, err)
 	defer qos.Close()
 
-	f, err := ioutil.TempFile(os.TempDir(), "TestQos")
+	f, err := os.CreateTemp(os.TempDir(), "TestQos")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()

--- a/blobstore/blobnode/base/util.go
+++ b/blobstore/blobnode/base/util.go
@@ -17,7 +17,6 @@ package base
 import (
 	"encoding/json"
 	err1 "errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -66,7 +65,7 @@ func IsEmptyDisk(filename string) (bool, error) {
 	if !isPathSafe(absPath) {
 		return false, ErrInValidFilePath
 	}
-	fis, err := ioutil.ReadDir(absPath)
+	fis, err := os.ReadDir(absPath)
 	if err != nil {
 		return false, err
 	}

--- a/blobstore/blobnode/base/util_test.go
+++ b/blobstore/blobnode/base/util_test.go
@@ -15,7 +15,6 @@
 package base
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,6 +27,7 @@ import (
 //   "Range": "bytes=100-200"
 //   "Range": "bytes=-50"
 //   "Range": "bytes=150-"
+
 func TestParseOneRange(t *testing.T) {
 	s1 := "bytes=0-99"
 	s2 := "bytes=100-200"
@@ -107,7 +107,7 @@ func TestIsEmptyDisk(t *testing.T) {
 	require.Equal(t, false, flag)
 	require.Error(t, err)
 
-	testDir, err := ioutil.TempDir(os.TempDir(), "blobnode_util")
+	testDir, err := os.MkdirTemp(os.TempDir(), "blobnode_util")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/base/workutils/dropped_bid_recorder_test.go
+++ b/blobstore/blobnode/base/workutils/dropped_bid_recorder_test.go
@@ -16,7 +16,6 @@ package workutils
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 
 func TestDroppedBidRecorder(t *testing.T) {
 	r := DroppedBidRecorderInst()
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
 	cfg := recordlog.Config{

--- a/blobstore/blobnode/chunkreport_test.go
+++ b/blobstore/blobnode/chunkreport_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"hash/crc32"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -128,7 +127,7 @@ func TestChunkReport2(t *testing.T) {
 	cc := &cmapi.Config{}
 	cc.Hosts = []string{mockClusterMgrServer.URL}
 
-	workDir, err := ioutil.TempDir(os.TempDir(), defaultSvrTestDir+"ChunkReport2")
+	workDir, err := os.MkdirTemp(os.TempDir(), defaultSvrTestDir+"ChunkReport2")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(workDir, 0o755)

--- a/blobstore/blobnode/config.go
+++ b/blobstore/blobnode/config.go
@@ -110,7 +110,6 @@ func configInit(config *Config) {
 	}
 	defaulter.LessOrEqual(&config.InspectConf.IntervalSec, DefaultChunkInspectIntervalSec)
 	defaulter.LessOrEqual(&config.InspectConf.RateLimit, DefaultInspectRate)
-	defaulter.LessOrEqual(&config.DiskConfig.ChunkCleanIntervalSec, core.DefaultChunkCleanIntervalSec)
 }
 
 func (s *Service) changeLimit(ctx context.Context, c Config) {

--- a/blobstore/blobnode/config.go
+++ b/blobstore/blobnode/config.go
@@ -110,6 +110,7 @@ func configInit(config *Config) {
 	}
 	defaulter.LessOrEqual(&config.InspectConf.IntervalSec, DefaultChunkInspectIntervalSec)
 	defaulter.LessOrEqual(&config.InspectConf.RateLimit, DefaultInspectRate)
+	defaulter.LessOrEqual(&config.DiskConfig.ChunkCleanIntervalSec, core.DefaultChunkCleanIntervalSec)
 }
 
 func (s *Service) changeLimit(ctx context.Context, c Config) {

--- a/blobstore/blobnode/core/blobfile_test.go
+++ b/blobstore/blobnode/core/blobfile_test.go
@@ -15,7 +15,6 @@
 package core
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestBlobFile_Op(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "BlobFileOp")
+	testDir, err := os.MkdirTemp(os.TempDir(), "BlobFileOp")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/chunk/compact_test.go
+++ b/blobstore/blobnode/core/chunk/compact_test.go
@@ -133,6 +133,10 @@ func (mock *diskMock) ResetChunks(ctx context.Context) {
 	// do nothing
 }
 
+func (mock *diskMock) IsCleanUp(ctx context.Context) bool {
+	return true
+}
+
 func (mock *diskMock) Close(ctx context.Context) {
 	// do nothing
 }

--- a/blobstore/blobnode/core/disk/chunkinspect.go
+++ b/blobstore/blobnode/core/disk/chunkinspect.go
@@ -17,7 +17,6 @@ package disk
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,7 +29,7 @@ import (
 func listPhyDiskChunkFile(ctx context.Context, dataPath string) (cis map[bnapi.ChunkId]struct{}, err error) {
 	span := trace.SpanFromContextSafe(ctx)
 
-	dir, err := ioutil.ReadDir(dataPath)
+	dir, err := os.ReadDir(dataPath)
 	if err != nil {
 		span.Errorf("Failed read dir, path:%s, err:%v", dataPath, err)
 		return nil, err

--- a/blobstore/blobnode/core/disk/chunkinspect_test.go
+++ b/blobstore/blobnode/core/disk/chunkinspect_test.go
@@ -16,7 +16,6 @@ package disk
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ import (
 )
 
 func TestMayChunkLost(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestMayChunkLost")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestMayChunkLost")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -93,7 +92,7 @@ func TestMayChunkLost(t *testing.T) {
 }
 
 func TestMaybeCleanRubbishChunk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestMaybeCleanRubbishChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestMaybeCleanRubbishChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -146,7 +145,7 @@ func TestMaybeCleanRubbishChunk(t *testing.T) {
 }
 
 func TestGcRubbishChunk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestGcRubbishChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestGcRubbishChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/disk/compact_test.go
+++ b/blobstore/blobnode/core/disk/compact_test.go
@@ -17,7 +17,6 @@ package disk
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ import (
 func TestDiskStorage_StartCompact(t *testing.T) {
 	_, ctx := trace.StartSpanFromContextWithTraceID(context.Background(), "", "NewBlobNodeService")
 
-	testDir, err := ioutil.TempDir(os.TempDir(), "DoCompact2")
+	testDir, err := os.MkdirTemp(os.TempDir(), "DoCompact2")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -99,7 +98,7 @@ func TestDiskStorage_StartCompact(t *testing.T) {
 }
 
 func TestCompactChunkInternal(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestCompactChunkInternal")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestCompactChunkInternal")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -162,7 +161,7 @@ func TestCompactChunkInternal(t *testing.T) {
 }
 
 func TestExecCompactChunk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestExecCompactChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestExecCompactChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/disk/disk_test.go
+++ b/blobstore/blobnode/core/disk/disk_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"hash/crc32"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -52,7 +51,7 @@ func setChunkCompactFn(ctx context.Context, args *cmapi.SetCompactChunkArgs) (er
 }
 
 func TestNewDiskStorage(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "NewDiskStorage")
+	testDir, err := os.MkdirTemp(os.TempDir(), "NewDiskStorage")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -134,7 +133,7 @@ func TestNewDiskStorage(t *testing.T) {
 }
 
 func TestRunCompact(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestRunCompact")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestRunCompact")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -193,7 +192,7 @@ func TestRunCompact(t *testing.T) {
 }
 
 func TestDiskStorage_UpdateChunkStatus(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "UpdateChunkStatus")
+	testDir, err := os.MkdirTemp(os.TempDir(), "UpdateChunkStatus")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -235,7 +234,7 @@ func TestDiskStorage_UpdateChunkStatus(t *testing.T) {
 }
 
 func TestSuperBlock_UpdateDiskStatus(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "UpdateDiskStatus")
+	testDir, err := os.MkdirTemp(os.TempDir(), "UpdateDiskStatus")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -284,7 +283,7 @@ func TestSuperBlock_UpdateDiskStatus(t *testing.T) {
 func TestDiskStorage_CompactChunkFile2(t *testing.T) {
 	span, ctx := trace.StartSpanFromContextWithTraceID(context.Background(), "", "NewBlobNodeService")
 
-	testDir, err := ioutil.TempDir(os.TempDir(), "CompactChunkFile2")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CompactChunkFile2")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -367,7 +366,7 @@ func TestDiskStorage_CompactChunkFile2(t *testing.T) {
 }
 
 func TestExecCompact(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "ExecCompact")
+	testDir, err := os.MkdirTemp(os.TempDir(), "ExecCompact")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -426,7 +425,7 @@ func TestExecCompact(t *testing.T) {
 }
 
 func TestCleanChunk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "CleanChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CleanChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -489,7 +488,7 @@ func TestCleanChunk(t *testing.T) {
 }
 
 func TestCheckChunkFile(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "CheckChunkFile")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CheckChunkFile")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -540,7 +539,7 @@ func TestCheckChunkFile(t *testing.T) {
 }
 
 func TestDiskstorage_Finalizer(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "NewDiskStorage")
+	testDir, err := os.MkdirTemp(os.TempDir(), "NewDiskStorage")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -606,7 +605,7 @@ func TestDiskstorage_Finalizer(t *testing.T) {
 }
 
 func TestDiskStorageWrapper_CreateChunk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "CreateChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CreateChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -638,7 +637,7 @@ func TestDiskStorageWrapper_CreateChunk(t *testing.T) {
 }
 
 func TestDiskStorage_ReleaseChunk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "CreateChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CreateChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -683,7 +682,7 @@ func TestDiskStorage_ReleaseChunk(t *testing.T) {
 }
 
 func TestDiskStorage_UpdateChunkStatus2(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "CreateChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CreateChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/disk/metrics_test.go
+++ b/blobstore/blobnode/core/disk/metrics_test.go
@@ -16,7 +16,6 @@ package disk
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestDiskMetricReport(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestDiskMetricReport")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestDiskMetricReport")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/disk/superblock_test.go
+++ b/blobstore/blobnode/core/disk/superblock_test.go
@@ -16,7 +16,6 @@ package disk
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ import (
 )
 
 func TestNewSuperBlock(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "NewSuperBlock")
+	testDir, err := os.MkdirTemp(os.TempDir(), "NewSuperBlock")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -90,7 +89,7 @@ func TestNewSuperBlock(t *testing.T) {
 }
 
 func TestSuperBlock_RegisterDisk(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "SBRegisterDisk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "SBRegisterDisk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -138,7 +137,7 @@ func TestSuperBlock_RegisterDisk(t *testing.T) {
 }
 
 func TestSuperBlock_ListChunks(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "SBListChunk")
+	testDir, err := os.MkdirTemp(os.TempDir(), "SBListChunk")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -181,7 +180,7 @@ func TestSuperBlock_ListChunks(t *testing.T) {
 }
 
 func TestSuperBlock_ListVuids(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "SBListVuid")
+	testDir, err := os.MkdirTemp(os.TempDir(), "SBListVuid")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -231,7 +230,7 @@ func TestParseVuidSpacePrefix(t *testing.T) {
 }
 
 func TestSuperblockErrorCondition(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestWriteData")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestWriteData")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -273,7 +272,7 @@ func TestSuperblockErrorCondition(t *testing.T) {
 }
 
 func TestCleanChunkSpace(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "CleanChunkSpace")
+	testDir, err := os.MkdirTemp(os.TempDir(), "CleanChunkSpace")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/disk/trash_test.go
+++ b/blobstore/blobnode/core/disk/trash_test.go
@@ -16,7 +16,6 @@ package disk
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestCleanTrash(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "TestRunCompact")
+	testDir, err := os.MkdirTemp(os.TempDir(), "TestRunCompact")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/format.go
+++ b/blobstore/blobnode/core/format.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"hash/crc32"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -175,7 +174,7 @@ func ReadFormatInfo(ctx context.Context, diskRootPath string) (
 	span := trace.SpanFromContextSafe(ctx)
 
 	configFile := filepath.Join(sysRootPath(diskRootPath), formatConfigFile)
-	buf, err := ioutil.ReadFile(configFile)
+	buf, err := os.ReadFile(configFile)
 	if err != nil {
 		span.Errorf("Failed read file:%v, err:%v", configFile, err)
 		return nil, err

--- a/blobstore/blobnode/core/format_test.go
+++ b/blobstore/blobnode/core/format_test.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -44,7 +43,7 @@ func TestFormatInfo(t *testing.T) {
 
 	ctx := context.Background()
 
-	diskPath, err := ioutil.TempDir(os.TempDir(), "BlobNodeTestFormatInfo")
+	diskPath, err := os.MkdirTemp(os.TempDir(), "BlobNodeTestFormatInfo")
 	require.NoError(t, err)
 	defer os.RemoveAll(diskPath)
 

--- a/blobstore/blobnode/core/proto.go
+++ b/blobstore/blobnode/core/proto.go
@@ -171,5 +171,6 @@ type DiskAPI interface {
 	GcRubbishChunk(ctx context.Context) (mayBeLost []bnapi.ChunkId, err error)
 	WalkChunksWithLock(ctx context.Context, fn func(cs ChunkAPI) error) (err error)
 	ResetChunks(ctx context.Context)
+	IsCleanUp(ctx context.Context) bool
 	Close(ctx context.Context)
 }

--- a/blobstore/blobnode/core/storage/datafile_test.go
+++ b/blobstore/blobnode/core/storage/datafile_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -51,7 +51,7 @@ func newIoPoolMock(t *testing.T) taskpool.IoPool {
 }
 
 func TestNewChunkData(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"NewChunkData")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"NewChunkData")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -103,7 +103,7 @@ func TestNewChunkData(t *testing.T) {
 }
 
 func TestChunkData_Write(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkDataWrite")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkDataWrite")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -156,7 +156,7 @@ func TestChunkData_Write(t *testing.T) {
 	// read crc
 	r, err := cd.Read(ctx, shard, 0, shard.Size)
 	require.NoError(t, err)
-	rd, err := ioutil.ReadAll(r)
+	rd, err := io.ReadAll(r)
 	require.NoError(t, err)
 
 	log.Infof("read: %s", string(rd))
@@ -172,7 +172,7 @@ func TestChunkData_Write(t *testing.T) {
 }
 
 func TestChunkData_ConcurrencyWrite(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkDataWriteCon")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkDataWriteCon")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -232,7 +232,7 @@ func TestChunkData_ConcurrencyWrite(t *testing.T) {
 
 			r, err := cd.Read(ctx, shard, 0, shard.Size)
 			require.NoError(t, err)
-			rd, err := ioutil.ReadAll(r)
+			rd, err := io.ReadAll(r)
 			require.NoError(t, err)
 
 			log.Infof("read: %s", string(rd))
@@ -255,7 +255,7 @@ func TestChunkData_ConcurrencyWrite(t *testing.T) {
 }
 
 func TestChunkData_Delete(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkDataDelete")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkDataDelete")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -317,7 +317,7 @@ func TestChunkData_Delete(t *testing.T) {
 
 			r, err := cd.Read(ctx, shard, 0, shard.Size)
 			require.NoError(t, err)
-			rd, err := ioutil.ReadAll(r)
+			rd, err := io.ReadAll(r)
 			require.NoError(t, err)
 
 			log.Infof("read: %s", string(rd))
@@ -380,7 +380,7 @@ func TestChunkData_Delete(t *testing.T) {
 }
 
 func TestChunkData_Destroy(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkDataDestroy")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkDataDestroy")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -426,7 +426,7 @@ func TestChunkData_Close(t *testing.T) {
 }
 
 func TestParseMeta(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ParseMeta")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ParseMeta")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/storage/metadb_test.go
+++ b/blobstore/blobnode/core/storage/metadb_test.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ import (
 )
 
 func TestNewChunkMeta(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"NewChunkMeta")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"NewChunkMeta")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -63,7 +62,7 @@ func TestNewChunkMeta(t *testing.T) {
 }
 
 func TestChunkMeta_Write(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkMetaWrite")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkMetaWrite")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -119,7 +118,7 @@ func TestChunkMeta_Write(t *testing.T) {
 }
 
 func TestChunkMeta_Scan(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkMetaScan")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkMetaScan")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -231,7 +230,7 @@ func TestGenShardKey(t *testing.T) {
 }
 
 func TestChunkMeta_Destroy(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), defaultDiskTestDir+"ChunkMetaDestroy")
+	testDir, err := os.MkdirTemp(os.TempDir(), defaultDiskTestDir+"ChunkMetaDestroy")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/core/storage/storage_test.go
+++ b/blobstore/blobnode/core/storage/storage_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -215,7 +214,7 @@ func TestStorage_Operations(t *testing.T) {
 	b.Body = bytes.NewReader(mockBody)
 	rc, err := stg.NewRangeReader(ctx, b, 0, int64(len(mockBody)))
 	require.NoError(t, err)
-	buffer, err := ioutil.ReadAll(rc)
+	buffer, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	require.Equal(t, mockBody, buffer)
 

--- a/blobstore/blobnode/db/metadb_bench_test.go
+++ b/blobstore/blobnode/db/metadb_bench_test.go
@@ -17,7 +17,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -31,7 +30,7 @@ import (
 )
 
 func BenchmarkKVDB_CoPut(b *testing.B) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbCoPut")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbCoPut")
 	require.NoError(b, err)
 	defer os.RemoveAll(testDir)
 
@@ -76,7 +75,7 @@ func BenchmarkKVDB_CoPut(b *testing.B) {
 }
 
 func BenchmarkKVDB_DirectPut(b *testing.B) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbBenchmarkPut")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbBenchmarkPut")
 	require.NoError(b, err)
 	defer os.RemoveAll(testDir)
 
@@ -121,7 +120,7 @@ func BenchmarkKVDB_DirectPut(b *testing.B) {
 }
 
 func BenchmarkKVDB_CoDelete(b *testing.B) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbCoDelete")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbCoDelete")
 	require.NoError(b, err)
 	defer os.RemoveAll(testDir)
 
@@ -177,7 +176,7 @@ func BenchmarkKVDB_CoDelete(b *testing.B) {
 }
 
 func BenchmarkKVDB_DirectDelete(b *testing.B) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbDelete")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbDelete")
 	require.NoError(b, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/db/metadb_test.go
+++ b/blobstore/blobnode/db/metadb_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 )
 
 func TestNewKVDB(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbNew")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbNew")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -47,7 +46,7 @@ func TestNewKVDB(t *testing.T) {
 }
 
 func TestKVDB_DirectOP(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbDirectOp")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbDirectOp")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -88,7 +87,7 @@ func TestKVDB_DirectOP(t *testing.T) {
 }
 
 func TestKVDB_BatchWrite(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbBatchWrite")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbBatchWrite")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -177,7 +176,7 @@ func TestKVDB_BatchWrite(t *testing.T) {
 }
 
 func TestKVDB_BatchDelete(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "kvdbBatchDelete")
+	testDir, err := os.MkdirTemp(os.TempDir(), "kvdbBatchDelete")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -250,7 +249,7 @@ func TestKVDB_BatchDelete(t *testing.T) {
 }
 
 func TestKVDB_Close(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "Metadb")
+	testDir, err := os.MkdirTemp(os.TempDir(), "Metadb")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 
@@ -268,7 +267,7 @@ func TestKVDB_Close(t *testing.T) {
 }
 
 func TestDeleteRange(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "DeleteRange")
+	testDir, err := os.MkdirTemp(os.TempDir(), "DeleteRange")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/blobnode/disk_mock_test.go
+++ b/blobstore/blobnode/disk_mock_test.go
@@ -192,6 +192,20 @@ func (mr *MockDiskAPIMockRecorder) ID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockDiskAPI)(nil).ID))
 }
 
+// IsCleanUp mocks base method.
+func (m *MockDiskAPI) IsCleanUp(arg0 context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCleanUp", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsCleanUp indicates an expected call of IsCleanUp.
+func (mr *MockDiskAPIMockRecorder) IsCleanUp(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCleanUp", reflect.TypeOf((*MockDiskAPI)(nil).IsCleanUp), arg0)
+}
+
 // ListChunks mocks base method.
 func (m *MockDiskAPI) ListChunks(arg0 context.Context) ([]core.VuidMeta, error) {
 	m.ctrl.T.Helper()

--- a/blobstore/blobnode/heartbeat.go
+++ b/blobstore/blobnode/heartbeat.go
@@ -92,11 +92,16 @@ func (s *Service) syncDiskStatus(ctx context.Context, diskInfosRet []*cmapi.Disk
 			continue
 		}
 
-		if status >= proto.DiskStatusBroken {
+		switch status {
+		case proto.DiskStatusBroken, proto.DiskStatusRepairing, proto.DiskStatusRepaired:
 			span.Warnf("notify broken. diskID:%v ds.Status:%v, status:%v", diskId, ds.Status(), status)
 			s.handleDiskIOError(ctx, diskId, bloberr.ErrDiskBroken)
 			continue
-		}
 
+		case proto.DiskStatusDropped:
+			span.Warnf("disk drop: diskID:%v ds.Status:%v, status:%v", diskId, ds.Status(), status)
+			s.handleDiskDrop(ctx, ds)
+			continue
+		}
 	}
 }

--- a/blobstore/blobnode/heartbeat.go
+++ b/blobstore/blobnode/heartbeat.go
@@ -92,15 +92,9 @@ func (s *Service) syncDiskStatus(ctx context.Context, diskInfosRet []*cmapi.Disk
 			continue
 		}
 
-		switch status {
-		case proto.DiskStatusBroken, proto.DiskStatusRepairing, proto.DiskStatusRepaired:
+		if status >= proto.DiskStatusBroken {
 			span.Warnf("notify broken. diskID:%v ds.Status:%v, status:%v", diskId, ds.Status(), status)
 			s.handleDiskIOError(ctx, diskId, bloberr.ErrDiskBroken)
-			continue
-
-		case proto.DiskStatusDropped:
-			span.Warnf("disk drop: diskID:%v ds.Status:%v, status:%v", diskId, ds.Status(), status)
-			s.handleDiskDrop(ctx, ds)
 			continue
 		}
 	}

--- a/blobstore/blobnode/heartbeat_test.go
+++ b/blobstore/blobnode/heartbeat_test.go
@@ -17,7 +17,6 @@ package blobnode
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -74,7 +73,7 @@ func TestHeartbeat2(t *testing.T) {
 	cc := &cmapi.Config{}
 	cc.Hosts = []string{mockClusterMgrServer.URL}
 
-	workDir, err := ioutil.TempDir(os.TempDir(), defaultSvrTestDir+"Heartbeat2")
+	workDir, err := os.MkdirTemp(os.TempDir(), defaultSvrTestDir+"Heartbeat2")
 	require.NoError(t, err)
 	defer os.Remove(workDir)
 
@@ -139,7 +138,7 @@ func TestHeartbeat3(t *testing.T) {
 	cc := &cmapi.Config{}
 	cc.Hosts = []string{mockClusterMgrServer.URL}
 
-	workDir, err := ioutil.TempDir(os.TempDir(), defaultSvrTestDir+"Heartbeat3")
+	workDir, err := os.MkdirTemp(os.TempDir(), defaultSvrTestDir+"Heartbeat3")
 	require.NoError(t, err)
 	defer os.Remove(workDir)
 

--- a/blobstore/blobnode/iostat.go
+++ b/blobstore/blobnode/iostat.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -76,7 +75,7 @@ func (s *Service) cleanExpiredStatFile() {
 			span.Errorf("path:%v, err:%v", path, err)
 			return err
 		}
-		data, err := ioutil.ReadFile(pidpath + "comm")
+		data, err := os.ReadFile(pidpath + "comm")
 		if err == nil {
 			return errors.New("progress still alive")
 		}

--- a/blobstore/blobnode/shard_test.go
+++ b/blobstore/blobnode/shard_test.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"reflect"
@@ -191,7 +191,7 @@ func TestShardPutAndGet(t *testing.T) {
 	defer body.Close()
 	require.Equal(t, dataCrc.Sum32(), crc)
 
-	getShardData, err := ioutil.ReadAll(body)
+	getShardData, err := io.ReadAll(body)
 	require.NoError(t, err)
 	require.Equal(t, true, reflect.DeepEqual(shardData, getShardData))
 
@@ -822,7 +822,7 @@ func TestShardRangeGet(t *testing.T) {
 	body, _, err := client.RangeGetShard(ctx, host, getShardArg)
 	require.NoError(t, err)
 
-	b, err := ioutil.ReadAll(body)
+	b, err := io.ReadAll(body)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(b))
 	require.Equal(t, byte('e'), byte(b[0]))
@@ -832,7 +832,7 @@ func TestShardRangeGet(t *testing.T) {
 	body, _, err = client.RangeGetShard(ctx, host, getShardArg)
 	require.NoError(t, err)
 
-	b, err = ioutil.ReadAll(body)
+	b, err = io.ReadAll(body)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(b))
 	require.Equal(t, byte('D'), byte(b[0]))
@@ -847,7 +847,7 @@ func TestShardRangeGet(t *testing.T) {
 	body, _, err = client.GetShard(ctx, host, &args)
 	require.NoError(t, err)
 
-	b, err = ioutil.ReadAll(body)
+	b, err = io.ReadAll(body)
 	require.NoError(t, err)
 	require.Equal(t, 8, len(b))
 	require.Equal(t, dataCrc.Sum32(), crc)

--- a/blobstore/blobnode/startup.go
+++ b/blobstore/blobnode/startup.go
@@ -17,7 +17,6 @@ package blobnode
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sync"
 	"time"
@@ -50,7 +49,7 @@ func readFormatInfo(ctx context.Context, diskRootPath string) (
 	formatInfo *core.FormatInfo, err error,
 ) {
 	span := trace.SpanFromContextSafe(ctx)
-	_, err = ioutil.ReadDir(diskRootPath)
+	_, err = os.ReadDir(diskRootPath)
 	if err != nil {
 		span.Errorf("read disk root path error:%s", diskRootPath)
 		return nil, err

--- a/blobstore/blobnode/svr_test.go
+++ b/blobstore/blobnode/svr_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -144,6 +145,73 @@ func TestHandleDiskIOError(t *testing.T) {
 		DiskID: proto.DiskID(102),
 	}
 	di, err = client.DiskInfo(ctx, host, diskInfoArg)
+	require.NoError(t, err)
+	require.Equal(t, proto.DiskID(102), di.DiskID)
+	require.Equal(t, di.Status, proto.DiskStatusNormal)
+}
+
+func TestHandleDiskDrop(t *testing.T) {
+	_, ctx := trace.StartSpanFromContextWithTraceID(context.Background(), "", "TestService")
+
+	service, _ := newTestBlobNodeService(t, "Service")
+	defer cleanTestBlobNodeService(service)
+
+	host := runTestServer(service)
+	client := bnapi.New(&bnapi.Config{})
+
+	dis, err := client.Stat(ctx, host)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(dis))
+
+	service.lock.RLock()
+	ds, exist := service.Disks[proto.DiskID(101)]
+	service.lock.RUnlock()
+	require.True(t, exist)
+	require.Equal(t, proto.DiskID(101), ds.ID())
+	delCh := make(chan struct{}, 1)
+	go func() {
+		ds.CreateChunk(ctx, proto.Vuid(146095996936), 8)
+		os.OpenFile(filepath.Join(ds.GetDataPath(), "testChunk"), os.O_CREATE, 0o644)
+
+		time.Sleep(time.Millisecond * 200)
+		ds.ResetChunks(ctx)
+		chunkFiles, err := os.ReadDir(ds.GetDataPath())
+		require.NoError(t, err)
+		for _, file := range chunkFiles {
+			os.Remove(filepath.Join(ds.GetDataPath(), file.Name()))
+		}
+		delCh <- struct{}{}
+	}()
+
+	service.lock.RLock()
+	ds, exist = service.Disks[proto.DiskID(101)]
+	service.lock.RUnlock()
+	require.True(t, exist)
+	require.Equal(t, proto.DiskID(101), ds.ID())
+	service.Conf.DiskConfig.ChunkCleanIntervalSec = 1
+	service.handleDiskDrop(ctx, ds)
+	require.Equal(t, ds.Status(), proto.DiskStatusDropped)
+
+	<-delCh
+	time.Sleep(time.Second)
+	service.lock.RLock()
+	ds, exist = service.Disks[proto.DiskID(101)]
+	service.lock.RUnlock()
+	require.False(t, exist)
+
+	// 101 broken
+	diskInfoArg := &bnapi.DiskStatArgs{
+		DiskID: proto.DiskID(101),
+	}
+	_, err = client.DiskInfo(ctx, host, diskInfoArg)
+	require.NotNil(t, err)
+	require.Equal(t, bloberr.ErrNoSuchDisk.Error(), err.Error())
+
+	// 102 ok
+	diskInfoArg = &bnapi.DiskStatArgs{
+		DiskID: proto.DiskID(102),
+	}
+	di, err := client.DiskInfo(ctx, host, diskInfoArg)
 	require.NoError(t, err)
 	require.Equal(t, proto.DiskID(102), di.DiskID)
 	require.Equal(t, di.Status, proto.DiskStatusNormal)

--- a/blobstore/blobnode/svr_test.go
+++ b/blobstore/blobnode/svr_test.go
@@ -16,7 +16,6 @@ package blobnode
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -151,7 +150,7 @@ func TestHandleDiskIOError(t *testing.T) {
 }
 
 func TestService2(t *testing.T) {
-	workDir, err := ioutil.TempDir(os.TempDir(), defaultSvrTestDir+"Service2")
+	workDir, err := os.MkdirTemp(os.TempDir(), defaultSvrTestDir+"Service2")
 	require.NoError(t, err)
 	defer os.Remove(workDir)
 
@@ -197,7 +196,7 @@ func TestService2(t *testing.T) {
 }
 
 func newTestBlobNodeService(t *testing.T, path string) (*Service, *mockClusterMgr) {
-	workDir, err := ioutil.TempDir(os.TempDir(), defaultSvrTestDir+path)
+	workDir, err := os.MkdirTemp(os.TempDir(), defaultSvrTestDir+path)
 	require.NoError(t, err)
 
 	path1 := filepath.Join(workDir, "disk1")
@@ -268,7 +267,7 @@ func newTestBlobNodeService(t *testing.T, path string) (*Service, *mockClusterMg
 }
 
 func TestService_CmdpChunk(t *testing.T) {
-	workDir, err := ioutil.TempDir(os.TempDir(), defaultSvrTestDir+"TestService_CmdpChunkCompact")
+	workDir, err := os.MkdirTemp(os.TempDir(), defaultSvrTestDir+"TestService_CmdpChunkCompact")
 	require.NoError(t, err)
 	defer os.RemoveAll(workDir)
 

--- a/blobstore/blobnode/svr_test.go
+++ b/blobstore/blobnode/svr_test.go
@@ -188,6 +188,7 @@ func TestHandleDiskDrop(t *testing.T) {
 	service.lock.RUnlock()
 	require.True(t, exist)
 	require.Equal(t, proto.DiskID(101), ds.ID())
+	require.NotZero(t, service.Conf.DiskConfig.ChunkCleanIntervalSec)
 	service.Conf.DiskConfig.ChunkCleanIntervalSec = 1
 	service.handleDiskDrop(ctx, ds)
 	require.Equal(t, ds.Status(), proto.DiskStatusDropped)

--- a/blobstore/blobnode/sys/stat_linux_test.go
+++ b/blobstore/blobnode/sys/stat_linux_test.go
@@ -15,7 +15,6 @@
 package sys
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func TestIsMountPoint(t *testing.T) {
 	require.Equal(t, false, b)
 
 	// test dir
-	dir, err := ioutil.TempDir(os.TempDir(), "MountPointTestFile")
+	dir, err := os.MkdirTemp(os.TempDir(), "MountPointTestFile")
 	require.NoError(t, err)
 
 	err = os.MkdirAll(dir, 0o775)

--- a/blobstore/blobnode/worker_for_test.go
+++ b/blobstore/blobnode/worker_for_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"sync"
 	"testing"
 
@@ -203,7 +202,7 @@ func (getter *MockGetter) GetShard(ctx context.Context, location proto.VunitLoca
 		return nil, 0, err
 	}
 	reader, crc, err := getter.vunits[vuid].getShard(bid)
-	return ioutil.NopCloser(reader), crc, err
+	return io.NopCloser(reader), crc, err
 }
 
 func (getter *MockGetter) MarkDelete(ctx context.Context, vuid proto.Vuid, bid proto.BlobID) {

--- a/blobstore/cli/access/get.go
+++ b/blobstore/cli/access/get.go
@@ -17,7 +17,6 @@ package access
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -77,7 +76,7 @@ func getFile(c *grumble.Context) error {
 		// > 4K
 		if size > 1<<12 {
 			fmt.Printf("data is too long %d > %d\n", size, 1<<12)
-			w = ioutil.Discard
+			w = io.Discard
 		} else {
 			w = buffer
 		}

--- a/blobstore/cli/blobnode/iostat.go
+++ b/blobstore/cli/blobnode/iostat.go
@@ -16,7 +16,6 @@ package blobnode
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path"
@@ -71,7 +70,7 @@ func newVDevice(dir, name string) (*vdevice, error) {
 	dev.Viewer = iov
 
 	pName := ""
-	if data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%s/comm", pid)); err == nil {
+	if data, err := os.ReadFile(fmt.Sprintf("/proc/%s/comm", pid)); err == nil {
 		pName = strings.TrimSpace(string(data)) + "."
 	}
 	devName := pName + pid
@@ -137,7 +136,7 @@ func showVDevices(devices []*vdevice, extend, megabytes bool, descend, number in
 }
 
 func scanVDevices(dir string, filters []string) ([]*vdevice, error) {
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/blobstore/cli/clustermgr/raft_wal.go
+++ b/blobstore/cli/clustermgr/raft_wal.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -83,7 +82,7 @@ func cmdWalParse(c *grumble.Context) error {
 		return parse(filepath, printf)
 	}
 
-	fis, err := ioutil.ReadDir(filepath)
+	fis, err := os.ReadDir(filepath)
 	if err != nil {
 		return err
 	}

--- a/blobstore/clustermgr/configmgr/applier_test.go
+++ b/blobstore/clustermgr/configmgr/applier_test.go
@@ -17,7 +17,6 @@ package configmgr
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,7 +30,7 @@ import (
 )
 
 func TestConfigMgr_Others(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cf")
+	testDir, err := os.MkdirTemp("", "cf")
 	defer os.RemoveAll(testDir)
 	require.NoError(t, err)
 
@@ -58,7 +57,7 @@ func TestConfigMgr_Others(t *testing.T) {
 }
 
 func TestConfigMgr_Apply(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "cf")
+	testDir, err := os.MkdirTemp("", "cf")
 	defer os.RemoveAll(testDir)
 	require.NoError(t, err)
 

--- a/blobstore/common/config/load_conf.go
+++ b/blobstore/common/config/load_conf.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cubefs/cubefs/blobstore/util/log"
 	"gopkg.in/go-playground/validator.v9"
@@ -52,7 +52,7 @@ func Load(conf interface{}) (err error) {
 }
 
 func LoadFile(conf interface{}, confName string) (err error) {
-	data, err := ioutil.ReadFile(confName)
+	data, err := os.ReadFile(confName)
 	if err != nil {
 		log.Error("LoadFile conf failed:", err)
 		return

--- a/blobstore/common/config/reload.go
+++ b/blobstore/common/config/reload.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -46,7 +45,7 @@ func HotReload(ctx context.Context, confName string) {
 			case <-ctx.Done():
 				return
 			case <-s:
-				conf, err := ioutil.ReadFile(path)
+				conf, err := os.ReadFile(path)
 				if err != nil {
 					log.Errorf("reload fail to read config file, filename: %s, err: %v", path, err)
 					continue

--- a/blobstore/common/crc32block/decode.go
+++ b/blobstore/common/crc32block/decode.go
@@ -17,7 +17,6 @@ package crc32block
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 )
 
 /*
@@ -109,7 +108,7 @@ func (br *blockReader) nextBlock() (err error) {
 
 func (r *rangeReader) Read(p []byte) (n int, err error) {
 	if !r.skiped {
-		_, err := io.CopyN(ioutil.Discard, r.r, r.skip)
+		_, err := io.CopyN(io.Discard, r.r, r.skip)
 		if err != nil {
 			return 0, err
 		}

--- a/blobstore/common/crc32block/encode_test.go
+++ b/blobstore/common/crc32block/encode_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,7 +104,7 @@ func TestDecodeData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, reader)
 
-		cont, err := ioutil.ReadAll(reader)
+		cont, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		require.Equal(t, data[tb.from:tb.to], cont)
 	}
@@ -161,7 +160,7 @@ func TestLimitEncoderReader(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, reader)
 
-		cont, err := ioutil.ReadAll(reader)
+		cont, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		require.Equal(t, data[tb.from:tb.to], cont)
 	}
@@ -221,7 +220,7 @@ func TestLimitEncoderReader2(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, reader)
 
-		cont, err := ioutil.ReadAll(reader)
+		cont, err := io.ReadAll(reader)
 		require.NoError(t, err)
 		require.Equal(t, data[tb.from:tb.to], cont)
 	}
@@ -247,7 +246,7 @@ func TestLimitEncoderReaderFailed(t *testing.T) {
 	require.Equal(t, n, EncodeSize(fsize, defaultCrc32BlockSize))
 
 	r = bytes.NewReader(data)
-	_, err = enc.Encode(r, fsize+1, ioutil.Discard)
+	_, err = enc.Encode(r, fsize+1, io.Discard)
 	require.Error(t, err)
 	_, ok := err.(ReaderError)
 	require.Equal(t, ok, true)

--- a/blobstore/common/fileutil/lock_test.go
+++ b/blobstore/common/fileutil/lock_test.go
@@ -15,7 +15,6 @@
 package fileutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +24,7 @@ import (
 )
 
 func TestLockAndUnlock(t *testing.T) {
-	testDir, err := ioutil.TempDir(os.TempDir(), "testflock")
+	testDir, err := os.MkdirTemp(os.TempDir(), "testflock")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/common/kvstore/db_test.go
+++ b/blobstore/common/kvstore/db_test.go
@@ -17,7 +17,6 @@ package kvstore
 import (
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func TestDb(t *testing.T) {
-	path, err := ioutil.TempDir("", "testrocksdbkvdb12233222")
+	path, err := os.MkdirTemp("", "testrocksdbkvdb12233222")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -71,7 +70,7 @@ func TestDb(t *testing.T) {
 }
 
 func TestTable(t *testing.T) {
-	path, err := ioutil.TempDir("", "testrocksdbkvdb12345")
+	path, err := os.MkdirTemp("", "testrocksdbkvdb12345")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -178,7 +177,7 @@ func TestTable(t *testing.T) {
 }
 
 func TestTableBatchOP(t *testing.T) {
-	path, err := ioutil.TempDir("", "testrocksdbkvdb12345")
+	path, err := os.MkdirTemp("", "testrocksdbkvdb12345")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 
@@ -212,7 +211,7 @@ func TestTableBatchOP(t *testing.T) {
 }
 
 func TestDbBatchOP(t *testing.T) {
-	path, err := ioutil.TempDir("", "testrocksdbkvdb121212323")
+	path, err := os.MkdirTemp("", "testrocksdbkvdb121212323")
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 

--- a/blobstore/common/profile/profile_test.go
+++ b/blobstore/common/profile/profile_test.go
@@ -2,7 +2,7 @@ package profile
 
 import (
 	"expvar"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -94,7 +94,7 @@ func TestProfileBase(t *testing.T) {
 	resp, err = http.Get(profileAddr + "/debug/var/int_key")
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "100", string(data))
 	resp.Body.Close()
@@ -102,7 +102,7 @@ func TestProfileBase(t *testing.T) {
 	resp, err = http.Get(profileAddr + "/test/before")
 	require.NoError(t, err)
 	require.Equal(t, 800, resp.StatusCode)
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "ok", string(data))
 	resp.Body.Close()
@@ -114,7 +114,7 @@ func TestProfileBase(t *testing.T) {
 	resp, err = http.Get(profileAddr + "/test/handlfunc")
 	require.NoError(t, err)
 	require.Equal(t, 900, resp.StatusCode)
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "ok", string(data))
 	resp.Body.Close()

--- a/blobstore/common/raftserver/wal/fileutil.go
+++ b/blobstore/common/raftserver/wal/fileutil.go
@@ -17,7 +17,6 @@ package wal
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -67,7 +66,7 @@ func (s logNameSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s logNameSlice) Less(i, j int) bool { return s[i].sequence < s[j].sequence }
 
 func listLogFiles(path string) (fnames []logName, err error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/blobstore/common/raftserver/wal/meta_test.go
+++ b/blobstore/common/raftserver/wal/meta_test.go
@@ -15,7 +15,6 @@
 package wal
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -100,7 +99,7 @@ func TestExceptionMeta(t *testing.T) {
 	defer clear()
 
 	os.MkdirAll(dir, 0o755)
-	err := ioutil.WriteFile(path.Join(dir, "meta01"), []byte("123456789"), 0o644)
+	err := os.WriteFile(path.Join(dir, "meta01"), []byte("123456789"), 0o644)
 	require.Nil(t, err)
 	_, _, _, err = NewMeta(dir)
 	require.NotNil(t, err)
@@ -116,9 +115,9 @@ func TestExceptionMeta(t *testing.T) {
 	data := make([]byte, metaSize)
 	md.encodeTo(data)
 	data[0] = 3
-	err = ioutil.WriteFile(path.Join(dir, "meta01"), data, 0o644)
+	err = os.WriteFile(path.Join(dir, "meta01"), data, 0o644)
 	require.Nil(t, err)
-	err = ioutil.WriteFile(path.Join(dir, "meta02"), data, 0o644)
+	err = os.WriteFile(path.Join(dir, "meta02"), data, 0o644)
 	require.Nil(t, err)
 	_, _, _, err = NewMeta(dir)
 	require.NotNil(t, err)

--- a/blobstore/common/rpc/auditlog/auditlog_test.go
+++ b/blobstore/common/rpc/auditlog/auditlog_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -65,7 +64,7 @@ func initServer(t *testing.T, name string, cfg Config) (server *httptest.Server,
 	require.NotNil(t, lc)
 
 	bussinessHandler := func(w http.ResponseWriter, req *http.Request) {
-		_, err := ioutil.ReadAll(req.Body)
+		_, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		w.Header().Set("testh1", "testh1value")
 		w.Header().Add("testh1", "testh1value2")
@@ -158,7 +157,7 @@ func initNoContentLengthServer(t *testing.T) (server *httptest.Server, tmpDir st
 	require.NotNil(t, lc)
 
 	noContentLengthHandler := func(w http.ResponseWriter, req *http.Request) {
-		buffered, err := ioutil.ReadAll(req.Body)
+		buffered, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 		bodySize := req.Body.(*reqBodyReadCloser).bodyRead
 		readSting := string(buffered[:bodySize])
@@ -195,7 +194,7 @@ func TestOpen(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	respData := &testRespData{}
 	err = json.Unmarshal(b, respData)
@@ -216,7 +215,7 @@ func TestOpen(t *testing.T) {
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		respData := &testRespData{}
 		err = json.Unmarshal(b, respData)
@@ -249,7 +248,7 @@ func TestNoContentLength(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	respData := &testRespData{}
 	err = json.Unmarshal(b, respData)
@@ -277,7 +276,7 @@ func TestNoLogBody(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	respData := &testRespData{}
 	err = json.Unmarshal(b, respData)
@@ -290,7 +289,7 @@ func TestNoLogBody(t *testing.T) {
 	resp, err = client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	respData2 := &testErrorRespData{}
 	err = xml.Unmarshal(b, respData2)

--- a/blobstore/common/rpc/codec_test.go
+++ b/blobstore/common/rpc/codec_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"testing"
@@ -31,7 +30,7 @@ func TestServerCrcDecode(t *testing.T) {
 	router.Handle(http.MethodPut, "/put/:size", func(c *Context) {
 		size, _ := strconv.Atoi(c.Param.ByName("size"))
 
-		n, err := io.Copy(ioutil.Discard, c.Request.Body)
+		n, err := io.Copy(io.Discard, c.Request.Body)
 		if err != nil && err != io.EOF {
 			c.RespondError(err)
 			return
@@ -74,7 +73,7 @@ func TestServerCrcDecodeWithMiddleware(t *testing.T) {
 	router.Handle(http.MethodPut, "/put/:size", func(c *Context) {
 		size, _ := strconv.Atoi(c.Param.ByName("size"))
 
-		n, err := io.Copy(ioutil.Discard, c.Request.Body)
+		n, err := io.Copy(io.Discard, c.Request.Body)
 		if err != nil && err != io.EOF {
 			c.RespondError(err)
 			return

--- a/blobstore/common/rpc/context_test.go
+++ b/blobstore/common/rpc/context_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -102,7 +101,7 @@ func TestServerResponse(t *testing.T) {
 		resp, err := cli.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		buf, _ := ioutil.ReadAll(resp.Body)
+		buf, _ := io.ReadAll(resp.Body)
 		require.Equal(t, 200, resp.StatusCode)
 		require.Equal(t, "127.0.0.1", string(buf))
 	}

--- a/blobstore/common/rpc/proto.go
+++ b/blobstore/common/rpc/proto.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -190,7 +189,7 @@ func marshalObj(obj interface{}) (*marshalledBody, error) {
 func programVersion() string {
 	sp := strings.Fields(strings.TrimSpace(version.Version()))
 	if len(sp) == 0 || sp[0] == "develop" {
-		data, err := ioutil.ReadFile(os.Args[0])
+		data, err := os.ReadFile(os.Args[0])
 		if err != nil {
 			return "_"
 		}

--- a/blobstore/common/rpc/simple_test.go
+++ b/blobstore/common/rpc/simple_test.go
@@ -17,7 +17,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,7 +40,7 @@ func (s *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	uri := r.URL.RequestURI()
 	switch uri {
 	case "/retry":
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil || int64(len(b)) != r.ContentLength || first {
 			ReplyErr(w, 500, "test retry")
 			first = false
@@ -256,7 +256,7 @@ func TestTimeoutReadCloser_Read(t *testing.T) {
 	// test for read data for input buffer timeout
 	readCloser := timeoutReadCloser{
 		timeoutMs: 1,
-		body:      ioutil.NopCloser(&testTimeoutReader{}),
+		body:      io.NopCloser(&testTimeoutReader{}),
 	}
 	res := make([]byte, 30)
 	_, err := readCloser.Read(res)

--- a/blobstore/scheduler/blob_deleter_test.go
+++ b/blobstore/scheduler/blob_deleter_test.go
@@ -17,7 +17,6 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -566,7 +565,7 @@ func TestNewDeleteMgr(t *testing.T) {
 	broker0 := NewBroker(t)
 	defer broker0.Close()
 
-	testDir, err := ioutil.TempDir(os.TempDir(), "delete_log")
+	testDir, err := os.MkdirTemp(os.TempDir(), "delete_log")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/scheduler/config.go
+++ b/blobstore/scheduler/config.go
@@ -239,9 +239,9 @@ func (c *Config) fixBalanceConfig() {
 
 func (c *Config) fixDiskDropConfig() {
 	c.DiskDrop.ClusterID = c.ClusterID
+	c.DiskDrop.CheckAndFix() // prevent DiskConcurrency is zero
 	defaulter.LessOrEqual(&c.DiskDrop.TaskLimitPerDisk, defaultTaskLimitPerDisk)
 	defaulter.LessOrEqual(&c.DiskDrop.TotalTaskLimit, c.DiskDrop.TaskLimitPerDisk*c.DiskDrop.DiskConcurrency)
-	c.DiskDrop.CheckAndFix()
 }
 
 func (c *Config) fixDiskRepairConfig() {

--- a/blobstore/scheduler/disk_droper_test.go
+++ b/blobstore/scheduler/disk_droper_test.go
@@ -124,14 +124,14 @@ func TestDiskDropCollectTask(t *testing.T) {
 	{
 		// reviseDropTask failed
 		mgr := newDiskDroper(t)
-		mgr.prepareTaskPool = taskpool.New(1, 2)
+		mgr.prepareTaskPool = taskpool.New(1, 1)
 		mgr.clusterMgrCli.(*MockClusterMgrAPI).EXPECT().ListDropDisks(any).Return(nil, errMock)
 		mgr.collectTask()
 		require.Equal(t, 0, mgr.collectedDisks.size())
 	}
 	{
 		mgr := newDiskDroper(t)
-		mgr.prepareTaskPool = taskpool.New(1, 2)
+		mgr.prepareTaskPool = taskpool.New(1, 1)
 		// loopGenerateTask success
 		volume := MockGenVolInfo(10005, codemode.EC6P6, proto.VolumeStatusIdle)
 		var units []*client.VunitInfoSimple

--- a/blobstore/scheduler/shard_repairer_test.go
+++ b/blobstore/scheduler/shard_repairer_test.go
@@ -17,7 +17,6 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -210,7 +209,7 @@ func TestNewShardRepairMgr(t *testing.T) {
 	broker0 := NewBroker(t)
 	defer broker0.Close()
 
-	testDir, err := ioutil.TempDir(os.TempDir(), "orphan_shard_log")
+	testDir, err := os.MkdirTemp(os.TempDir(), "orphan_shard_log")
 	require.NoError(t, err)
 	defer os.RemoveAll(testDir)
 

--- a/blobstore/util/largefile/large_file_test.go
+++ b/blobstore/util/largefile/large_file_test.go
@@ -16,7 +16,6 @@ package largefile
 
 import (
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strconv"
@@ -58,7 +57,7 @@ func TestLargeFile(t *testing.T) {
 	dir, _ := os.Open(tmpPath)
 	fis, _ := dir.Readdir(-1)
 	for i := range fis {
-		b, err := ioutil.ReadFile(tmpPath + "/" + fis[i].Name())
+		b, err := os.ReadFile(tmpPath + "/" + fis[i].Name())
 		require.NoError(t, err)
 		t.Log(fis[i].Name(), len(b))
 	}

--- a/blobstore/util/log/logext_test.go
+++ b/blobstore/util/log/logext_test.go
@@ -16,7 +16,7 @@ package log
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"strconv"
@@ -117,7 +117,7 @@ func BenchmarkFormatOutputLine(b *testing.B) {
 }
 
 func outputwith(b *testing.B, calldepth int) {
-	l := New(ioutil.Discard, 1)
+	l := New(io.Discard, 1)
 	b.Helper()
 	for ii := 0; ii < b.N; ii++ {
 		l.Output("id-xxx-id", Linfo, calldepth, "loggingggggggg")

--- a/blobstore/util/version/version.go
+++ b/blobstore/util/version/version.go
@@ -16,7 +16,6 @@ package version
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -39,6 +38,6 @@ func Version() string {
 
 func writeFile(fname, field string) {
 	if field != "" {
-		ioutil.WriteFile(fname, []byte(field), fPerm)
+		os.WriteFile(fname, []byte(field), fPerm)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

Fixes: #3345

### Motivation
When a disk is dropped it is necessary to verify that the chunk files under the disk/data path are emptied.

### Modifications
For the state "disk dropped" an additional special handling flow has been introduced: upon detecting this state, it is checked whether the chunk files has been cleaned completely.

### Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)

### Does this pull request potentially affect one of the following parts:
- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
- [ ] `in-two-days`
- [ ] `weeks`
- [x] `free-time`
- [ ] `whenever`

<!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
