### PR TITLE
fix(clustermgr): fix kvDBPath argument for blobstore-cli cm listAllDB

### DIFF
--- a/blobstore/cli/clustermgr/list_all.go
+++ b/blobstore/cli/clustermgr/list_all.go
@@ -53,6 +53,7 @@ func addCmdListAllDB(cmd *grumble.Command) {
 		Args: func(a *grumble.Args) {
 			a.String("volumeDBPath", "volume db path")
 			a.String("normalDBPath", "normal db path")
+			a.String("kvDBPath", "kv db path")
 		},
 	}
 	cmd.AddCommand(command)
@@ -88,6 +89,13 @@ func cmdListAllDB(c *grumble.Context) error {
 	}
 	fmt.Println("list volumes: ")
 	err = listAllVolumes(volumeTbl)
+	if err != nil {
+		return err
+	}
+	fmt.Println()
+
+	fmt.Println("list volumeUnits: ")
+	err = listAllVolumeUnits(volumeTbl)
 	if err != nil {
 		return err
 	}
@@ -180,6 +188,17 @@ func listAllVolumes(volumeTbl *volumedb.VolumeTable) error {
 		}
 
 		data, err := json.Marshal(volInfo)
+		if err != nil {
+			return fmt.Errorf("json marshal failed, err: %s", err.Error())
+		}
+		fmt.Println(string(data))
+		return nil
+	})
+}
+
+func listAllVolumeUnits(volumeTbl *volumedb.VolumeTable) error {
+	return volumeTbl.RangeVolumeUnits(func(unitRecord *volumedb.VolumeUnitRecord) error {
+		data, err := json.Marshal(*unitRecord)
 		if err != nil {
 			return fmt.Errorf("json marshal failed, err: %s", err.Error())
 		}

--- a/blobstore/clustermgr/persistence/volumedb/volumetbl.go
+++ b/blobstore/clustermgr/persistence/volumedb/volumetbl.go
@@ -472,7 +472,7 @@ func (v *VolumeTable) PutVolumeUnits(units []*VolumeUnitRecord) (err error) {
 	return v.unitTbl.DoBatch(batch)
 }
 
-func (v *VolumeTable) RangeVolumeUnits(f func(unitRecord *VolumeUnitRecord)) (err error) {
+func (v *VolumeTable) RangeVolumeUnits(f func(unitRecord *VolumeUnitRecord) error) (err error) {
 	snap := v.unitTbl.NewSnapshot()
 	defer v.unitTbl.ReleaseSnapshot(snap)
 	iter := v.unitTbl.NewIterator(snap)

--- a/blobstore/clustermgr/persistence/volumedb/volumetbl_test.go
+++ b/blobstore/clustermgr/persistence/volumedb/volumetbl_test.go
@@ -414,8 +414,9 @@ func TestVolumeUnitTable_RangeVolumeUints(t *testing.T) {
 	require.NoError(t, err)
 
 	i := 0
-	volumeTable.RangeVolumeUnits(func(unitRecord *VolumeUnitRecord) {
+	volumeTable.RangeVolumeUnits(func(unitRecord *VolumeUnitRecord) error {
 		i++
+		return nil
 	})
 	require.Equal(t, len(units), i)
 }


### PR DESCRIPTION
```
Author: zhangjianwei <jianwei1216@qq.com>
Date:   Mon Jun 17 21:17:55 2024 +0800

    fix(clustermgr): fix kvDBPath argument for blobstore-cli cm listAllDB

    kvDBPath introduced in 4961b8437807269b57115f993a87a215561552c0,
    now command is:
    blobstore-cli cm listAllDB <volumeDBPath> <normalDBPath> <kvDBPath>

    Signed-off-by: zhangjianwei <jianwei1216@qq.com>
```


error command
```
blobstore-cli cm listAllDB /root/cubefs-amd64/cubefs/build/run/db1/volumedb /root/cubefs-amd64/cubefs/build/run/db1/normaldb
panic: missing argument value: arg 'kvDBPath' not registered

goroutine 1 [running]:
github.com/desertbit/grumble.ArgMap.String(0xc001b60a98, {0xef0ff3, 0x8})
	vendor/github.com/desertbit/grumble/argmap.go:46 +0x105
github.com/cubefs/cubefs/blobstore/cli/clustermgr.cmdListAllDB(0xc001b58ce0)
	blobstore/cli/clustermgr/list_all.go:64 +0xac
github.com/desertbit/grumble.(*App).RunCommand(0xc001b361c0, {0xc000020060, 0x4, 0xc00004a6b8})
	vendor/github.com/desertbit/grumble/app.go:270 +0x19f
github.com/desertbit/grumble.(*App).Run(0xc001b361c0)
	vendor/github.com/desertbit/grumble/app.go:370 +0x612
github.com/desertbit/grumble.Main(0xc0000001a0)
	vendor/github.com/desertbit/grumble/grumble.go:36 +0x19
main.main()
	blobstore/cli/cli/main.go:24 +0x25
```