### PR TITLE
fix(cubefs): fix miss makezero bug

### DIFF
--- a/depends/tiglabs/raft/raft_fsm.go
+++ b/depends/tiglabs/raft/raft_fsm.go
@@ -20,9 +20,10 @@ import (
 	"math/rand"
 	"strings"
 
+	"time"
+
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/logger"
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/proto"
-	"time"
 )
 
 // CampaignType represents the type of campaigning
@@ -188,7 +189,7 @@ func (r *raftFsm) doRandomSeed() {
 }
 
 func (r *raftFsm) StopFsm() {
-	peers := make([]proto.Peer, len(r.replicas))
+	peers := make([]proto.Peer, 0, len(r.replicas))
 	for _, r := range r.replicas {
 		peers = append(peers, r.peer)
 	}

--- a/metanode/sorted_extents.go
+++ b/metanode/sorted_extents.go
@@ -610,7 +610,7 @@ func (se *SortedExtents) Delete(delEks []proto.ExtentKey) (curEks []proto.Extent
 	se.RLock()
 	defer se.RUnlock()
 
-	curEks = make([]proto.ExtentKey, len(se.eks)-len(delEks))
+	curEks = make([]proto.ExtentKey, 0, len(se.eks)-len(delEks))
 	for _, key := range se.eks {
 		delFlag := false
 		for _, delKey := range delEks {

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -446,7 +446,7 @@ func (w *Wrapper) getDataPartitionFromMaster(isInit bool, dpId uint64) (err erro
 	dpr.IsRecover = dpInfo.IsRecover
 	dpr.IsDiscard = dpInfo.IsDiscard
 
-	DataPartitions := make([]*proto.DataPartitionResponse, 1)
+	DataPartitions := make([]*proto.DataPartitionResponse, 0, 1)
 	DataPartitions = append(DataPartitions, dpr)
 	return w.updateDataPartitionByRsp(isInit, DataPartitions)
 }


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #xyz

<!-- or this PR is one task of an issue. -->

Main Issue: #xyz


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output  https://github.com/alingse/go-linter-runner/actions/runs/9242658508/job/25425756585

```
====================================================================================================
append to slice `peers` with non-zero initialized length at https://github.com/cubefs/cubefs/blob/master/depends/tiglabs/raft/raft_fsm.go#L1[9](https://github.com/alingse/go-linter-runner/actions/runs/9242658508/job/25425756585#step:4:10)3:11
append to slice `DataPartitions` with non-zero initialized length at https://github.com/cubefs/cubefs/blob/master/sdk/data/wrapper/wrapper.go#L450:19
append to slice `curEks` with non-zero initialized length at https://github.com/cubefs/cubefs/blob/master/metanode/sorted_extents.go#L625:13
append to slice `collection` with non-zero initialized length at https://github.com/cubefs/cubefs/blob/master/master/topology.go#L2326:16
====================================================================================================
```

### Modifications
<!-- Describe the modifications you've done. -->

``` go
	DataPartitions := make([]*proto.DataPartitionResponse, 1)
	DataPartitions = append(DataPartitions, dpr)
	return w.updateDataPartitionByRsp(isInit, DataPartitions)
```
change to
```go
	DataPartitions := make([]*proto.DataPartitionResponse, 0, 1)
	DataPartitions = append(DataPartitions, dpr)
	return w.updateDataPartitionByRsp(isInit, DataPartitions)
```

the function `updateDataPartitionByRsp` has ever filter the DataPartitions nil element

```go
for index, partition := range DataPartitions {
		if partition == nil {
			log.LogErrorf("action[updateDataPartitionByRsp] index [%v] is nil", index)
			continue
		}
		...
```

the `peers` and `DataPartitions` is easy to check they are bugs, but  I don't know is it ok to modify the  `curEks`  (I can remove the code change part for `curEks`)


### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [x] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
