### PR TITLE
fix(metanode): remove item may changed clone btree

### DIFF
--- a/util/btree/btree.go
+++ b/util/btree/btree.go
@@ -495,7 +495,7 @@ func (n *node) growChildAndRemove(i int, item Item, minItems int, typ toRemove) 
 		child := n.mutableChild(i)
 		// merge with right child
 		mergeItem := n.items.removeAt(i)
-		mergeChild := n.children.removeAt(i + 1)
+		mergeChild := n.children.removeAt(i + 1).mutableFor(n.cow)
 		child.items = append(child.items, mergeItem)
 		child.items = append(child.items, mergeChild.items...)
 		child.children = append(child.children, mergeChild.children...)

--- a/util/btree/btree_test.go
+++ b/util/btree/btree_test.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -788,5 +790,118 @@ func BenchmarkDeleteAndRestore(b *testing.B) {
 				tr.ReplaceOrInsert(v)
 			}
 		}
+	})
+}
+
+type inode struct {
+	ID    uint64
+	Nlink int
+}
+
+func (i *inode) Less(than Item) bool {
+	ino, ok := than.(*inode)
+	return ok && i.ID < ino.ID
+}
+
+func (i *inode) Copy() Item {
+	return &inode{
+		ID:    i.ID,
+		Nlink: i.Nlink,
+	}
+}
+
+const (
+	nodeTestCount  = 1000
+	nodeTotalCount = 2560000
+	interval       = 5
+)
+
+func TestBtree_NodeSplit(t *testing.T) {
+	tree := New(DefaultFreeListSize)
+	for index := 0; index < nodeTestCount; index++ {
+		ino := &inode{
+			ID:    uint64(index * interval),
+			Nlink: 2,
+		}
+		tree.ReplaceOrInsert(ino)
+	}
+
+	snapTree := tree.Clone()
+
+	for index := 0; index < nodeTotalCount; index++ {
+		ino := &inode{
+			ID:    uint64(index),
+			Nlink: 3,
+		}
+		if tree.Get(ino) != nil {
+			continue
+		}
+		tree.ReplaceOrInsert(ino)
+	}
+
+	for index := 0; index < nodeTestCount; index++ {
+		item := tree.CopyGet(&inode{ID: uint64(index * interval)})
+		item.(*inode).Nlink++
+	}
+
+	snapTree.AscendRange(nil, nil, func(i Item) bool {
+		if !assert.Equal(t, 2, i.(*inode).Nlink) {
+			t.Errorf("Snap tree mismatch, ID:%v, Nlink(expect:2, actual:%v)\n", i.(*inode).ID, i.(*inode).Nlink)
+		}
+		return true
+	})
+
+	tree.AscendRange(nil, nil, func(i Item) bool {
+		if !assert.Equal(t, 3, i.(*inode).Nlink) {
+			t.Errorf("Origin tree mismatch, ID:%v, Nlink(expect:3, actual:%v)\n", i.(*inode).ID, i.(*inode).Nlink)
+		}
+		return true
+	})
+}
+
+func TestBtree_NodeMerge(t *testing.T) {
+	tree := New(DefaultFreeListSize)
+	for index := 0; index < nodeTotalCount; index++ {
+		ino := &inode{
+			ID:    uint64(index),
+			Nlink: 2,
+		}
+		tree.ReplaceOrInsert(ino)
+	}
+
+	snapTree := tree.Clone()
+
+	for index := 0; index < nodeTotalCount-nodeTestCount; index++ {
+		if tree.Get(&inode{ID: uint64(index)}) == nil {
+			continue
+		}
+		tree.Delete(&inode{
+			ID: uint64(index),
+		})
+	}
+
+	for index := nodeTotalCount - nodeTestCount; index < nodeTotalCount; index++ {
+		ino := &inode{
+			ID: uint64(index),
+		}
+		item := tree.CopyGet(ino)
+		if item == nil {
+			continue
+		}
+		item.(*inode).Nlink++
+	}
+
+	snapTree.AscendRange(nil, nil, func(i Item) bool {
+		if !assert.Equal(t, 2, i.(*inode).Nlink) {
+			t.Errorf("Snap tree mismatch, ID:%v, Nlink(expect:2, actual:%v)\n", i.(*inode).ID, i.(*inode).Nlink)
+		}
+		return true
+	})
+
+	tree.AscendRange(nil, nil, func(i Item) bool {
+		if !assert.Equal(t, 3, i.(*inode).Nlink) {
+			t.Errorf("Origin tree mismatch, ID:%v, Nlink(expect:3, actual:%v)\n", i.(*inode).ID, i.(*inode).Nlink)
+		}
+		return true
 	})
 }


### PR DESCRIPTION
Fixes:  remove item may changed clone btree; (i+1) children has new cow but do not copy

### Motivation

bug flow
new btree t1
clone btree t2
remove item and need merge i + 1 children.
now, i + 1 children has new cow, but no copy;
t1 modiyf i + 1 children item, t2 follow modify (bug happen).

### Modifications
fix:
when merge i + 1 children, copy it

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

This change added unit tests 

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [x] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection

- [ ] `in-two-days`
- [ ] `weekly`
- [x] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
