### PR TITLE
fix(cubefs): cherry-pick repairs to master

### DIFF
--- a/authnode/server.go
+++ b/authnode/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cubefs/cubefs/util/config"
 	"github.com/cubefs/cubefs/util/cryptoutil"
 	"github.com/cubefs/cubefs/util/errors"
+	"github.com/cubefs/cubefs/util/exporter"
 	"github.com/cubefs/cubefs/util/log"
 )
 
@@ -225,7 +226,7 @@ func (m *Server) Start(cfg *config.Config) (err error) {
 		m.cluster.PKIKey.EnableHTTPS = false
 	}
 	m.authProxy = m.newAuthProxy()
-
+	exporter.RegistConsul(m.clusterName, cfg.GetString("role"), cfg)
 	m.cluster.scheduleTask()
 	m.startHTTPService()
 	m.wg.Add(1)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -61,6 +61,7 @@ func setupCommands(cfg *cmd.Config) *cobra.Command {
 	  $ echo 'source {path of cfs-cli.sh}' >>~/.bashrc
 	  $ source ~/.bashrc
 	`)
+			fmt.Fprintf(os.Stdout, "\n")
 		},
 	}
 

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -253,6 +253,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 	dataNodeSelector := ""
 	metaNodeSelector := ""
 	markBrokenDiskThreshold := ""
+	autoDpMetaRepair := ""
 	opMaxMpCntLimit := ""
 	dpRepairTimeout := ""
 	cmd := &cobra.Command{
@@ -271,6 +272,11 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 				}
 				markBrokenDiskThreshold = fmt.Sprintf("%v", val)
 			}
+			if autoDpMetaRepair != "" {
+				if _, err = strconv.ParseBool(autoDpMetaRepair); err != nil {
+					return
+				}
+			}
 
 			if dpRepairTimeout != "" {
 				var repairTimeout time.Duration
@@ -288,7 +294,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 			if err = client.AdminAPI().SetClusterParas(optDelBatchCount, optMarkDeleteRate, optDelWorkerSleepMs,
 				optAutoRepairRate, optLoadFactor, opMaxDpCntLimit, opMaxMpCntLimit, clientIDKey,
 				dataNodesetSelector, metaNodesetSelector,
-				dataNodeSelector, metaNodeSelector, markBrokenDiskThreshold, dpRepairTimeout); err != nil {
+				dataNodeSelector, metaNodeSelector, markBrokenDiskThreshold, autoDpMetaRepair, dpRepairTimeout); err != nil {
 				return
 			}
 			stdout("Cluster parameters has been set successfully. \n")
@@ -307,6 +313,7 @@ func newClusterSetParasCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&dataNodeSelector, CliFlagDataNodeSelector, "", "Set the node select policy(datanode) for cluster")
 	cmd.Flags().StringVar(&metaNodeSelector, CliFlagMetaNodeSelector, "", "Set the node select policy(metanode) for cluster")
 	cmd.Flags().StringVar(&markBrokenDiskThreshold, CliFlagMarkDiskBrokenThreshold, "", "Threshold to mark disk as broken")
+	cmd.Flags().StringVar(&autoDpMetaRepair, CliFlagAutoDpMetaRepair, "", "Enable or disable auto data partition meta repair")
 	cmd.Flags().StringVar(&dpRepairTimeout, CliFlagDpRepairTimeout, "", "Data partition repair timeout")
 	return cmd
 }

--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -134,6 +134,7 @@ const (
 	CliFlagMarkDiskBrokenThreshold = "markBrokenDiskThreshold"
 	CliFlagForce                   = "force"
 	CliFlagEnableCrossZone         = "cross-zone"
+	CliFlagDpRepairTimeout         = "dpRepairTimeout"
 
 	// CliFlagSetDataPartitionCount	= "count" use dp-count instead
 

--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -134,6 +134,7 @@ const (
 	CliFlagMarkDiskBrokenThreshold = "markBrokenDiskThreshold"
 	CliFlagForce                   = "force"
 	CliFlagEnableCrossZone         = "cross-zone"
+	CliFlagAutoDpMetaRepair        = "autoDpMetaRepair"
 	CliFlagDpRepairTimeout         = "dpRepairTimeout"
 
 	// CliFlagSetDataPartitionCount	= "count" use dp-count instead

--- a/cli/cmd/const.go
+++ b/cli/cmd/const.go
@@ -136,6 +136,7 @@ const (
 	CliFlagEnableCrossZone         = "cross-zone"
 	CliFlagAutoDpMetaRepair        = "autoDpMetaRepair"
 	CliFlagDpRepairTimeout         = "dpRepairTimeout"
+	CliFlagDpTimeout               = "dpTimeout"
 
 	// CliFlagSetDataPartitionCount	= "count" use dp-count instead
 

--- a/cli/cmd/datapartition.go
+++ b/cli/cmd/datapartition.go
@@ -278,6 +278,7 @@ The "reset" command will be released in next version`,
 
 func newDataPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command {
 	var raftForceDel bool
+	var decommissionType string
 	var clientIDKey string
 	cmd := &cobra.Command{
 		Use:   CliOpDecommission + " [ADDRESS] [DATA PARTITION ID]",
@@ -296,7 +297,7 @@ func newDataPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 			if err != nil {
 				return
 			}
-			if err := client.AdminAPI().DecommissionDataPartition(partitionID, address, raftForceDel, clientIDKey); err != nil {
+			if err := client.AdminAPI().DecommissionDataPartition(partitionID, address, raftForceDel, clientIDKey, decommissionType); err != nil {
 				stdout(fmt.Sprintf("failed:err(%v)\n", err.Error()))
 				return
 			}
@@ -310,6 +311,7 @@ func newDataPartitionDecommissionCmd(client *master.MasterClient) *cobra.Command
 		},
 	}
 	cmd.Flags().BoolVarP(&raftForceDel, "raftForceDel", "r", false, "true for raftForceDel")
+	cmd.Flags().StringVar(&decommissionType, "decommissionType", "1", "decommission type")
 	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }

--- a/cli/cmd/datapartition.go
+++ b/cli/cmd/datapartition.go
@@ -135,7 +135,7 @@ The "reset" command will be released in next version`,
 			for _, pid := range diagnosis.CorruptDataPartitionIDs {
 				var partition *proto.DataPartitionInfo
 				if partition, err = client.AdminAPI().GetDataPartition("", pid); err != nil {
-					err = fmt.Errorf("Partition not found, err:[%v] ", err)
+					err = fmt.Errorf("Partition not not found[%v], err:[%v] ", pid, err)
 					return
 				}
 				stdoutln(formatDataPartitionInfoRow(partition))
@@ -150,7 +150,7 @@ The "reset" command will be released in next version`,
 			for _, pid := range diagnosis.LackReplicaDataPartitionIDs {
 				var partition *proto.DataPartitionInfo
 				if partition, err = client.AdminAPI().GetDataPartition("", pid); err != nil {
-					err = fmt.Errorf("Partition not found, err:[%v] ", err)
+					err = fmt.Errorf("Partition not found[%v], err:[%v] ", pid, err)
 					return
 				}
 				if partition != nil {
@@ -182,7 +182,7 @@ The "reset" command will be released in next version`,
 			for _, dpId := range diagnosis.BadReplicaDataPartitionIDs {
 				var partition *proto.DataPartitionInfo
 				if partition, err = client.AdminAPI().GetDataPartition("", dpId); err != nil {
-					err = fmt.Errorf("Partition not found, err:[%v] ", err)
+					err = fmt.Errorf("Partition not found[%v], err:[%v] ", dpId, err)
 					return
 				}
 				if partition != nil {
@@ -200,7 +200,7 @@ The "reset" command will be released in next version`,
 				for _, dpId := range diagnosis.RepFileCountDifferDpIDs {
 					var partition *proto.DataPartitionInfo
 					if partition, err = client.AdminAPI().GetDataPartition("", dpId); err != nil {
-						err = fmt.Errorf("Partition not found, err:[%v] ", err)
+						err = fmt.Errorf("Partition not found[%v], err:[%v] ", dpId, err)
 						return
 					}
 					if partition != nil {
@@ -217,7 +217,7 @@ The "reset" command will be released in next version`,
 				for _, dpId := range diagnosis.RepUsedSizeDifferDpIDs {
 					var partition *proto.DataPartitionInfo
 					if partition, err = client.AdminAPI().GetDataPartition("", dpId); err != nil {
-						err = fmt.Errorf("Partition not found, err:[%v] ", err)
+						err = fmt.Errorf("Partition not found[%v], err:[%v] ", dpId, err)
 						return
 					}
 					if partition != nil {
@@ -243,7 +243,7 @@ The "reset" command will be released in next version`,
 			for _, pid := range diagnosis.ExcessReplicaDpIDs {
 				var partition *proto.DataPartitionInfo
 				if partition, err = client.AdminAPI().GetDataPartition("", pid); err != nil {
-					err = fmt.Errorf("Partition not found, err:[%v] ", err)
+					err = fmt.Errorf("Partition not found[%v], err:[%v] ", pid, err)
 					return
 				}
 				if partition != nil {
@@ -255,9 +255,13 @@ The "reset" command will be released in next version`,
 			stdoutln("[Partition with disk error replicas]:")
 			stdoutln(diskErrorReplicaPartitionInfoTableHeader)
 			for pid, infos := range diagnosis.DiskErrorDataPartitionInfos.DiskErrReplicas {
+				// DiskErrNotAssociatedWithPartition equals to 0
+				if pid == 0 {
+					continue
+				}
 				var partition *proto.DataPartitionInfo
 				if partition, err = client.AdminAPI().GetDataPartition("", pid); err != nil {
-					err = fmt.Errorf("Partition not found, err:[%v] ", err)
+					err = fmt.Errorf("Partition not found[%v], err:[%v] ", pid, err)
 					return
 				}
 				if partition != nil {

--- a/cli/cmd/disk.go
+++ b/cli/cmd/disk.go
@@ -157,7 +157,7 @@ func newDecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
 			if err = client.AdminAPI().DecommissionDisk(args[0], args[1]); err != nil {
 				return
 			}
-			stdout("Mark disk %v:%v to be decommissioned", args[0], args[1])
+			stdout("Mark disk %v:%v to be decommissioned\n", args[0], args[1])
 		},
 	}
 	return cmd
@@ -180,7 +180,7 @@ func newRecommissionDiskCmd(client *master.MasterClient) *cobra.Command {
 			if err = client.AdminAPI().RecommissionDisk(args[0], args[1]); err != nil {
 				return
 			}
-			stdout("Mark disk %v:%v to be recommissioned", args[0], args[1])
+			stdout("Mark disk %v:%v to be recommissioned\n", args[0], args[1])
 		},
 	}
 	return cmd

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -779,7 +779,7 @@ func formatDataNodeDetail(dn *proto.DataNodeInfo, rowTable bool) string {
 	sb.WriteString(fmt.Sprintf("  Report time         : %v\n", formatTimeToString(dn.ReportTime)))
 	sb.WriteString(fmt.Sprintf("  Partition count     : %v\n", dn.DataPartitionCount))
 	sb.WriteString(fmt.Sprintf("  Bad disks           : %v\n", dn.BadDisks))
-	sb.WriteString(fmt.Sprintf("  Decommissioned disks           : %v\n", dn.DecommissionedDisk))
+	sb.WriteString(fmt.Sprintf("  Decommissioned disks: %v\n", dn.DecommissionedDisk))
 	sb.WriteString(fmt.Sprintf("  Persist partitions  : %v\n", dn.PersistenceDataPartitions))
 	sb.WriteString(fmt.Sprintf("  Can alloc partition : %v\n", dn.CanAllocPartition))
 	sb.WriteString(fmt.Sprintf("  Max partition count : %v\n", dn.MaxDpCntLimit))

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -70,6 +70,7 @@ func formatClusterView(cv *proto.ClusterView, cn *proto.ClusterNodeInfo, cp *pro
 	sb.WriteString(fmt.Sprintf("  EbsAddr            : %v\n", cp.EbsAddr))
 	sb.WriteString(fmt.Sprintf("  LoadFactor         : %v\n", cn.LoadFactor))
 	sb.WriteString(fmt.Sprintf("  DpRepairTimeout    : %v\n", cv.DpRepairTimeout))
+	sb.WriteString(fmt.Sprintf("  DataPartitionTimeout : %v\n", cv.DpTimeout))
 	sb.WriteString(fmt.Sprintf("  volDeletionDelayTime : %v h\n", cv.VolDeletionDelayTimeHour))
 	sb.WriteString(fmt.Sprintf("  EnableAutoDecommission: %v\n", cv.EnableAutoDecommission))
 	sb.WriteString(fmt.Sprintf("  EnableAutoDpMetaRepair: %v\n", cv.EnableAutoDpMetaRepair))

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -69,6 +69,7 @@ func formatClusterView(cv *proto.ClusterView, cn *proto.ClusterNodeInfo, cp *pro
 	sb.WriteString(fmt.Sprintf("  Allow Mp Decomm    : %v\n", formatEnabledDisabled(!cv.ForbidMpDecommission)))
 	sb.WriteString(fmt.Sprintf("  EbsAddr            : %v\n", cp.EbsAddr))
 	sb.WriteString(fmt.Sprintf("  LoadFactor         : %v\n", cn.LoadFactor))
+	sb.WriteString(fmt.Sprintf("  DpRepairTimeout    : %v\n", cv.DpRepairTimeout))
 	sb.WriteString(fmt.Sprintf("  volDeletionDelayTime : %v h\n", cv.VolDeletionDelayTimeHour))
 	sb.WriteString(fmt.Sprintf("  EnableAutoDecommission: %v\n", cv.EnableAutoDecommission))
 	sb.WriteString(fmt.Sprintf("  MarkDiskBrokenThreshold : %v\n", strutil.FormatPercent(cv.MarkDiskBrokenThreshold)))

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -783,6 +783,7 @@ func formatDataNodeDetail(dn *proto.DataNodeInfo, rowTable bool) string {
 	sb.WriteString(fmt.Sprintf("  Bad disks           : %v\n", dn.BadDisks))
 	sb.WriteString(fmt.Sprintf("  Decommissioned disks: %v\n", dn.DecommissionedDisk))
 	sb.WriteString(fmt.Sprintf("  Persist partitions  : %v\n", dn.PersistenceDataPartitions))
+	sb.WriteString(fmt.Sprintf("  Backup partitions  : %v\n", dn.BackupDataPartitions))
 	sb.WriteString(fmt.Sprintf("  Can alloc partition : %v\n", dn.CanAllocPartition))
 	sb.WriteString(fmt.Sprintf("  Max partition count : %v\n", dn.MaxDpCntLimit))
 	sb.WriteString(fmt.Sprintf("  CpuUtil             : %.1f%%\n", dn.CpuUtil))

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -72,7 +72,7 @@ func formatClusterView(cv *proto.ClusterView, cn *proto.ClusterNodeInfo, cp *pro
 	sb.WriteString(fmt.Sprintf("  DpRepairTimeout    : %v\n", cv.DpRepairTimeout))
 	sb.WriteString(fmt.Sprintf("  volDeletionDelayTime : %v h\n", cv.VolDeletionDelayTimeHour))
 	sb.WriteString(fmt.Sprintf("  EnableAutoDecommission: %v\n", cv.EnableAutoDecommission))
-	sb.WriteString(fmt.Sprintf("  DisableAutoDpMetaRepair: %v\n", cv.DisableAutoDpMetaRepair))
+	sb.WriteString(fmt.Sprintf("  EnableAutoDpMetaRepair: %v\n", cv.EnableAutoDpMetaRepair))
 	sb.WriteString(fmt.Sprintf("  MarkDiskBrokenThreshold : %v\n", strutil.FormatPercent(cv.MarkDiskBrokenThreshold)))
 	sb.WriteString(fmt.Sprintf("  DecommissionDiskLimit: %v\n", cv.DecommissionDiskLimit))
 	return sb.String()
@@ -175,6 +175,7 @@ func formatSimpleVolView(svv *proto.SimpleVolView) string {
 	sb.WriteString(fmt.Sprintf("  DisableAuditLog                 : %v\n", svv.DisableAuditLog))
 	sb.WriteString(fmt.Sprintf("  TrashInterval                   : %v\n", time.Duration(svv.TrashInterval)*time.Minute))
 	sb.WriteString(fmt.Sprintf("  DpRepairBlockSize               : %v\n", strutil.FormatSize(svv.DpRepairBlockSize)))
+	sb.WriteString(fmt.Sprintf("  EnableAutoDpMetaRepair          : %v\n", svv.EnableAutoDpMetaRepair))
 	sb.WriteString(fmt.Sprintf("  Quota                           : %v\n", formatEnabledDisabled(svv.EnableQuota)))
 	if svv.Forbidden && svv.Status == 1 {
 		sb.WriteString(fmt.Sprintf("  DeleteDelayTime                 : %v\n", time.Until(svv.DeleteExecTime)))

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -72,6 +72,7 @@ func formatClusterView(cv *proto.ClusterView, cn *proto.ClusterNodeInfo, cp *pro
 	sb.WriteString(fmt.Sprintf("  DpRepairTimeout    : %v\n", cv.DpRepairTimeout))
 	sb.WriteString(fmt.Sprintf("  volDeletionDelayTime : %v h\n", cv.VolDeletionDelayTimeHour))
 	sb.WriteString(fmt.Sprintf("  EnableAutoDecommission: %v\n", cv.EnableAutoDecommission))
+	sb.WriteString(fmt.Sprintf("  DisableAutoDpMetaRepair: %v\n", cv.DisableAutoDpMetaRepair))
 	sb.WriteString(fmt.Sprintf("  MarkDiskBrokenThreshold : %v\n", strutil.FormatPercent(cv.MarkDiskBrokenThreshold)))
 	sb.WriteString(fmt.Sprintf("  DecommissionDiskLimit: %v\n", cv.DecommissionDiskLimit))
 	return sb.String()

--- a/cli/cmd/fmt.go
+++ b/cli/cmd/fmt.go
@@ -823,6 +823,8 @@ func formatNodeSetView(ns *proto.NodeSetStatInfo) string {
 	sb.WriteString(fmt.Sprintf("NodeSet ID:       %v\n", ns.ID))
 	sb.WriteString(fmt.Sprintf("Capacity:         %v\n", ns.Capacity))
 	sb.WriteString(fmt.Sprintf("Zone:             %v\n", ns.Zone))
+	sb.WriteString(fmt.Sprintf("CanAllocDataNode: %v\n", ns.CanAllocDataNodeCnt))
+	sb.WriteString(fmt.Sprintf("CanAllocMetaNode: %v\n", ns.CanAllocMetaNodeCnt))
 	sb.WriteString(fmt.Sprintf("DataNodeSelector: %v\n", ns.DataNodeSelector))
 	sb.WriteString(fmt.Sprintf("MetaNodeSelector: %v\n", ns.MetaNodeSelector))
 	var dataTotal, dataUsed, dataAvail, metaTotal, metaUsed, metaAvail uint64

--- a/cli/cmd/nodeset.go
+++ b/cli/cmd/nodeset.go
@@ -59,11 +59,11 @@ func newNodeSetListCmd(client *master.MasterClient) *cobra.Command {
 			if nodeSetStats, err = client.AdminAPI().ListNodeSets(zoneName); err != nil {
 				return
 			}
-			zoneTablePattern := "%-6v %-6v %-12v %-10v %-10v\n"
-			stdout(zoneTablePattern, "ID", "Cap", "Zone", "MetaNum", "DataNum")
-			zoneDataPattern := "%-6v %-6v %-12v %-10v %-10v\n"
+			zoneTablePattern := "%-6v %-6v %-12v %-10v %-12v %-10v %-12v\n"
+			stdout(zoneTablePattern, "ID", "Cap", "Zone", "MetaNum", "CanAllocMeta", "DataNum", "CanAllocData")
+			zoneDataPattern := "%-6v %-6v %-12v %-10v %-12v %-10v %-12v\n"
 			for _, nodeSet := range nodeSetStats {
-				stdout(zoneDataPattern, nodeSet.ID, nodeSet.Capacity, nodeSet.Zone, nodeSet.MetaNodeNum, nodeSet.DataNodeNum)
+				stdout(zoneDataPattern, nodeSet.ID, nodeSet.Capacity, nodeSet.Zone, nodeSet.MetaNodeNum, nodeSet.CanAllocMetaNodeCnt, nodeSet.DataNodeNum, nodeSet.CanAllocDataNodeCnt)
 			}
 		},
 	}

--- a/cli/cmd/vol.go
+++ b/cli/cmd/vol.go
@@ -292,6 +292,7 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 	var optReplicaNum string
 	var optDeleteLockTime int64
 	var optEnableQuota string
+	var optEnableDpAutoMetaRepair string
 	confirmString := strings.Builder{}
 	var vv *proto.SimpleVolView
 	cmd := &cobra.Command{
@@ -582,8 +583,23 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 					formatEnabledDisabled(vv.DpReadOnlyWhenVolFull), formatEnabledDisabled(enable)))
 				vv.DpReadOnlyWhenVolFull = enable
 			} else {
-				confirmString.WriteString(fmt.Sprintf("  Vol readonly full : %v\n",
+				confirmString.WriteString(fmt.Sprintf("  Vol readonly when full : %v\n",
 					formatEnabledDisabled(vv.DpReadOnlyWhenVolFull)))
+			}
+			if optEnableDpAutoMetaRepair != "" {
+				enable := false
+				if enable, err = strconv.ParseBool(optEnableDpAutoMetaRepair); err != nil {
+					return
+				}
+				if vv.EnableAutoDpMetaRepair != enable {
+					isChange = true
+					confirmString.WriteString(fmt.Sprintf("  EnableAutoDpMetaRepair : %v -> %v\n", vv.EnableAutoDpMetaRepair, enable))
+					vv.EnableAutoDpMetaRepair = enable
+				} else {
+					confirmString.WriteString(fmt.Sprintf("  EnableAutoDpMetaRepair : %v", vv.EnableAutoDpMetaRepair))
+				}
+			} else {
+				confirmString.WriteString(fmt.Sprintf("  EnableAutoDpMetaRepair : %v", vv.EnableAutoDpMetaRepair))
 			}
 
 			if err != nil {
@@ -644,6 +660,7 @@ func newVolUpdateCmd(client *master.MasterClient) *cobra.Command {
 	cmd.Flags().StringVar(&optEnableQuota, CliFlagEnableQuota, "", "Enable quota")
 	cmd.Flags().Int64Var(&optDeleteLockTime, CliFlagDeleteLockTime, -1, "Specify delete lock time[Unit: hour] for volume")
 	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
+	cmd.Flags().StringVar(&optEnableDpAutoMetaRepair, CliFlagAutoDpMetaRepair, "", "Enable or disable dp auto meta repair")
 
 	return cmd
 }

--- a/client/fs/file.go
+++ b/client/fs/file.go
@@ -404,14 +404,6 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.Wri
 
 	defer func() {
 		f.super.ic.Delete(ino)
-
-		if log.EnableDebug() && err == nil {
-			expectedSize := req.Offset + int64(len(req.Data))
-			streamSize, _, _ := f.super.ec.FileSize(ino)
-			if streamSize < int(expectedSize) {
-				log.LogErrorf("[Write] ino(%v) uncorrect write, expected size(%v), actual size(%v)", ino, expectedSize, streamSize)
-			}
-		}
 	}()
 
 	var waitForFlush bool

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -83,11 +83,11 @@ const (
 )
 
 const (
-	LoggerDir             = "client"
-	LoggerPrefix          = "client"
-	LoggerOutput          = "output.log"
-	ModuleName            = "fuseclient"
-	ConfigKeyExporterPort = "exporterKey"
+	// LoggerDir             = "client"
+	LoggerPrefix = "client"
+	LoggerOutput = "output.log"
+	ModuleName   = "fuseclient"
+	// ConfigKeyExporterPort = "exporterKey"
 
 	ControlCommandSetRate      = "/rate/set"
 	ControlCommandGetRate      = "/rate/get"

--- a/client/fuse.go
+++ b/client/fuse.go
@@ -515,6 +515,9 @@ func main() {
 
 	exporter.Init(ModuleName, cfg)
 	exporter.RegistConsul(super.ClusterName(), ModuleName, cfg)
+	metric := exporter.NewVersionMetrics(ModuleName)
+	defer metric.Stop()
+	go metric.Start()
 
 	err = log.OutputPid(opt.Logpath, ModuleName)
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/config"
 	"github.com/cubefs/cubefs/util/errors"
+	"github.com/cubefs/cubefs/util/exporter"
 	"github.com/cubefs/cubefs/util/log"
 	sysutil "github.com/cubefs/cubefs/util/sys"
 	"github.com/cubefs/cubefs/util/ump"
@@ -339,6 +340,10 @@ func main() {
 	}
 
 	interceptSignal(server)
+	exporter.Init(role, cfg)
+	versionMetric := exporter.NewVersionMetrics(role)
+	go versionMetric.Start()
+	defer versionMetric.Stop()
 	err = server.Start(cfg)
 	if err != nil {
 		log.LogFlush()

--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -843,7 +843,19 @@ func (dp *DataPartition) streamRepairExtent(remoteExtentInfo *storage.ExtentInfo
 				}
 			} else {
 				log.LogDebugf("streamRepairExtent reply size %v, currFixoffset %v, reply %v ", reply.GetSize(), currFixOffset, reply)
-				_, err = store.Write(uint64(localExtentInfo.FileID), int64(currFixOffset), int64(reply.GetSize()), reply.GetData(), reply.GetCRC(), wType, BufferWrite, isEmptyResponse, true, request.GetOpcode() == proto.OpBackupWrite)
+				param := &storage.WriteParam{
+					ExtentID:      uint64(localExtentInfo.FileID),
+					Offset:        int64(currFixOffset),
+					Size:          int64(reply.GetSize()),
+					Data:          reply.GetData(),
+					Crc:           reply.GetCRC(),
+					WriteType:     wType,
+					IsSync:        BufferWrite,
+					IsHole:        isEmptyResponse,
+					IsRepair:      true,
+					IsBackupWrite: request.GetOpcode() == proto.OpBackupWrite,
+				}
+				_, err = store.Write(param)
 			}
 			// log.LogDebugf("streamRepairExtent reply size %v, currFixoffset %v, reply %v err %v", reply.Size, currFixOffset, reply, err)
 			// write to the local extent file

--- a/datanode/data_partition_repair.go
+++ b/datanode/data_partition_repair.go
@@ -430,7 +430,9 @@ func (dp *DataPartition) notifyFollower(wg *sync.WaitGroup, index int, members [
 	defer func() {
 		wg.Done()
 		if err == nil {
-			log.LogInfof(ActionNotifyFollowerToRepair+" to host(%v) Partition(%v) done", target, dp.partitionID)
+			log.LogInfof(ActionNotifyFollowerToRepair+" to host(%v) Partition(%v) type(%v) ToBeCreated(%v) ToBeRepaired(%v) done",
+				target, dp.partitionID, members[index].TaskType, len(members[index].ExtentsToBeCreated),
+				len(members[index].ExtentsToBeRepaired))
 		} else {
 			log.LogErrorf(ActionNotifyFollowerToRepair+" to host(%v) Partition(%v) failed, err(%v)", target, dp.partitionID, err)
 		}

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -690,7 +690,6 @@ func (dp *DataPartition) ForceLoadHeader() {
 func (dp *DataPartition) RemoveAll(decommissionType uint32, force, isSpecialReplica bool) (err error) {
 	dp.persistMetaMutex.Lock()
 	defer dp.persistMetaMutex.Unlock()
-
 	if force && isSpecialReplica && decommissionType == proto.AutoDecommission {
 		originalPath := dp.Path()
 		parent := path.Dir(originalPath)
@@ -754,6 +753,7 @@ func (dp *DataPartition) PersistMetadata() (err error) {
 	if metaData, err = json.Marshal(md); err != nil {
 		return
 	}
+	// persist meta can be failed with  io error
 	if _, err = metadataFile.Write(metaData); err != nil {
 		return
 	}
@@ -1481,8 +1481,8 @@ func (dp *DataPartition) isDecommissionRecovering() bool {
 
 func (dp *DataPartition) incDiskErrCnt() {
 	diskErrCnt := atomic.AddUint64(&dp.diskErrCnt, 1)
-	dp.PersistMetadata()
-	log.LogWarnf("[incDiskErrCnt]: dp(%v) disk err count:%v", dp.partitionID, diskErrCnt)
+	err := dp.PersistMetadata()
+	log.LogWarnf("[incDiskErrCnt]: dp(%v) disk err count:%v, err %v", dp.partitionID, diskErrCnt, err)
 }
 
 func (dp *DataPartition) getDiskErrCnt() uint64 {

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -1470,13 +1470,15 @@ func (dp *DataPartition) reload(s *SpaceManager) error {
 	disk := dp.disk
 	rootDir := dp.path
 	log.LogDebugf("data partition disk %v rootDir %v", disk, rootDir)
-	s.partitionMutex.Lock()
-	delete(s.partitions, dp.partitionID)
-	s.partitionMutex.Unlock()
+	s.DetachDataPartition(dp.partitionID)
 	dp.Stop()
 	dp.Disk().DetachDataPartition(dp)
 	log.LogDebugf("data partition %v is detached", dp.partitionID)
-	_, err := LoadDataPartition(rootDir, disk)
+	dp2, err := LoadDataPartition(rootDir, disk)
+	if err != nil {
+		return err
+	}
+	s.AttachPartition(dp2)
 	return err
 }
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -301,7 +301,7 @@ func LoadDataPartition(partitionDir string, disk *Disk) (dp *DataPartition, err 
 	}
 	if err != nil {
 		log.LogErrorf("PartitionID(%v) start raft err(%v)..", dp.info(), err)
-		// disk.space.DetachDataPartition(dp.partitionID)
+		disk.space.DetachDataPartition(dp.partitionID)
 		return
 	}
 

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -687,10 +687,10 @@ func (dp *DataPartition) ForceLoadHeader() {
 	dp.loadExtentHeaderStatus = FinishLoadDataPartitionExtentHeader
 }
 
-func (dp *DataPartition) RemoveAll(decommissionType uint32, force, isSpecialReplica bool) (err error) {
+func (dp *DataPartition) RemoveAll(decommissionType uint32, force bool) (err error) {
 	dp.persistMetaMutex.Lock()
 	defer dp.persistMetaMutex.Unlock()
-	if force && isSpecialReplica && decommissionType == proto.AutoDecommission {
+	if force && decommissionType == proto.AutoDecommission {
 		originalPath := dp.Path()
 		parent := path.Dir(originalPath)
 		fileName := path.Base(originalPath)
@@ -1497,12 +1497,11 @@ func (dp *DataPartition) reload(s *SpaceManager) error {
 	dp.Stop()
 	dp.Disk().DetachDataPartition(dp)
 	log.LogDebugf("data partition %v is detached", dp.partitionID)
-	dp2, err := LoadDataPartition(rootDir, disk)
+	_, err := LoadDataPartition(rootDir, disk)
 	if err != nil {
 		return err
 	}
-	s.AttachPartition(dp2)
-	return err
+	return nil
 }
 
 func (dp *DataPartition) resetDiskErrCnt() {

--- a/datanode/partition.go
+++ b/datanode/partition.go
@@ -638,6 +638,7 @@ func (dp *DataPartition) Stop() {
 		log.LogInfo(msg)
 	}()
 	dp.stopOnce.Do(func() {
+		log.LogInfof("action[Stop]:dp(%v) stop once", dp.info())
 		if dp.stopC != nil {
 			close(dp.stopC)
 		}
@@ -690,6 +691,7 @@ func (dp *DataPartition) RemoveAll() (err error) {
 	defer dp.persistMetaMutex.Unlock()
 
 	err = os.RemoveAll(dp.Path())
+	log.LogInfof("action[Stop]:dp(%v) remove %v", dp.info(), dp.Path())
 	return
 }
 
@@ -1491,4 +1493,25 @@ func (dp *DataPartition) hasNodeIDConflict(addr string, nodeID uint64) error {
 		}
 	}
 	return nil
+}
+
+func (dp *DataPartition) info() string {
+	return fmt.Sprintf("id(%v)_disk(%v)_type(%v)", dp.partitionID, dp.disk.Path, dp.partitionType)
+}
+
+func (dp *DataPartition) fetchDataNodesFromMaster() (nodes []proto.NodeView, err error) {
+	retry := 0
+	for {
+		if nodes, err = MasterClient.AdminAPI().GetClusterDataNodes(); err != nil {
+			retry++
+			if retry > 5 {
+				return
+			}
+		} else {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return
 }

--- a/datanode/partition_op_by_raft.go
+++ b/datanode/partition_op_by_raft.go
@@ -282,7 +282,19 @@ func (dp *DataPartition) ApplyRandomWrite(command []byte, raftApplyID uint64) (r
 		}
 
 		dp.disk.limitWrite.Run(int(opItem.size), func() {
-			respStatus, err = dp.ExtentStore().Write(opItem.extentID, opItem.offset, opItem.size, opItem.data, opItem.crc, writeType, syncWrite, false, false, opItem.opcode == proto.OpBackupWrite)
+			param := &storage.WriteParam{
+				ExtentID:      uint64(opItem.extentID),
+				Offset:        int64(opItem.offset),
+				Size:          opItem.size,
+				Data:          opItem.data,
+				Crc:           opItem.crc,
+				WriteType:     writeType,
+				IsSync:        syncWrite,
+				IsHole:        false,
+				IsRepair:      false,
+				IsBackupWrite: opItem.opcode == proto.OpBackupWrite,
+			}
+			respStatus, err = dp.ExtentStore().Write(param)
 		})
 		if err == nil || err == storage.ErrStoreAlreadyClosed {
 			break

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -348,9 +348,11 @@ func (dp *DataPartition) StartRaftAfterRepair(isLoad bool) {
 			}
 
 			if err := dp.StartRaft(isLoad); err != nil {
-				log.LogErrorf("action[StartRaftAfterRepair] PartitionID(%v) start raft err(%v). Retry after 20s.", dp.partitionID, err)
-				timer.Reset(5 * time.Second)
-				continue
+				log.LogErrorf("action[StartRaftAfterRepair] dp(%v) start raft err(%v)", dp.info(), err)
+				dp.DataPartitionCreateType = proto.NormalCreateDataPartition
+				dp.decommissionRepairProgress = float64(1)
+				dp.PersistMetadata()
+				return
 			}
 			// start raft
 			dp.DataPartitionCreateType = proto.NormalCreateDataPartition

--- a/datanode/partition_raft.go
+++ b/datanode/partition_raft.go
@@ -252,8 +252,12 @@ func (dp *DataPartition) StartRaftLoggingSchedule() {
 					dp.checkIsDiskError(err, WriteFlag)
 					continue
 				}
-				dp.raftPartition.Truncate(dp.minAppliedID)
-				dp.lastTruncateID = dp.minAppliedID
+				truncIndex := dp.minAppliedID
+				if truncIndex > appliedID {
+					truncIndex = appliedID
+				}
+				dp.raftPartition.Truncate(truncIndex)
+				dp.lastTruncateID = truncIndex
 				if err := dp.PersistMetadata(); err != nil {
 					log.LogErrorf("[StartRaftLoggingSchedule] partition [%v] persist metadata during scheduled truncate raft log failed: %v", dp.partitionID, err)
 					truncateRaftLogTimer.Reset(time.Minute)

--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -74,7 +74,7 @@ func (dp *DataPartition) ApplyMemberChange(confChange *raftproto.ConfChange, ind
 		} else {
 			err = fmt.Errorf("[ApplyMemberChange] ApplyID(%v) Partition(%v) apply err(%v)]", index, dp.partitionID, err)
 			exporter.Warning(err.Error())
-			panic(newRaftApplyError(err))
+			// panic(newRaftApplyError(err))
 		}
 	}(index)
 
@@ -128,18 +128,13 @@ func (dp *DataPartition) ApplyMemberChange(confChange *raftproto.ConfChange, ind
 	}
 	if err != nil {
 		log.LogErrorf("action[ApplyMemberChange] dp(%v) type(%v) err(%v) index(%v).", dp.partitionID, confChange.Type, err, index)
-		if IsDiskErr(err.Error()) {
-			panic(newRaftApplyError(err))
-		}
 		return
 	}
 	if isUpdated {
 		dp.DataPartitionCreateType = proto.NormalCreateDataPartition
 		if err = dp.PersistMetadata(); err != nil {
 			log.LogErrorf("action[ApplyMemberChange] dp(%v) PersistMetadata err(%v).", dp.partitionID, err)
-			if IsDiskErr(err.Error()) {
-				panic(newRaftApplyError(err))
-			}
+			dp.checkIsDiskError(err, WriteFlag)
 			return
 		}
 	}

--- a/datanode/partition_raftfsm.go
+++ b/datanode/partition_raftfsm.go
@@ -205,4 +205,5 @@ func (dp *DataPartition) Del(key interface{}) (interface{}, error) {
 func (dp *DataPartition) uploadApplyID(applyID uint64) {
 	log.LogDebugf("[uploadApplyID] dp(%v) upload apply id(%v)", dp.partitionID, applyID)
 	atomic.StoreUint64(&dp.appliedID, applyID)
+	atomic.StoreUint64(&dp.extentStore.ApplyId, applyID)
 }

--- a/datanode/server.go
+++ b/datanode/server.go
@@ -232,7 +232,6 @@ func doStart(server common.Server, cfg *config.Config) (err error) {
 		return
 	}
 
-	exporter.Init(ModuleName, cfg)
 	s.registerMetrics()
 	s.register(cfg)
 

--- a/datanode/server_handler.go
+++ b/datanode/server_handler.go
@@ -767,3 +767,171 @@ func (s *DataNode) markDiskBroken(w http.ResponseWriter, r *http.Request) {
 	}
 	s.buildSuccessResp(w, "success")
 }
+
+func (s *DataNode) setDiskExtentReadLimitStatus(w http.ResponseWriter, r *http.Request) {
+	const (
+		paramStatus = "status"
+	)
+	if err := r.ParseForm(); err != nil {
+		err = fmt.Errorf("parse form fail: %v", err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	status, err := strconv.ParseBool(r.FormValue(paramStatus))
+	if err != nil {
+		err = fmt.Errorf("parse param %v fail: %v", paramStatus, err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	for _, disk := range s.space.disks {
+		disk.SetExtentRepairReadLimitStatus(status)
+	}
+	s.buildSuccessResp(w, "success")
+}
+
+type DiskExtentReadLimitInfo struct {
+	DiskPath              string `json:"diskPath"`
+	ExtentReadLimitStatus bool   `json:"extentReadLimitStatus"`
+	Dp                    uint64 `json:"dp"`
+}
+
+type DiskExtentReadLimitStatusResponse struct {
+	Infos []DiskExtentReadLimitInfo `json:"infos"`
+}
+
+func (s *DataNode) queryDiskExtentReadLimitStatus(w http.ResponseWriter, r *http.Request) {
+	resp := &DiskExtentReadLimitStatusResponse{}
+	for _, disk := range s.space.disks {
+		status, dp := disk.QueryExtentRepairReadLimitStatus()
+		resp.Infos = append(resp.Infos, DiskExtentReadLimitInfo{DiskPath: disk.Path, ExtentReadLimitStatus: status, Dp: dp})
+	}
+	s.buildSuccessResp(w, resp)
+}
+
+func (s *DataNode) detachDataPartition(w http.ResponseWriter, r *http.Request) {
+	const (
+		paramID = "id"
+	)
+	if err := r.ParseForm(); err != nil {
+		err = fmt.Errorf("parse form fail: %v", err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	partitionID, err := strconv.ParseUint(r.FormValue(paramID), 10, 64)
+	if err != nil {
+		err = fmt.Errorf("parse param %v fail: %v", paramID, err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	partition := s.space.Partition(partitionID)
+	if partition == nil {
+		s.buildFailureResp(w, http.StatusBadRequest, "partition not exist")
+		return
+	}
+	// store disk path and root of dp
+	disk := partition.disk
+	rootDir := partition.path
+	log.LogDebugf("data partition disk %v rootDir %v", disk, rootDir)
+
+	s.space.partitionMutex.Lock()
+	delete(s.space.partitions, partitionID)
+	s.space.partitionMutex.Unlock()
+	partition.Stop()
+	partition.Disk().DetachDataPartition(partition)
+
+	log.LogDebugf("data partition %v is detached", partitionID)
+	s.buildSuccessResp(w, "success")
+}
+
+func (s *DataNode) releaseDiskExtentReadLimitToken(w http.ResponseWriter, r *http.Request) {
+	const (
+		paramDisk = "disk"
+	)
+	if err := r.ParseForm(); err != nil {
+		err = fmt.Errorf("parse form fail: %v", err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	diskPath := r.FormValue(paramDisk)
+	// store disk path and root of dp
+	disk, err := s.space.GetDisk(diskPath)
+	if err != nil {
+		log.LogErrorf("action[loadDataPartition] disk(%v) is not found err(%v).", diskPath, err)
+		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf("disk %v is not found", diskPath))
+		return
+	}
+	disk.ReleaseReadExtentToken()
+	s.buildSuccessResp(w, "success")
+}
+
+func (s *DataNode) loadDataPartition(w http.ResponseWriter, r *http.Request) {
+	const (
+		paramID   = "id"
+		paramDisk = "disk"
+	)
+	if err := r.ParseForm(); err != nil {
+		err = fmt.Errorf("parse form fail: %v", err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	partitionID, err := strconv.ParseUint(r.FormValue(paramID), 10, 64)
+	if err != nil {
+		err = fmt.Errorf("parse param %v fail: %v", paramID, err)
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	partition := s.space.Partition(partitionID)
+	if partition != nil {
+		s.buildFailureResp(w, http.StatusBadRequest, "partition is already loaded")
+		return
+	}
+	diskPath := r.FormValue(paramDisk)
+	// store disk path and root of dp
+	disk, err := s.space.GetDisk(diskPath)
+	if err != nil {
+		log.LogErrorf("action[loadDataPartition] disk(%v) is not found err(%v).", diskPath, err)
+		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf("disk %v is not found", diskPath))
+		return
+	}
+
+	fileInfoList, err := os.ReadDir(disk.Path)
+	if err != nil {
+		log.LogErrorf("action[loadDataPartition] read dir(%v) err(%v).", disk.Path, err)
+		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf(" read dir(%v) err(%v)", disk.Path, err))
+		return
+	}
+	rootDir := ""
+	for _, fileInfo := range fileInfoList {
+		filename := fileInfo.Name()
+		if !disk.isPartitionDir(filename) {
+			if disk.isExpiredPartitionDir(filename) {
+			}
+			continue
+		}
+
+		if id, _, err := unmarshalPartitionName(filename); err != nil {
+			log.LogErrorf("action[RestorePartition] unmarshal partitionName(%v) from disk(%v) err(%v) ",
+				filename, disk.Path, err.Error())
+			continue
+		} else {
+			if id == partitionID {
+				rootDir = filename
+			}
+		}
+	}
+	if rootDir == "" {
+		log.LogErrorf("action[loadDataPartition] dp root not found in dir(%v) .", disk.Path)
+		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf("dp root not found in dir(%v)", disk.Path))
+		return
+	}
+
+	log.LogDebugf("data partition disk %v rootDir %v", disk, rootDir)
+
+	dp, err := LoadDataPartition(path.Join(diskPath, rootDir), disk)
+	if err != nil {
+		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
+	} else {
+		s.space.AttachPartition(dp)
+		s.buildSuccessResp(w, "success")
+	}
+}

--- a/datanode/server_handler.go
+++ b/datanode/server_handler.go
@@ -557,148 +557,6 @@ func (s *DataNode) reloadDataPartition(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *DataNode) setDiskExtentReadLimitStatus(w http.ResponseWriter, r *http.Request) {
-	var status common.Bool
-	if err := parseArgs(r, status.Status()); err != nil {
-		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	for _, disk := range s.space.disks {
-		disk.SetExtentRepairReadLimitStatus(status.V)
-	}
-	s.buildSuccessResp(w, "success")
-}
-
-type DiskExtentReadLimitInfo struct {
-	DiskPath              string `json:"diskPath"`
-	ExtentReadLimitStatus bool   `json:"extentReadLimitStatus"`
-	Dp                    uint64 `json:"dp"`
-}
-
-type DiskExtentReadLimitStatusResponse struct {
-	Infos []DiskExtentReadLimitInfo `json:"infos"`
-}
-
-func (s *DataNode) queryDiskExtentReadLimitStatus(w http.ResponseWriter, r *http.Request) {
-	resp := &DiskExtentReadLimitStatusResponse{}
-	for _, disk := range s.space.disks {
-		status, dp := disk.QueryExtentRepairReadLimitStatus()
-		resp.Infos = append(resp.Infos, DiskExtentReadLimitInfo{DiskPath: disk.Path, ExtentReadLimitStatus: status, Dp: dp})
-	}
-	s.buildSuccessResp(w, resp)
-}
-
-func (s *DataNode) detachDataPartition(w http.ResponseWriter, r *http.Request) {
-	var pid common.Uint
-	if err := parseArgs(r, pid.ID()); err != nil {
-		err = fmt.Errorf("parse form fail: %v", err)
-		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	partitionID := pid.V
-
-	partition := s.space.Partition(partitionID)
-	if partition == nil {
-		s.buildFailureResp(w, http.StatusBadRequest, "partition not exist")
-		return
-	}
-	// store disk path and root of dp
-	disk := partition.disk
-	rootDir := partition.path
-	log.LogDebugf("data partition disk %v rootDir %v", disk, rootDir)
-
-	s.space.partitionMutex.Lock()
-	delete(s.space.partitions, partitionID)
-	s.space.partitionMutex.Unlock()
-	partition.Stop()
-	partition.Disk().DetachDataPartition(partition)
-
-	log.LogDebugf("data partition %v is detached", partitionID)
-	s.buildSuccessResp(w, "success")
-}
-
-func (s *DataNode) releaseDiskExtentReadLimitToken(w http.ResponseWriter, r *http.Request) {
-	var diskParam common.String
-	if err := parseArgs(r, diskParam.Disk()); err != nil {
-		err = fmt.Errorf("parse form fail: %v", err)
-		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	diskPath := diskParam.V
-	// store disk path and root of dp
-	disk, err := s.space.GetDisk(diskPath)
-	if err != nil {
-		log.LogErrorf("action[loadDataPartition] disk(%v) is not found err(%v).", diskPath, err)
-		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf("disk %v is not found", diskPath))
-		return
-	}
-	disk.ReleaseReadExtentToken()
-	s.buildSuccessResp(w, "success")
-}
-
-func (s *DataNode) loadDataPartition(w http.ResponseWriter, r *http.Request) {
-	var pid common.Uint
-	var diskParam common.String
-	if err := parseArgs(r, pid.ID(), diskParam.Disk()); err != nil {
-		err = fmt.Errorf("parse form fail: %v", err)
-		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	partitionID := pid.V
-	diskPath := diskParam.V
-
-	partition := s.space.Partition(partitionID)
-	if partition != nil {
-		s.buildFailureResp(w, http.StatusBadRequest, "partition is already loaded")
-		return
-	}
-	// store disk path and root of dp
-	disk, err := s.space.GetDisk(diskPath)
-	if err != nil {
-		log.LogErrorf("action[loadDataPartition] disk(%v) is not found err(%v).", diskPath, err)
-		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf("disk %v is not found", diskPath))
-		return
-	}
-
-	fileInfoList, err := os.ReadDir(disk.Path)
-	if err != nil {
-		log.LogErrorf("action[loadDataPartition] read dir(%v) err(%v).", disk.Path, err)
-		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf(" read dir(%v) err(%v)", disk.Path, err))
-		return
-	}
-	rootDir := ""
-	for _, fileInfo := range fileInfoList {
-		filename := fileInfo.Name()
-		if !disk.isPartitionDir(filename) {
-			continue
-		}
-
-		if id, _, err := unmarshalPartitionName(filename); err != nil {
-			log.LogErrorf("action[RestorePartition] unmarshal partitionName(%v) from disk(%v) err(%v) ",
-				filename, disk.Path, err.Error())
-			continue
-		} else {
-			if id == partitionID {
-				rootDir = filename
-			}
-		}
-	}
-	if rootDir == "" {
-		log.LogErrorf("action[loadDataPartition] dp root not found in dir(%v) .", disk.Path)
-		s.buildFailureResp(w, http.StatusBadRequest, fmt.Sprintf("dp root not found in dir(%v)", disk.Path))
-		return
-	}
-
-	log.LogDebugf("data partition disk %v rootDir %v", disk, rootDir)
-
-	_, err = LoadDataPartition(path.Join(diskPath, rootDir), disk)
-	if err != nil {
-		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
-	} else {
-		s.buildSuccessResp(w, "success")
-	}
-}
-
 // NOTE: use for test
 func (s *DataNode) markDataPartitionBroken(w http.ResponseWriter, r *http.Request) {
 	const (
@@ -904,8 +762,6 @@ func (s *DataNode) loadDataPartition(w http.ResponseWriter, r *http.Request) {
 	for _, fileInfo := range fileInfoList {
 		filename := fileInfo.Name()
 		if !disk.isPartitionDir(filename) {
-			if disk.isExpiredPartitionDir(filename) {
-			}
 			continue
 		}
 
@@ -927,11 +783,10 @@ func (s *DataNode) loadDataPartition(w http.ResponseWriter, r *http.Request) {
 
 	log.LogDebugf("data partition disk %v rootDir %v", disk, rootDir)
 
-	dp, err := LoadDataPartition(path.Join(diskPath, rootDir), disk)
+	_, err = LoadDataPartition(path.Join(diskPath, rootDir), disk)
 	if err != nil {
 		s.buildFailureResp(w, http.StatusBadRequest, err.Error())
 	} else {
-		s.space.AttachPartition(dp)
 		s.buildSuccessResp(w, "success")
 	}
 }

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cubefs/cubefs/util/atomicutil"
 	"github.com/cubefs/cubefs/util/loadutil"
 	"github.com/cubefs/cubefs/util/log"
+	"github.com/cubefs/cubefs/util/strutil"
 	"github.com/shirou/gopsutil/disk"
 )
 
@@ -357,7 +358,11 @@ func (manager *SpaceManager) updateMetrics() {
 		}
 
 		used += d.Used
-		available += d.Available
+		if !d.GetDecommissionStatus() {
+			available += d.Available
+		} else {
+			log.LogInfof("[updateMetrics] disk(%v) is decommissioned, avaliable space(%v) raw(%v)", d.Path, strutil.FormatSize(d.Available), d.Available)
+		}
 		totalPartitionSize += d.Allocated
 		remainingCapacityToCreatePartition += d.Unallocated
 		partitionCnt += uint64(d.PartitionCount())

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -40,23 +40,27 @@ const DefaultStopDpLimit = 4
 
 // SpaceManager manages the disk space.
 type SpaceManager struct {
-	clusterID          string
-	disks              map[string]*Disk
-	partitions         map[uint64]*DataPartition
-	raftStore          raftstore.RaftStore
-	nodeID             uint64
-	diskMutex          sync.RWMutex
-	partitionMutex     sync.RWMutex
-	stats              *Stats
-	stopC              chan bool
-	diskList           []string
-	dataNode           *DataNode
-	rand               *rand.Rand
-	currentLoadDpCount int
-	currentStopDpCount int
-	diskUtils          map[string]*atomicutil.Float64
-	samplerDone        chan struct{}
-	allDisksLoaded     bool
+	clusterID            string
+	disks                map[string]*Disk
+	partitions           map[uint64]*DataPartition
+	raftStore            raftstore.RaftStore
+	nodeID               uint64
+	diskMutex            sync.RWMutex
+	partitionMutex       sync.RWMutex
+	stats                *Stats
+	stopC                chan bool
+	selectedIndex        int // TODO what is selected index
+	diskList             []string
+	dataNode             *DataNode
+	createPartitionMutex sync.RWMutex
+	rand                 *rand.Rand
+	currentLoadDpCount   int
+	currentStopDpCount   int
+	diskUtils            map[string]*atomicutil.Float64
+	samplerDone          chan struct{}
+	allDisksLoaded       bool
+	dataNodeIDs          map[string]uint64
+	dataNodeIDsMutex     sync.RWMutex
 }
 
 const diskSampleDuration = 1 * time.Second
@@ -74,6 +78,7 @@ func NewSpaceManager(dataNode *DataNode) *SpaceManager {
 	space.currentLoadDpCount = DefaultCurrentLoadDpLimit
 	space.currentStopDpCount = DefaultStopDpLimit
 	space.diskUtils = make(map[string]*atomicutil.Float64)
+	space.dataNodeIDs = make(map[string]uint64)
 	go space.statUpdateScheduler()
 
 	return space
@@ -469,6 +474,7 @@ func (manager *SpaceManager) statUpdateScheduler() {
 			select {
 			case <-ticker.C:
 				manager.updateMetrics()
+				manager.updateDataNodeIDs()
 			case <-manager.stopC:
 				ticker.Stop()
 				return
@@ -673,4 +679,53 @@ func (manager *SpaceManager) deleteDataPartitionNotLoaded(id uint64) {
 			}
 		}
 	}
+}
+
+func (manager *SpaceManager) fetchDataNodesFromMaster() (nodes []proto.NodeView, err error) {
+	retry := 0
+	for {
+		if nodes, err = MasterClient.AdminAPI().GetClusterDataNodes(); err != nil {
+			retry++
+			if retry > 5 {
+				return
+			}
+		} else {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	return
+}
+
+func (manager *SpaceManager) updateDataNodeIDs() {
+	dataNodes, err := manager.fetchDataNodesFromMaster()
+	if err != nil {
+		log.LogErrorf("action[updateDataNodeID] fetch dataNodes from master failed err(%v) ", err.Error())
+		return
+	}
+	// lear old
+	manager.dataNodeIDsMutex.Lock()
+	defer manager.dataNodeIDsMutex.Unlock()
+	for key := range manager.dataNodeIDs {
+		delete(manager.dataNodeIDs, key)
+	}
+	for _, dn := range dataNodes {
+		manager.dataNodeIDs[dn.Addr] = dn.ID
+	}
+}
+
+type DataNodeID struct {
+	Addr string
+	ID   uint64
+}
+
+func (manager *SpaceManager) getDataNodeIDs() []DataNodeID {
+	manager.dataNodeIDsMutex.RLock()
+	defer manager.dataNodeIDsMutex.RUnlock()
+	var ids []DataNodeID
+	for addr, id := range manager.dataNodeIDs {
+		ids = append(ids, DataNodeID{Addr: addr, ID: id})
+	}
+	return ids
 }

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -297,9 +297,16 @@ func (manager *SpaceManager) LoadDisk(path string, reservedSpace, diskRdonlySpac
 		if loadedDp, has := manager.partitions[dp.partitionID]; !has {
 			manager.partitions[dp.partitionID] = dp
 			manager.partitionMutex.Unlock()
-			log.LogDebugf("action[LoadDisk] put partition(%v) to manager manager.", dp.partitionID)
+			log.LogDebugf("action[LoadDisk] put partition(%v) to manager.", dp.partitionID)
 		} else {
 			manager.partitionMutex.Unlock()
+
+			if loadedDp.disk.Path == dp.disk.Path {
+				log.LogWarnf("[LoadDisk] dp(%v) is loaded, to load(%v), but disk path is the same",
+					loadedDp.info(), dp.info())
+				return
+			}
+
 			log.LogWarnf("action[LoadDisk] dp(%v) is loaded, to load(%v).", loadedDp.info(), dp.info())
 			_, _, infos, err := dp.fetchReplicasFromMaster()
 			if err != nil {

--- a/datanode/space_manager.go
+++ b/datanode/space_manager.go
@@ -40,27 +40,25 @@ const DefaultStopDpLimit = 4
 
 // SpaceManager manages the disk space.
 type SpaceManager struct {
-	clusterID            string
-	disks                map[string]*Disk
-	partitions           map[uint64]*DataPartition
-	raftStore            raftstore.RaftStore
-	nodeID               uint64
-	diskMutex            sync.RWMutex
-	partitionMutex       sync.RWMutex
-	stats                *Stats
-	stopC                chan bool
-	selectedIndex        int // TODO what is selected index
-	diskList             []string
-	dataNode             *DataNode
-	createPartitionMutex sync.RWMutex
-	rand                 *rand.Rand
-	currentLoadDpCount   int
-	currentStopDpCount   int
-	diskUtils            map[string]*atomicutil.Float64
-	samplerDone          chan struct{}
-	allDisksLoaded       bool
-	dataNodeIDs          map[string]uint64
-	dataNodeIDsMutex     sync.RWMutex
+	clusterID          string
+	disks              map[string]*Disk
+	partitions         map[uint64]*DataPartition
+	raftStore          raftstore.RaftStore
+	nodeID             uint64
+	diskMutex          sync.RWMutex
+	partitionMutex     sync.RWMutex
+	stats              *Stats
+	stopC              chan bool
+	diskList           []string
+	dataNode           *DataNode
+	rand               *rand.Rand
+	currentLoadDpCount int
+	currentStopDpCount int
+	diskUtils          map[string]*atomicutil.Float64
+	samplerDone        chan struct{}
+	allDisksLoaded     bool
+	dataNodeIDs        map[string]uint64
+	dataNodeIDsMutex   sync.RWMutex
 }
 
 const diskSampleDuration = 1 * time.Second
@@ -293,70 +291,7 @@ func (manager *SpaceManager) LoadDisk(path string, reservedSpace, diskRdonlySpac
 
 	log.LogDebugf("action[LoadDisk] load disk from path(%v).", path)
 	visitor = func(dp *DataPartition) {
-		manager.partitionMutex.Lock()
-		if loadedDp, has := manager.partitions[dp.partitionID]; !has {
-			manager.partitions[dp.partitionID] = dp
-			manager.partitionMutex.Unlock()
-			log.LogDebugf("action[LoadDisk] put partition(%v) to manager.", dp.partitionID)
-		} else {
-			manager.partitionMutex.Unlock()
-
-			if loadedDp.disk.Path == dp.disk.Path {
-				log.LogWarnf("[LoadDisk] dp(%v) is loaded, to load(%v), but disk path is the same",
-					loadedDp.info(), dp.info())
-				return
-			}
-
-			log.LogWarnf("action[LoadDisk] dp(%v) is loaded, to load(%v).", loadedDp.info(), dp.info())
-			_, _, infos, err := dp.fetchReplicasFromMaster()
-			if err != nil {
-				manager.DetachDataPartition(loadedDp.partitionID)
-				loadedDp.Stop()
-				loadedDp.Disk().DetachDataPartition(loadedDp)
-				log.LogErrorf("action[LoadDisk] dp(%v) is detached,due to get dp info failed(%v).",
-					loadedDp.info(), err)
-			} else {
-				var correctReplic ReplicaInfo
-				for _, replica := range infos {
-					if replica.Addr == manager.dataNode.localServerAddr {
-						correctReplic = replica
-						break
-					}
-				}
-				if correctReplic.Disk == "" && correctReplic.Addr == "" {
-					loadedDp.Stop()
-					loadedDp.Disk().DetachDataPartition(loadedDp)
-					log.LogErrorf("action[LoadDisk] dp(%v) is detached,due to data node not contains in replicas"+
-						"from master.", loadedDp.info())
-				} else {
-					if loadedDp.disk.Path == correctReplic.Disk {
-						dp.Stop()
-						dp.Disk().DetachDataPartition(dp)
-						if err := dp.RemoveAll(proto.InitialDecommission, false, false); err != nil {
-							log.LogErrorf("action[LoadDisk]failed to remove dp(%v) dir(%v), err(%v)",
-								dp.partitionID, dp.Path(), err)
-						}
-					} else {
-						// detach loaded dp
-						loadedDp.Stop()
-						loadedDp.Disk().DetachDataPartition(loadedDp)
-						if err := loadedDp.RemoveAll(proto.InitialDecommission, false, false); err != nil {
-							log.LogErrorf("action[LoadDisk]failed to remove dp(%v) dir(%v), err(%v)",
-								loadedDp.partitionID, loadedDp.Path(), err)
-						}
-						dp.Stop()
-						dp.Disk().DetachDataPartition(dp)
-						dp2, err := LoadDataPartition(dp.path, dp.disk)
-						if err != nil {
-							log.LogErrorf("action[LoadDisk]failed to load dp %v (%v_%v), err(%v)",
-								dp.partitionID, dp.path, dp.disk, err)
-						} else {
-							manager.AttachPartition(dp2)
-						}
-					}
-				}
-			}
-		}
+		// do noting here, dp is attached to space manager in RestorePartition
 	}
 
 	if _, err = manager.GetDisk(path); err != nil {
@@ -503,8 +438,67 @@ func (manager *SpaceManager) AttachPartition(dp *DataPartition) {
 		log.LogInfof("[AttachPartition] load dp(%v) attach using time(%v)", dp.partitionID, time.Since(begin))
 	}()
 	manager.partitionMutex.Lock()
-	defer manager.partitionMutex.Unlock()
-	manager.partitions[dp.partitionID] = dp
+	if loadedDp, has := manager.partitions[dp.partitionID]; !has {
+		manager.partitions[dp.partitionID] = dp
+		manager.partitionMutex.Unlock()
+		log.LogDebugf("action[AttachPartition] put partition(%v) to manager.", dp.partitionID)
+	} else {
+		manager.partitionMutex.Unlock()
+
+		if loadedDp.disk.Path == dp.disk.Path {
+			log.LogWarnf("[AttachPartition] dp(%v) is loaded, to load(%v), but disk path is the same",
+				loadedDp.info(), dp.info())
+			return
+		}
+
+		log.LogWarnf("action[AttachPartition] dp(%v) is loaded, to load(%v).", loadedDp.info(), dp.info())
+		_, _, infos, err := dp.fetchReplicasFromMaster()
+		if err != nil {
+			manager.DetachDataPartition(loadedDp.partitionID)
+			loadedDp.Stop()
+			loadedDp.Disk().DetachDataPartition(loadedDp)
+			log.LogErrorf("action[LoadDisk] dp(%v) is detached,due to get dp info failed(%v).",
+				loadedDp.info(), err)
+		} else {
+			var correctReplica ReplicaInfo
+			for _, replica := range infos {
+				if replica.Addr == manager.dataNode.localServerAddr {
+					correctReplica = replica
+					break
+				}
+			}
+			if correctReplica.Disk == "" && correctReplica.Addr == "" {
+				loadedDp.Stop()
+				loadedDp.Disk().DetachDataPartition(loadedDp)
+				log.LogErrorf("action[LoadDisk] dp(%v) is detached,due to data node not contains in replicas"+
+					"from master.", loadedDp.info())
+			} else {
+				if loadedDp.disk.Path == correctReplica.Disk {
+					dp.Stop()
+					dp.Disk().DetachDataPartition(dp)
+					if err := dp.RemoveAll(proto.InitialDecommission, true); err != nil {
+						log.LogErrorf("action[LoadDisk]failed to remove dp(%v) dir(%v), err(%v)",
+							dp.partitionID, dp.Path(), err)
+					}
+				} else {
+					// detach loaded dp
+					loadedDp.Stop()
+					loadedDp.Disk().DetachDataPartition(loadedDp)
+					if err := loadedDp.RemoveAll(proto.InitialDecommission, true); err != nil {
+						log.LogErrorf("action[LoadDisk]failed to remove dp(%v) dir(%v), err(%v)",
+							loadedDp.partitionID, loadedDp.Path(), err)
+					}
+					dp.Stop()
+					dp.Disk().DetachDataPartition(dp)
+					_, err := LoadDataPartition(dp.path, dp.disk)
+					if err != nil {
+						log.LogErrorf("action[LoadDisk]failed to load dp %v (%v_%v), err(%v)",
+							dp.partitionID, dp.path, dp.disk, err)
+					}
+				}
+			}
+		}
+	}
 }
 
 // DetachDataPartition removes a data partition from the partition map.
@@ -554,14 +548,14 @@ func (manager *SpaceManager) CreatePartition(request *proto.CreateDataPartitionR
 }
 
 // DeletePartition deletes a partition based on the partition id.
-func (manager *SpaceManager) DeletePartition(dpID uint64, decommissionType uint32, force, isSpecialReplica bool) (err error) {
+func (manager *SpaceManager) DeletePartition(dpID uint64, decommissionType uint32, force bool) (err error) {
 	manager.partitionMutex.Lock()
 
 	dp := manager.partitions[dpID]
 	if dp == nil {
 		manager.partitionMutex.Unlock()
 		// maybe dp not loaded when triggered disk error, need to remove disk root dir
-		err = manager.deleteDataPartitionNotLoaded(dpID, decommissionType, force, isSpecialReplica)
+		err = manager.deleteDataPartitionNotLoaded(dpID, decommissionType, force)
 		return err
 	}
 
@@ -569,7 +563,7 @@ func (manager *SpaceManager) DeletePartition(dpID uint64, decommissionType uint3
 	manager.partitionMutex.Unlock()
 	dp.Stop()
 	dp.Disk().DetachDataPartition(dp)
-	if err := dp.RemoveAll(decommissionType, force, isSpecialReplica); err != nil {
+	if err := dp.RemoveAll(decommissionType, force); err != nil {
 		return err
 	}
 	return nil
@@ -637,7 +631,7 @@ func (s *DataNode) buildHeartBeatResponse(response *proto.DataNodeHeartbeatRespo
 	}
 }
 
-func (manager *SpaceManager) deleteDataPartitionNotLoaded(id uint64, decommissionType uint32, force, isSpecialReplica bool) error {
+func (manager *SpaceManager) deleteDataPartitionNotLoaded(id uint64, decommissionType uint32, force bool) error {
 	disks := manager.GetDisks()
 	for _, d := range disks {
 		if d.HasDiskErrPartition(id) {
@@ -665,7 +659,7 @@ func (manager *SpaceManager) deleteDataPartitionNotLoaded(id uint64, decommissio
 				} else {
 					if partitionID == id {
 						rootPath := path.Join(d.Path, filename)
-						if decommissionType == proto.AutoDecommission && isSpecialReplica && force {
+						if decommissionType == proto.AutoDecommission && force {
 							newPath := path.Join(d.Path, BackupPartitionPrefix+filename)
 							err = os.Rename(rootPath, newPath)
 							if err == nil {

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -1325,7 +1325,8 @@ func (s *DataNode) handlePacketToAddDataPartitionRaftMember(p *repl.Packet) {
 		return
 	}
 
-	log.LogInfof("action[handlePacketToAddDataPartitionRaftMember] %v, partition id %v", req.AddPeer, req.PartitionId)
+	log.LogInfof("action[handlePacketToAddDataPartitionRaftMember]req(%v) addPeer %v, partition id %v",
+		p.GetReqID(), req.AddPeer, req.PartitionId)
 
 	p.AddMesgLog(string(reqData))
 	dp := s.space.Partition(req.PartitionId)
@@ -1348,11 +1349,11 @@ func (s *DataNode) handlePacketToAddDataPartitionRaftMember(p *repl.Packet) {
 	isRaftLeader, err = s.forwardToRaftLeader(dp, p, false)
 	if !isRaftLeader {
 		if err != nil {
-			log.LogWarnf("action[handlePacketToAddDataPartitionRaftMember]dp %v  req %v forward to leader failed:%v",
-				dp.partitionID, p.GetReqID(), err)
+			log.LogWarnf("action[handlePacketToAddDataPartitionRaftMember]dp %v  req %v  addPeer %v forward to leader failed:%v",
+				dp.partitionID, p.GetReqID(), req.AddPeer, err)
 		} else {
-			log.LogWarnf("action[handlePacketToAddDataPartitionRaftMember]dp %v  req %v forward to leader",
-				dp.partitionID, p.GetReqID())
+			log.LogWarnf("action[handlePacketToAddDataPartitionRaftMember]dp %v  req %v  addPeer %v forward to leader",
+				dp.partitionID, p.GetReqID(), req.AddPeer)
 		}
 		return
 	}
@@ -1408,8 +1409,9 @@ func (s *DataNode) handlePacketToRemoveDataPartitionRaftMember(p *repl.Packet) {
 		p.GetReqID(), string(reqData), req.RemovePeer.Addr, dp.partitionID, dp.replicaNum, dp.config.Peers, dp.replicas)
 
 	p.PartitionID = req.PartitionId
-	// do not return error to keep decommission progress go forward
-	// do not check replica existence on leader for autoRemove enable, follower may be contains redundant peers
+	// do not return error to keep master decommission progress go forward
+	// do not check replica existence on leader for autoRemove enable, follower may be contains redundant peers, make sure
+	// leader can send remove wal logs to follower
 	if !dp.IsExistReplica(req.RemovePeer.Addr) && !req.Force && !req.AutoRemove {
 		log.LogWarnf("action[handlePacketToRemoveDataPartitionRaftMember]dp %v receive MasterCommand:  req %v "+
 			"RemoveRaftPeer(%v) force(%v)  autoRemove(%v) has not exist", dp.partitionID, p.GetReqID(), req.RemovePeer, req.Force, req.AutoRemove)
@@ -1456,7 +1458,8 @@ func (s *DataNode) handlePacketToRemoveDataPartitionRaftMember(p *repl.Packet) {
 			}
 		}
 	}
-	if !found && !req.AutoRemove {
+
+	if !found && !req.AutoRemove && !req.Force {
 		err = errors.NewErrorf("cannot found peer(%v) in dp(%v) peers", req.RemovePeer.Addr, dp.partitionID)
 		log.LogWarnf("handlePacketToRemoveDataPartitionRaftMember:%v", err.Error())
 		return

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -611,6 +611,7 @@ func (s *DataNode) handlePacketToDeleteDataPartition(p *repl.Packet) {
 		return
 	}
 	request := &proto.DeleteDataPartitionRequest{}
+	log.LogInfof(fmt.Sprintf("action[handlePacketToDeleteDataPartition] request %v ", request))
 	if task.OpCode == proto.OpDeleteDataPartition {
 		bytes, _ := json.Marshal(task.Request)
 		p.AddMesgLog(string(bytes))
@@ -618,7 +619,7 @@ func (s *DataNode) handlePacketToDeleteDataPartition(p *repl.Packet) {
 		if err != nil {
 			return
 		} else {
-			s.space.DeletePartition(request.PartitionId)
+			err = s.space.DeletePartition(request.PartitionId, request.DecommissionType, request.Force, request.IsSpecialReplica)
 		}
 	} else {
 		err = fmt.Errorf("illegal opcode ")
@@ -626,8 +627,9 @@ func (s *DataNode) handlePacketToDeleteDataPartition(p *repl.Packet) {
 	if err != nil {
 		err = errors.Trace(err, "delete DataPartition failed,PartitionID(%v)", request.PartitionId)
 		log.LogErrorf("action[handlePacketToDeleteDataPartition] err(%v).", err)
+	} else {
+		log.LogInfof(fmt.Sprintf("action[handlePacketToDeleteDataPartition] %v success", request.PartitionId))
 	}
-	log.LogInfof(fmt.Sprintf("action[handlePacketToDeleteDataPartition] %v error(%v)", request.PartitionId, err))
 }
 
 // Handle OpLoadDataPartition packet.

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -623,7 +623,7 @@ func (s *DataNode) handlePacketToDeleteDataPartition(p *repl.Packet) {
 		if err != nil {
 			return
 		} else {
-			err = s.space.DeletePartition(request.PartitionId, request.DecommissionType, request.Force, request.IsSpecialReplica)
+			err = s.space.DeletePartition(request.PartitionId, request.DecommissionType, request.Force)
 		}
 	} else {
 		err = fmt.Errorf("illegal opcode ")
@@ -1845,12 +1845,11 @@ func (s *DataNode) handlePacketToRecoverBackupDataReplica(p *repl.Packet) {
 		return
 	}
 
-	dp, err := LoadDataPartition(path.Join(request.Disk, newPath), disk)
+	_, err = LoadDataPartition(path.Join(request.Disk, newPath), disk)
 	if err != nil {
 		log.LogErrorf("action[handlePacketToRecoverBackupDataReplica] load disk %v rootDir %v failed err %v.",
 			disk.Path, rootDir, err)
 	} else {
-		s.space.AttachPartition(dp)
 		log.LogInfof("action[handlePacketToRecoverBackupDataReplica] load disk %v rootDir %v success .",
 			disk.Path, rootDir)
 	}

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -824,7 +824,19 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 		partition.disk.allocCheckLimit(proto.IopsWriteType, 1)
 
 		if writable := partition.disk.limitWrite.TryRun(int(p.Size), func() {
-			_, err = store.Write(p.ExtentID, p.ExtentOffset, int64(p.Size), p.Data, p.CRC, storage.AppendWriteType, p.IsSyncWrite(), false, false, false)
+			param := &storage.WriteParam{
+				ExtentID:      p.ExtentID,
+				Offset:        p.ExtentOffset,
+				Size:          int64(p.Size),
+				Data:          p.Data,
+				Crc:           p.CRC,
+				WriteType:     storage.AppendWriteType,
+				IsSync:        p.IsSyncWrite(),
+				IsHole:        false,
+				IsRepair:      false,
+				IsBackupWrite: false,
+			}
+			_, err = store.Write(param)
 		}); !writable {
 			err = storage.LimitedIoError
 			return
@@ -846,7 +858,19 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 		partition.disk.allocCheckLimit(proto.IopsWriteType, 1)
 
 		if writable := partition.disk.limitWrite.TryRun(int(p.Size), func() {
-			_, err = store.Write(p.ExtentID, p.ExtentOffset, int64(p.Size), p.Data, p.CRC, storage.AppendWriteType, p.IsSyncWrite(), false, false, false)
+			param := &storage.WriteParam{
+				ExtentID:      p.ExtentID,
+				Offset:        p.ExtentOffset,
+				Size:          int64(p.Size),
+				Data:          p.Data,
+				Crc:           p.CRC,
+				WriteType:     storage.AppendWriteType,
+				IsSync:        p.IsSyncWrite(),
+				IsHole:        false,
+				IsRepair:      false,
+				IsBackupWrite: false,
+			}
+			_, err = store.Write(param)
 		}); !writable {
 			err = storage.LimitedIoError
 			return
@@ -874,7 +898,19 @@ func (s *DataNode) handleWritePacket(p *repl.Packet) {
 			partition.disk.allocCheckLimit(proto.IopsWriteType, 1)
 
 			if writable := partition.disk.limitWrite.TryRun(currSize, func() {
-				_, err = store.Write(p.ExtentID, p.ExtentOffset+int64(offset), int64(currSize), data, crc, storage.AppendWriteType, p.IsSyncWrite(), false, false, false)
+				param := &storage.WriteParam{
+					ExtentID:      p.ExtentID,
+					Offset:        p.ExtentOffset + int64(offset),
+					Size:          int64(currSize),
+					Data:          data,
+					Crc:           crc,
+					WriteType:     storage.AppendWriteType,
+					IsSync:        p.IsSyncWrite(),
+					IsHole:        false,
+					IsRepair:      false,
+					IsBackupWrite: false,
+				}
+				_, err = store.Write(param)
 			}); !writable {
 				err = storage.LimitedIoError
 				return

--- a/datanode/wrap_operator.go
+++ b/datanode/wrap_operator.go
@@ -536,7 +536,6 @@ func (s *DataNode) handleHeartbeatPacket(p *repl.Packet) {
 	go func() {
 		request := &proto.HeartBeatRequest{}
 		response := &proto.DataNodeHeartbeatResponse{}
-		s.buildHeartBeatResponse(response)
 
 		if task.OpCode == proto.OpDataNodeHeartbeat {
 			marshaled, _ := json.Marshal(task.Request)
@@ -547,11 +546,13 @@ func (s *DataNode) handleHeartbeatPacket(p *repl.Packet) {
 					request.EnableDiskQos,
 					s.diskQosEnable)
 			}
+			// NOTE: set decommission disks
+			s.checkDecommissionDisks(request.DecommissionDisks)
+
+			s.buildHeartBeatResponse(response)
 
 			// set volume forbidden
 			s.checkVolumeForbidden(request.ForbiddenVols)
-			// set decommission disks
-			s.checkDecommissionDisks(request.DecommissionDisks)
 			s.diskQosEnableFromMaster = request.EnableDiskQos
 
 			s.checkVolumeDpRepairBlockSize(request.VolDpRepairBlockSize)

--- a/datanode/wrap_prepare.go
+++ b/datanode/wrap_prepare.go
@@ -161,7 +161,8 @@ func (s *DataNode) checkPacketAndPrepare(p *repl.Packet) error {
 		}
 	} else if p.IsLeaderPacket() && p.IsCreateExtentOperation() {
 		if partition.isNormalType() && partition.GetExtentCount() >= storage.MaxExtentCount*3 {
-			return fmt.Errorf("checkPacketAndPrepare partition %v has reached maxExtentId", p.PartitionID)
+			log.LogErrorf("[checkPacketAndPrepare] partition %v has reached maxExtentId", p.PartitionID)
+			return storage.ReachMaxExtentsCountError
 		}
 		p.ExtentID, err = store.NextExtentID()
 		if err != nil {

--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -206,6 +206,9 @@ func (s *raft) doStop() {
 
 func (s *raft) runApply() {
 	defer func() {
+		if r := recover(); r != nil {
+			log.LogWarnf("raft(%v) runApply occurred panic,err[%v]", s.raftFsm.id, r)
+		}
 		s.doStop()
 		s.resetApply()
 	}()

--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -211,6 +211,7 @@ func (s *raft) runApply() {
 		}
 		s.doStop()
 		s.resetApply()
+		log.LogWarnf("raft(%v) quit runApply", s.raftFsm.id)
 	}()
 
 	loopCount := 0
@@ -271,6 +272,7 @@ func (s *raft) run() {
 		s.stopSnapping()
 		s.raftConfig.Storage.Close()
 		close(s.done)
+		log.LogWarnf("raft(%v) quit run", s.raftFsm.id)
 	}()
 
 	s.prevHardSt.Term = s.raftFsm.term

--- a/depends/tiglabs/raft/raft_fsm_candidate.go
+++ b/depends/tiglabs/raft/raft_fsm_candidate.go
@@ -121,8 +121,8 @@ func (r *raftFsm) campaign(force bool, t CampaignType) {
 		}
 		li, lt := r.raftLog.lastIndexAndTerm()
 		if logger.IsEnableDebug() {
-			logger.Debug("[raft->campaign][%v,%v logterm: %d, index: %d] sent "+
-				"%v request to %v at term %d.   raftFSM[%p]", msgType, r.id, r.config.ReplicateAddr, lt, li, id, r.term, r)
+			logger.Debug("[raft->campaign][%v,raft %v, term: %d] sent "+
+				"index %v request to %v at term %d. raftFSM[%p]", msgType, r.id, lt, li, id, r.term, r)
 		}
 
 		m := proto.GetMessage()

--- a/depends/tiglabs/raft/server.go
+++ b/depends/tiglabs/raft/server.go
@@ -234,6 +234,8 @@ func (rs *RaftServer) Status(id uint64) (status *Status) {
 
 	if ok {
 		status = raft.status()
+	} else {
+		logger.Warn("raftServer cannot found, id:%d", id)
 	}
 	if status == nil {
 		status = &Status{

--- a/gosdk/cfs_client.go
+++ b/gosdk/cfs_client.go
@@ -1,0 +1,1291 @@
+package gosdk
+
+import "C"
+import (
+	"context"
+	"fmt"
+	"io"
+	syslog "log"
+	"os"
+	gopath "path"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/bits-and-blooms/bitset"
+	"github.com/cubefs/cubefs/blobstore/api/access"
+	"github.com/cubefs/cubefs/blobstore/common/trace"
+	"github.com/cubefs/cubefs/blockcache/bcache"
+	"github.com/cubefs/cubefs/client/fs"
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/sdk/data/blobstore"
+	"github.com/cubefs/cubefs/sdk/data/stream"
+	masterSDK "github.com/cubefs/cubefs/sdk/master"
+	"github.com/cubefs/cubefs/sdk/meta"
+	"github.com/cubefs/cubefs/util/auditlog"
+	"github.com/cubefs/cubefs/util/buf"
+	"github.com/cubefs/cubefs/util/errors"
+	"github.com/cubefs/cubefs/util/log"
+	"github.com/cubefs/cubefs/util/stat"
+)
+
+const (
+	defaultBlkSize      = uint32(1) << 12
+	maxFdNum       uint = 10240000
+	MaxSizePutOnce      = int64(1) << 23
+)
+
+var gid int64
+
+type (
+	Config struct {
+		VolName    string `json:"volName"`
+		MasterAddr string `json:"masterAddr"`
+		AccessKey  string `json:"accessKey"`
+		SecretKey  string `json:"secretKey"`
+
+		FollowerRead     bool   `json:"followerRead,omitempty"`
+		EnableBcache     bool   `json:"enableBcache,omitempty"`
+		EnableSummary    bool   `json:"enableSummary,omitempty"`
+		EnableAudit      bool   `json:"enableAudit,omitempty"`
+		ReadBlockThread  int    `json:"readBlockThread,omitempty"`
+		WriteBlockThread int    `json:"writeBlockThread,omitempty"`
+		LogDir           string `json:"logDir,omitempty"`
+		LogLevel         string `json:"logLevel,omitempty"`
+		PushAddr         string `json:"pushAddr,omitempty"`
+	}
+
+	Client struct {
+		// Client ID allocated by libsdk
+		ID int64
+
+		// mount config
+		cfg Config
+
+		ebsEndpoint         string
+		servicePath         string
+		volType             int
+		cacheAction         int
+		ebsBlockSize        int
+		cacheRuleKey        string
+		cacheThreshold      int
+		subDir              string
+		cluster             string
+		dirChildrenNumLimit uint32
+
+		// runtime context
+		cwd    string // current working directory
+		fdmap  map[uint]*File
+		fdset  *bitset.BitSet
+		fdlock sync.RWMutex
+
+		// server info
+		mw   *meta.MetaWrapper
+		ec   *stream.ExtentClient
+		ic   *fs.InodeCache
+		dc   *fs.DentryCache
+		bc   *bcache.BcacheClient
+		ebsc *blobstore.BlobStoreClient
+		sc   *fs.SummaryCache
+	}
+
+	StatInfo struct {
+		AtimeNsec uint32
+		MtimeNsec uint32
+		CtimeNsec uint32
+		Mode      uint32
+		Nlink     uint32
+		BlkSize   uint32
+		Uid       uint32
+		Gid       uint32
+
+		Ino    uint64
+		Size   uint64
+		Blocks uint64
+		Atime  uint64
+		Mtime  uint64
+		Ctime  uint64
+	}
+
+	Dirent struct {
+		Name  string
+		DType uint8
+		Ino   uint64
+	}
+
+	HdfsStatInfo struct {
+		AtimeNsec uint32
+		MtimeNsec uint32
+		Mode      uint32
+		Size      uint64
+		Atime     uint64
+		Mtime     uint64
+	}
+	DirentInfo struct {
+		DType uint8
+		Name  string
+		Stat  HdfsStatInfo
+	}
+
+	SummaryInfo struct {
+		Files   int64
+		Subdirs int64
+		Fbytes  int64
+	}
+
+	File struct {
+		client *Client
+
+		fd    uint
+		ino   uint64
+		pino  uint64
+		flags int
+		mode  uint32
+
+		// dir only
+		dirp *dirStream
+
+		// rw
+		fileWriter *blobstore.Writer
+		fileReader *blobstore.Reader
+
+		closed bool
+		path   string
+	}
+
+	dirStream struct {
+		pos     int
+		dirents []proto.Dentry
+	}
+)
+
+func New(cfg Config) *Client {
+	id := atomic.AddInt64(&gid, 1)
+	c := &Client{
+		ID:                  id,
+		cfg:                 cfg,
+		fdmap:               make(map[uint]*File),
+		fdset:               bitset.New(maxFdNum),
+		dirChildrenNumLimit: proto.DefaultDirChildrenNumLimit,
+		cwd:                 "/",
+		sc:                  fs.NewSummaryCache(fs.DefaultSummaryExpiration, fs.MaxSummaryCache),
+		ic:                  fs.NewInodeCache(fs.DefaultInodeExpiration, fs.MaxInodeCache),
+		dc:                  fs.NewDentryCache(),
+	}
+	// Just skip fd 0, 1, 2, to avoid confusion.
+	c.fdset.Set(0).Set(1).Set(2)
+	return c
+}
+
+func (c *Client) Start() (err error) {
+	masters := strings.Split(c.cfg.MasterAddr, ",")
+	if c.cfg.LogDir != "" && log.LogDir == "" {
+		if c.cfg.LogLevel == "" {
+			c.cfg.LogLevel = "WARN"
+		}
+		level := parseLogLevel(c.cfg.LogLevel)
+		log.InitLog(c.cfg.LogDir, "libcfs", level, nil, log.DefaultLogLeftSpaceLimitRatio)
+		stat.NewStatistic(c.cfg.LogDir, "libcfs", int64(stat.DefaultStatLogSize), stat.DefaultTimeOutUs, true)
+	}
+	proto.InitBufferPool(int64(32768))
+	if c.cfg.ReadBlockThread == 0 {
+		c.cfg.ReadBlockThread = 10
+	}
+	if c.cfg.WriteBlockThread == 0 {
+		c.cfg.WriteBlockThread = 10
+	}
+	if err = c.loadConfFromMaster(masters); err != nil {
+		return
+	}
+	if err = c.checkPermission(); err != nil {
+		err = errors.NewErrorf("check permission failed: %v", err)
+		syslog.Println(err)
+		return
+	}
+
+	if c.cfg.EnableAudit {
+		_, err = auditlog.InitAudit(c.cfg.LogDir, "clientSdk", int64(auditlog.DefaultAuditLogSize))
+		if err != nil {
+			log.LogWarnf("Init audit log fail: %v", err)
+		}
+	}
+
+	if c.cfg.EnableSummary {
+		c.sc = fs.NewSummaryCache(fs.DefaultSummaryExpiration, fs.MaxSummaryCache)
+	}
+	if c.cfg.EnableBcache {
+		c.bc = bcache.NewBcacheClient()
+	}
+	var ebsc *blobstore.BlobStoreClient
+	if c.ebsEndpoint != "" {
+		if ebsc, err = blobstore.NewEbsClient(access.Config{
+			ConnMode: access.NoLimitConnMode,
+			Consul: access.ConsulConfig{
+				Address: c.ebsEndpoint,
+			},
+			MaxSizePutOnce: MaxSizePutOnce,
+			Logger: &access.Logger{
+				Filename: gopath.Join(c.cfg.LogDir, "libcfs/ebs.log"),
+			},
+		}); err != nil {
+			return
+		}
+	}
+	var mw *meta.MetaWrapper
+	if mw, err = meta.NewMetaWrapper(&meta.MetaConfig{
+		Volume:        c.cfg.VolName,
+		Masters:       masters,
+		ValidateOwner: false,
+		EnableSummary: c.cfg.EnableSummary,
+	}); err != nil {
+		log.LogErrorf("newClient NewMetaWrapper failed(%v)", err)
+		return err
+	}
+	var ec *stream.ExtentClient
+	if ec, err = stream.NewExtentClient(&stream.ExtentConfig{
+		Volume:            c.cfg.VolName,
+		VolumeType:        c.volType,
+		Masters:           masters,
+		FollowerRead:      c.cfg.FollowerRead,
+		OnAppendExtentKey: mw.AppendExtentKey,
+		OnGetExtents:      mw.GetExtents,
+		OnTruncate:        mw.Truncate,
+		BcacheEnable:      c.cfg.EnableBcache,
+		OnLoadBcache:      c.bc.Get,
+		OnCacheBcache:     c.bc.Put,
+		OnEvictBcache:     c.bc.Evict,
+		DisableMetaCache:  true,
+	}); err != nil {
+		log.LogErrorf("newClient NewExtentClient failed(%v)", err)
+		return
+	}
+
+	c.mw = mw
+	c.ec = ec
+	c.ebsc = ebsc
+	return nil
+}
+
+func (c *Client) Close() {
+	if c.ec != nil {
+		_ = c.ec.Close()
+	}
+	if c.mw != nil {
+		_ = c.mw.Close()
+	}
+	auditlog.StopAudit()
+	log.LogFlush()
+}
+
+func (c *Client) Chdir(path string) error {
+	cwd := c.absPath(path)
+	dirInfo, err := c.lookupPath(cwd)
+	if err != nil {
+		return err
+	}
+	if !proto.IsDir(dirInfo.Mode) {
+		return syscall.ENOTDIR
+	}
+	c.cwd = cwd
+	return nil
+}
+
+func (c *Client) GetCwd() string {
+	return c.cwd
+}
+
+func (c *Client) GetAttr(path string) (stat *StatInfo, err error) {
+	info, err := c.lookupPath(c.absPath(path))
+	if err != nil {
+		return nil, err
+	}
+
+	// fill up the stat
+	stat = &StatInfo{}
+	stat.Ino = info.Inode
+	stat.Size = info.Size
+	stat.Nlink = info.Nlink
+	stat.BlkSize = defaultBlkSize
+	stat.Uid = info.Uid
+	stat.Gid = info.Gid
+
+	if info.Size%512 != 0 {
+		stat.Blocks = (info.Size >> 9) + 1
+	} else {
+		stat.Blocks = info.Size >> 9
+	}
+	// fill up the mode
+	if proto.IsRegular(info.Mode) {
+		stat.Mode = (syscall.S_IFREG) | (info.Mode & 0o777)
+	} else if proto.IsDir(info.Mode) {
+		stat.Mode = (syscall.S_IFDIR) | (info.Mode & 0o777)
+	} else if proto.IsSymlink(info.Mode) {
+		stat.Mode = (syscall.S_IFLNK) | (info.Mode & 0o777)
+	} else {
+		stat.Mode = (syscall.S_IFSOCK) | (info.Mode & 0o777)
+	}
+
+	// fill up the time struct
+	t := info.AccessTime.UnixNano()
+	stat.Atime = uint64(t / 1e9)
+	stat.AtimeNsec = uint32(t % 1e9)
+
+	t = info.ModifyTime.UnixNano()
+	stat.Mtime = uint64(t / 1e9)
+	stat.MtimeNsec = uint32(t % 1e9)
+
+	t = info.CreateTime.UnixNano()
+	stat.Ctime = uint64(t / 1e9)
+	stat.CtimeNsec = uint32(t % 1e9)
+
+	return stat, nil
+}
+
+func (c *Client) SetAttr(path string, stat *StatInfo, valid uint32) error {
+	info, err := c.lookupPath(c.absPath(path))
+	if err != nil {
+		return err
+	}
+
+	err = c.setattr(info, valid, uint32(stat.Mode), uint32(stat.Uid), uint32(stat.Gid), int64(stat.Atime), int64(stat.Mtime))
+	if err != nil {
+		return err
+	}
+
+	c.ic.Delete(info.Inode)
+	return nil
+}
+
+func (c *Client) OpenFile(path string, flags int, mode uint32) (*File, error) {
+	start := time.Now()
+	absPath := c.absPath(path)
+
+	fuseMode := mode & uint32(0o777)
+	fuseFlags := flags &^ 0x8000
+	accFlags := fuseFlags & syscall.O_ACCMODE
+
+	var info *proto.InodeInfo
+	var parentIno uint64
+
+	/*
+	 * Note that the rwx mode is ignored when using libsdk
+	 */
+
+	if fuseFlags&syscall.O_CREAT != 0 {
+		if accFlags != syscall.O_WRONLY && accFlags != syscall.O_RDWR {
+			return nil, syscall.EACCES
+		}
+		dirpath, name := gopath.Split(absPath)
+		dirInfo, err := c.lookupPath(dirpath)
+		if err != nil {
+			return nil, err
+		}
+		parentIno = dirInfo.Inode
+		defer func() {
+			if info != nil {
+				auditlog.LogClientOp("Create", dirpath, "nil", err, time.Since(start).Microseconds(), info.Inode, 0)
+			} else {
+				auditlog.LogClientOp("Create", dirpath, "nil", err, time.Since(start).Microseconds(), 0, 0)
+			}
+		}()
+		newInfo, err := c.create(dirInfo.Inode, name, fuseMode, absPath)
+		if err != nil {
+			if err != syscall.EEXIST {
+				return nil, err
+			}
+			newInfo, err = c.lookupPath(absPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+		info = newInfo
+	} else {
+		dirpath, _ := gopath.Split(absPath)
+		dirInfo, err := c.lookupPath(dirpath)
+		if err != nil {
+			return nil, err
+		}
+		parentIno = dirInfo.Inode // parent inode
+		newInfo, err := c.lookupPath(absPath)
+		if err != nil {
+			return nil, err
+		}
+		info = newInfo
+	}
+	var fileCache bool
+	if c.cacheRuleKey == "" {
+		fileCache = false
+	} else {
+		fileCachePattern := fmt.Sprintf(".*%s.*", c.cacheRuleKey)
+		fileCache, _ = regexp.MatchString(fileCachePattern, absPath)
+	}
+	f := c.allocFD(info.Inode, fuseFlags, fuseMode, fileCache, info.Size, parentIno, absPath)
+	if f == nil {
+		return nil, syscall.EMFILE
+	}
+
+	if proto.IsRegular(info.Mode) {
+		c.openStream(f)
+		if fuseFlags&(syscall.O_TRUNC) != 0 {
+			if accFlags != (syscall.O_WRONLY) && accFlags != (syscall.O_RDWR) {
+				_ = c.closeStream(f)
+				c.releaseFD(f.fd)
+				return nil, syscall.EACCES
+			}
+			if err := c.truncate(f, 0); err != nil {
+				_ = c.closeStream(f)
+				c.releaseFD(f.fd)
+				return nil, syscall.EIO
+			}
+		}
+	}
+
+	return f, nil
+}
+
+func (f *File) Flush() error {
+	if f.closed {
+		return syscall.EBADFD
+	}
+
+	err := f.client.flush(f)
+	if err != nil {
+		return err
+	}
+	f.client.ic.Delete(f.ino)
+	return nil
+}
+
+func (f *File) CloseFile() (err error) {
+	if f.closed {
+		return syscall.EBADFD
+	}
+
+	info := f.client.ic.Get(f.ino)
+	if info == nil {
+		info, err = f.client.mw.InodeGet_ll(f.ino)
+		if err != nil {
+			return err
+		}
+	}
+
+	f = f.client.releaseFD(f.fd)
+	if f == nil {
+		return syscall.EBADFD
+	}
+
+	// Consistent with cfs open, do close and closeStream only if f is regular file
+	if proto.IsRegular(info.Mode) {
+		err = f.client.flush(f)
+		if err != nil {
+			return err
+		}
+		err = f.client.closeStream(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	f.closed = true
+	return
+}
+
+func (f *File) WriteFile(data []byte, off int64) (n int, err error) {
+	if f.closed {
+		return 0, syscall.EBADFD
+	}
+
+	accFlags := f.flags & (syscall.O_ACCMODE)
+	if accFlags != (syscall.O_WRONLY) && accFlags != (syscall.O_RDWR) {
+		return 0, syscall.EACCES
+	}
+
+	var flags int
+	var wait bool
+
+	if f.flags&(syscall.O_DIRECT) != 0 || f.flags&(syscall.O_SYNC) != 0 || f.flags&(syscall.O_DSYNC) != 0 {
+		if proto.IsHot(f.client.volType) {
+			wait = true
+		}
+	}
+	if f.flags&(syscall.O_APPEND) != 0 || proto.IsCold(f.client.volType) {
+		flags |= proto.FlagsAppend
+		flags |= proto.FlagsSyncWrite
+	}
+
+	n, err = f.client.write(f, off, data, flags)
+	if err != nil {
+		return 0, err
+	}
+
+	if wait {
+		if err = f.client.flush(f); err != nil {
+			return 0, err
+		}
+	}
+
+	return n, nil
+}
+
+func (f *File) ReadFile(buf []byte, off int64) (n int, err error) {
+	if f.closed {
+		return 0, syscall.EBADFD
+	}
+
+	accFlags := f.flags & (syscall.O_ACCMODE)
+	if accFlags == (syscall.O_WRONLY) {
+		return 0, syscall.EACCES
+	}
+
+	n, err = f.client.read(f, off, buf)
+	if err != nil {
+		return 0, err
+	}
+
+	return n, err
+}
+
+func (f *File) BatchGetInodes(inodeIDS []uint64, count int) (stats []StatInfo, err error) {
+	infos := f.client.mw.BatchInodeGet(inodeIDS)
+	if len(infos) > count {
+		return nil, syscall.EINVAL
+	}
+
+	stats = make([]StatInfo, len(infos))
+	for i := 0; i < len(infos); i++ {
+		// fill up the stat
+		stats[i].Ino = infos[i].Inode
+		stats[i].Size = infos[i].Size
+		stats[i].Blocks = infos[i].Size >> 9
+		stats[i].Nlink = infos[i].Nlink
+		stats[i].BlkSize = defaultBlkSize
+		stats[i].Uid = infos[i].Uid
+		stats[i].Gid = infos[i].Gid
+
+		// fill up the mode
+		if proto.IsRegular(infos[i].Mode) {
+			stats[i].Mode = syscall.S_IFREG | (infos[i].Mode & 0o777)
+		} else if proto.IsDir(infos[i].Mode) {
+			stats[i].Mode = syscall.S_IFDIR | (infos[i].Mode & 0o777)
+		} else if proto.IsSymlink(infos[i].Mode) {
+			stats[i].Mode = syscall.S_IFLNK | (infos[i].Mode & 0o777)
+		} else {
+			stats[i].Mode = syscall.S_IFSOCK | (infos[i].Mode & 0o777)
+		}
+
+		// fill up the time struct
+		t := infos[i].AccessTime.UnixNano()
+		stats[i].Atime = uint64(t / 1e9)
+		stats[i].AtimeNsec = uint32(t % 1e9)
+
+		t = infos[i].ModifyTime.UnixNano()
+		stats[i].Mtime = uint64(t / 1e9)
+		stats[i].MtimeNsec = uint32(t % 1e9)
+
+		t = infos[i].CreateTime.UnixNano()
+		stats[i].Ctime = uint64(t / 1e9)
+		stats[i].CtimeNsec = uint32(t % 1e9)
+	}
+
+	return stats, nil
+}
+
+func (c *Client) RefreshSummary(path string, goroutineNum int32) error {
+	if !c.cfg.EnableSummary {
+		return syscall.EINVAL
+	}
+	info, err := c.lookupPath(c.absPath(path))
+	var ino uint64
+	if err != nil {
+		ino = proto.RootIno
+	} else {
+		ino = info.Inode
+	}
+
+	err = c.mw.RefreshSummary_ll(ino, goroutineNum)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *File) Readdir(count int) (dirents []Dirent, err error) {
+	if f.closed {
+		return nil, syscall.EBADFD
+	}
+
+	if f.dirp == nil {
+		f.dirp = &dirStream{}
+		dentries, err := f.client.mw.ReadDir_ll(f.ino)
+		if err != nil {
+			return nil, err
+		}
+		f.dirp.dirents = dentries
+	}
+
+	dirp := f.dirp
+	dirents = make([]Dirent, count)
+	n := 0
+	for dirp.pos < len(dirp.dirents) && n < count {
+		// fill up ino
+		dirents[n].Ino = dirp.dirents[dirp.pos].Inode
+
+		// fill up d_type
+		if proto.IsRegular(dirp.dirents[dirp.pos].Type) {
+			dirents[n].DType = syscall.DT_REG
+		} else if proto.IsDir(dirp.dirents[dirp.pos].Type) {
+			dirents[n].DType = syscall.DT_DIR
+		} else if proto.IsSymlink(dirp.dirents[dirp.pos].Type) {
+			dirents[n].DType = syscall.DT_LNK
+		} else {
+			dirents[n].DType = syscall.DT_UNKNOWN
+		}
+
+		// fill up name
+		dirents[n].Name = dirp.dirents[dirp.pos].Name
+		// advance cursor
+		dirp.pos++
+		n++
+	}
+
+	return dirents[:n], nil
+}
+
+func (f *File) Lsdir(count int) (direntsInfo []DirentInfo, err error) {
+	if f.closed {
+		return nil, syscall.EBADFD
+	}
+
+	if f.dirp == nil {
+		f.dirp = &dirStream{}
+		dentries, err := f.client.mw.ReadDir_ll(f.ino)
+		if err != nil {
+			return nil, err
+		}
+		f.dirp.dirents = dentries
+	}
+
+	var (
+		n        int
+		dirp     = f.dirp
+		inodeIDS = make([]uint64, count)
+		inodeMap = make(map[uint64]int)
+	)
+	direntsInfo = make([]DirentInfo, count)
+
+	for dirp.pos < len(dirp.dirents) && n < count {
+		inodeIDS[n] = dirp.dirents[dirp.pos].Inode
+		inodeMap[dirp.dirents[dirp.pos].Inode] = n
+		// fill up d_type
+		if proto.IsRegular(dirp.dirents[dirp.pos].Type) {
+			direntsInfo[n].DType = syscall.DT_REG
+		} else if proto.IsDir(dirp.dirents[dirp.pos].Type) {
+			direntsInfo[n].DType = syscall.DT_DIR
+		} else if proto.IsSymlink(dirp.dirents[dirp.pos].Type) {
+			direntsInfo[n].DType = syscall.DT_LNK
+		} else {
+			direntsInfo[n].DType = syscall.DT_UNKNOWN
+		}
+
+		direntsInfo[n].Name = dirp.dirents[dirp.pos].Name
+		// advance cursor
+		dirp.pos++
+		n++
+	}
+	if n == 0 {
+		return nil, nil
+	}
+
+	infos := f.client.mw.BatchInodeGet(inodeIDS)
+	if len(infos) != n {
+		return nil, syscall.EIO
+	}
+
+	for i := 0; i < len(infos); i++ {
+		// fill up the stat
+		index := inodeMap[infos[i].Inode]
+		direntsInfo[index].Stat.Size = infos[i].Size
+
+		// fill up the mode
+		if proto.IsRegular(infos[i].Mode) {
+			direntsInfo[index].Stat.Mode = syscall.S_IFREG | (infos[i].Mode & 0o777)
+		} else if proto.IsDir(infos[i].Mode) {
+			direntsInfo[index].Stat.Mode = syscall.S_IFDIR | (infos[i].Mode & 0o777)
+		} else if proto.IsSymlink(infos[i].Mode) {
+			direntsInfo[index].Stat.Mode = syscall.S_IFLNK | (infos[i].Mode & 0o777)
+		} else {
+			direntsInfo[index].Stat.Mode = syscall.S_IFSOCK | (infos[i].Mode & 0o777)
+		}
+
+		// fill up the time struct
+		t := infos[index].AccessTime.UnixNano()
+		direntsInfo[index].Stat.Atime = uint64(t / 1e9)
+		direntsInfo[index].Stat.AtimeNsec = uint32(t % 1e9)
+
+		t = infos[index].ModifyTime.UnixNano()
+		direntsInfo[index].Stat.Mtime = uint64(t / 1e9)
+		direntsInfo[index].Stat.MtimeNsec = uint32(t % 1e9)
+	}
+	return direntsInfo[:n], nil
+}
+
+func (c *Client) Mkdirs(path string, mode uint32) error {
+	start := time.Now()
+	var gerr error
+	var gino uint64
+
+	dirpath := c.absPath(path)
+	if dirpath == "/" {
+		return syscall.EEXIST
+	}
+
+	defer func() {
+		if gerr == nil {
+			auditlog.LogClientOp("Mkdir", dirpath, "nil", gerr, time.Since(start).Microseconds(), gino, 0)
+		} else {
+			auditlog.LogClientOp("Mkdir", dirpath, "nil", gerr, time.Since(start).Microseconds(), 0, 0)
+		}
+	}()
+
+	pino := proto.RootIno
+	dirs := strings.Split(dirpath, "/")
+	for _, dir := range dirs {
+		if dir == "/" || dir == "" {
+			continue
+		}
+		child, _, err := c.mw.Lookup_ll(pino, dir)
+		if err != nil {
+			if err == syscall.ENOENT {
+				info, err := c.mkdir(pino, dir, mode, dirpath)
+
+				if err != nil {
+					if err != syscall.EEXIST {
+						gerr = err
+						return err
+					}
+					// if dir already exist, lookup and assign to child
+					child_ino, _, err := c.mw.Lookup_ll(pino, dir)
+					if err != nil {
+						gerr = err
+						return err
+					}
+					child = child_ino
+				} else {
+					child = info.Inode
+				}
+			} else {
+				gerr = err
+				return err
+			}
+		}
+		pino = child
+		gino = child
+	}
+
+	return nil
+}
+
+func (c *Client) Rmdir(path string) error {
+	start := time.Now()
+	var err error
+	var info *proto.InodeInfo
+
+	absPath := c.absPath(path)
+	defer func() {
+		if info == nil {
+			auditlog.LogClientOp("Rmdir", absPath, "nil", err, time.Since(start).Microseconds(), 0, 0)
+		} else {
+			auditlog.LogClientOp("Rmdir", absPath, "nil", err, time.Since(start).Microseconds(), info.Inode, 0)
+		}
+	}()
+	dirpath, name := gopath.Split(absPath)
+	dirInfo, err := c.lookupPath(dirpath)
+	if err != nil {
+		return err
+	}
+
+	info, err = c.mw.Delete_ll(dirInfo.Inode, name, true, absPath)
+	c.ic.Delete(dirInfo.Inode)
+	c.dc.Delete(absPath)
+	return err
+}
+
+func (c *Client) Unlink(path string) error {
+	start := time.Now()
+	var err error
+	var info *proto.InodeInfo
+
+	absPath := c.absPath(path)
+	dirpath, name := gopath.Split(absPath)
+
+	defer func() {
+		if info == nil {
+			auditlog.LogClientOp("Unlink", absPath, "nil", err, time.Since(start).Microseconds(), 0, 0)
+		} else {
+			auditlog.LogClientOp("Unlink", absPath, "nil", err, time.Since(start).Microseconds(), info.Inode, 0)
+		}
+	}()
+	dirInfo, err := c.lookupPath(dirpath)
+	if err != nil {
+		return err
+	}
+
+	_, mode, err := c.mw.Lookup_ll(dirInfo.Inode, name)
+	if err != nil {
+		return err
+	}
+	if proto.IsDir(mode) {
+		return syscall.EISDIR
+	}
+
+	info, err = c.mw.Delete_ll(dirInfo.Inode, name, false, absPath)
+	if err != nil {
+		return err
+	}
+
+	if info != nil {
+		_ = c.mw.Evict(info.Inode, absPath)
+		c.ic.Delete(info.Inode)
+		c.dc.Delete(absPath)
+	}
+	return nil
+}
+
+func (c *Client) Rename(from, to string, overwritten bool) error {
+	start := time.Now()
+	var err error
+
+	absFrom := c.absPath(from)
+	absTo := c.absPath(to)
+
+	defer func() {
+		auditlog.LogClientOp("Rename", absFrom, absTo, err, time.Since(start).Microseconds(), 0, 0)
+	}()
+
+	srcDirPath, srcName := gopath.Split(absFrom)
+	dstDirPath, dstName := gopath.Split(absTo)
+
+	srcDirInfo, err := c.lookupPath(srcDirPath)
+	if err != nil {
+		return err
+	}
+	dstDirInfo, err := c.lookupPath(dstDirPath)
+	if err != nil {
+		return err
+	}
+
+	err = c.mw.Rename_ll(srcDirInfo.Inode, srcName, dstDirInfo.Inode, dstName, absFrom, absTo, overwritten)
+	c.ic.Delete(srcDirInfo.Inode)
+	c.ic.Delete(dstDirInfo.Inode)
+	c.dc.Delete(absFrom)
+	c.dc.Delete(absTo)
+	return err
+}
+
+func (f *File) Fchmod(mode uint32) error {
+	if f.closed {
+		return syscall.EBADFD
+	}
+
+	info, err := f.client.mw.InodeGet_ll(f.ino)
+	if err != nil {
+		return err
+	}
+
+	err = f.client.setattr(info, proto.AttrMode, uint32(mode), 0, 0, 0, 0)
+	if err != nil {
+		return err
+	}
+	f.client.ic.Delete(info.Inode)
+	return nil
+}
+
+func (c *Client) GetSummary(path string, useCache string, goroutineNum int32) (summary *SummaryInfo, err error) {
+	info, err := c.lookupPath(c.absPath(path))
+	if err != nil {
+		return nil, err
+	}
+
+	summary = &SummaryInfo{}
+	if strings.ToLower(useCache) == "true" {
+		cacheSummaryInfo := c.sc.Get(info.Inode)
+		if cacheSummaryInfo != nil {
+			summary.Files = cacheSummaryInfo.Files
+			summary.Subdirs = cacheSummaryInfo.Subdirs
+			summary.Fbytes = cacheSummaryInfo.Fbytes
+			return summary, nil
+		}
+	}
+
+	if !proto.IsDir(info.Mode) {
+		return nil, syscall.ENOTDIR
+	}
+
+	summaryInfo, err := c.mw.GetSummary_ll(info.Inode, goroutineNum)
+	if err != nil {
+		return nil, err
+	}
+	if strings.ToLower(useCache) != "false" {
+		c.sc.Put(info.Inode, &summaryInfo)
+	}
+	summary.Files = summaryInfo.Files
+	summary.Subdirs = summaryInfo.Subdirs
+	summary.Fbytes = summaryInfo.Fbytes
+	return summary, nil
+}
+
+func (f *File) Truncate(size int) error {
+	if f.closed {
+		return syscall.EBADFD
+	}
+
+	if err := f.client.truncate(f, size); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) create(pino uint64, name string, mode uint32, fullPath string) (info *proto.InodeInfo, err error) {
+	fuseMode := mode & 0o777
+	return c.mw.Create_ll(pino, name, fuseMode, 0, 0, nil, fullPath, false)
+}
+
+func (c *Client) mkdir(pino uint64, name string, mode uint32, fullPath string) (info *proto.InodeInfo, err error) {
+	fuseMode := mode & 0o777
+	fuseMode |= uint32(os.ModeDir)
+	return c.mw.Create_ll(pino, name, fuseMode, 0, 0, nil, fullPath, false)
+}
+
+func (c *Client) openStream(f *File) {
+	_ = c.ec.OpenStream(f.ino)
+}
+
+func (c *Client) closeStream(f *File) error {
+	err := c.ec.CloseStream(f.ino)
+	if err != nil {
+		return err
+	}
+	err = c.ec.EvictStream(f.ino)
+	if err != nil {
+		return err
+	}
+	f.fileWriter.FreeCache()
+	f.fileWriter = nil
+	f.fileReader = nil
+	return nil
+}
+
+func (c *Client) truncate(f *File, size int) error {
+	err := c.ec.Truncate(c.mw, f.pino, f.ino, size, f.path)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) releaseFD(fd uint) *File {
+	c.fdlock.Lock()
+	defer c.fdlock.Unlock()
+	f, ok := c.fdmap[fd]
+	if !ok {
+		return nil
+	}
+	delete(c.fdmap, fd)
+	c.fdset.Clear(fd)
+	c.ic.Delete(f.ino)
+	return f
+}
+
+func (c *Client) getFile(fd uint) *File {
+	c.fdlock.RLock()
+	f := c.fdmap[fd]
+	c.fdlock.RUnlock()
+	return f
+}
+
+func (c *Client) flush(f *File) error {
+	if proto.IsHot(c.volType) {
+		return c.ec.Flush(f.ino)
+	} else {
+		if f.fileWriter != nil {
+			return f.fileWriter.Flush(f.ino, c.ctx(c.ID, f.ino))
+		}
+	}
+	return nil
+}
+
+func (c *Client) write(f *File, offset int64, data []byte, flags int) (n int, err error) {
+	if proto.IsHot(c.volType) {
+		c.ec.GetStreamer(f.ino).SetParentInode(f.pino) // set the parent inode
+		checkFunc := func() error {
+			if !c.mw.EnableQuota {
+				return nil
+			}
+
+			if ok := c.ec.UidIsLimited(0); ok {
+				return syscall.ENOSPC
+			}
+
+			if c.mw.IsQuotaLimitedById(f.ino, true, false) {
+				return syscall.ENOSPC
+			}
+			return nil
+		}
+		n, err = c.ec.Write(f.ino, int(offset), data, flags, checkFunc)
+	} else {
+		n, err = f.fileWriter.Write(c.ctx(c.ID, f.ino), int(offset), data, flags)
+	}
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (c *Client) read(f *File, offset int64, data []byte) (n int, err error) {
+	if proto.IsHot(c.volType) {
+		n, err = c.ec.Read(f.ino, data, int(offset), len(data))
+	} else {
+		n, err = f.fileReader.Read(c.ctx(c.ID, f.ino), data, int(offset), len(data))
+	}
+	if err != nil && err != io.EOF {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (c *Client) setattr(info *proto.InodeInfo, valid uint32, mode, uid, gid uint32, atime, mtime int64) error {
+	// Only rwx mode bit can be set
+	if valid&proto.AttrMode != 0 {
+		fuseMode := mode & uint32(0o777)
+		mode = info.Mode &^ uint32(0o777) // clear rwx mode bit
+		mode |= fuseMode
+	}
+	return c.mw.Setattr(info.Inode, valid, mode, uid, gid, atime, mtime)
+}
+
+func (c *Client) lookupPath(path string) (*proto.InodeInfo, error) {
+	ino, ok := c.dc.Get(gopath.Clean(path))
+	if !ok {
+		inoInterval, err := c.mw.LookupPath(gopath.Clean(path))
+		if err != nil {
+			return nil, err
+		}
+		c.dc.Put(gopath.Clean(path), inoInterval)
+		ino = inoInterval
+	}
+	info := c.ic.Get(ino)
+	if info != nil {
+		return info, nil
+	}
+	info, err := c.mw.InodeGet_ll(ino)
+	if err != nil {
+		return nil, err
+	}
+	c.ic.Put(info)
+
+	return info, nil
+}
+
+func (c *Client) allocFD(ino uint64, flags int, mode uint32, fileCache bool, fileSize uint64, parentInode uint64, path string) *File {
+	c.fdlock.Lock()
+	defer c.fdlock.Unlock()
+	fd, ok := c.fdset.NextClear(0)
+	if !ok || fd > maxFdNum {
+		return nil
+	}
+	c.fdset.Set(fd)
+	f := &File{client: c, fd: fd, ino: ino, flags: flags, mode: mode, pino: parentInode, path: path}
+	if proto.IsCold(c.volType) {
+		clientConf := blobstore.ClientConfig{
+			VolName:         c.cfg.VolName,
+			VolType:         c.volType,
+			BlockSize:       c.ebsBlockSize,
+			Ino:             ino,
+			Bc:              c.bc,
+			Mw:              c.mw,
+			Ec:              c.ec,
+			Ebsc:            c.ebsc,
+			EnableBcache:    c.cfg.EnableBcache,
+			WConcurrency:    c.cfg.WriteBlockThread,
+			ReadConcurrency: c.cfg.ReadBlockThread,
+			CacheAction:     c.cacheAction,
+			FileCache:       fileCache,
+			FileSize:        fileSize,
+			CacheThreshold:  c.cacheThreshold,
+		}
+		f.fileWriter.FreeCache()
+		switch flags & 0xff {
+		case syscall.O_RDONLY:
+			f.fileReader = blobstore.NewReader(clientConf)
+			f.fileWriter = nil
+		case syscall.O_WRONLY:
+			f.fileWriter = blobstore.NewWriter(clientConf)
+			f.fileReader = nil
+		case syscall.O_RDWR:
+			f.fileReader = blobstore.NewReader(clientConf)
+			f.fileWriter = blobstore.NewWriter(clientConf)
+		default:
+			f.fileWriter = blobstore.NewWriter(clientConf)
+			f.fileReader = nil
+		}
+	}
+	c.fdmap[fd] = f
+	return f
+}
+
+func (c *Client) absPath(path string) string {
+	p := gopath.Clean(path)
+	if !gopath.IsAbs(p) {
+		p = gopath.Join(c.cwd, p)
+	}
+	return gopath.Clean(p)
+}
+
+func (c *Client) loadConfFromMaster(masters []string) (err error) {
+	mc := masterSDK.NewMasterClient(masters, false)
+	var volumeInfo *proto.SimpleVolView
+	volumeInfo, err = mc.AdminAPI().GetVolumeSimpleInfo(c.cfg.VolName)
+	if err != nil {
+		return
+	}
+	c.volType = volumeInfo.VolType
+	c.ebsBlockSize = volumeInfo.ObjBlockSize
+	c.cacheAction = volumeInfo.CacheAction
+	c.cacheRuleKey = volumeInfo.CacheRule
+	c.cacheThreshold = volumeInfo.CacheThreshold
+
+	var clusterInfo *proto.ClusterInfo
+	clusterInfo, err = mc.AdminAPI().GetClusterInfo()
+	if err != nil {
+		return
+	}
+	c.ebsEndpoint = clusterInfo.EbsAddr
+	c.servicePath = clusterInfo.ServicePath
+	c.cluster = clusterInfo.Cluster
+	c.dirChildrenNumLimit = clusterInfo.DirChildrenNumLimit
+	buf.InitCachePool(c.ebsBlockSize)
+	return
+}
+
+func (c *Client) checkPermission() (err error) {
+	if c.cfg.AccessKey == "" || c.cfg.SecretKey == "" {
+		err = errors.New("invalid AccessKey or SecretKey")
+		return
+	}
+
+	// checkPermission
+	mc := masterSDK.NewMasterClientFromString(c.cfg.MasterAddr, false)
+	var userInfo *proto.UserInfo
+	if userInfo, err = mc.UserAPI().GetAKInfo(c.cfg.AccessKey); err != nil {
+		return
+	}
+	if userInfo.SecretKey != c.cfg.SecretKey {
+		err = proto.ErrNoPermission
+		return
+	}
+	policy := userInfo.Policy
+	if policy.IsOwn(c.cfg.VolName) {
+		return
+	}
+	// read write
+	if policy.IsAuthorized(c.cfg.VolName, c.subDir, proto.POSIXWriteAction) &&
+		policy.IsAuthorized(c.cfg.VolName, c.subDir, proto.POSIXReadAction) {
+		return
+	}
+	// read only
+	if policy.IsAuthorized(c.cfg.VolName, c.subDir, proto.POSIXReadAction) &&
+		!policy.IsAuthorized(c.cfg.VolName, c.subDir, proto.POSIXWriteAction) {
+		return
+	}
+	err = proto.ErrNoPermission
+	return
+}
+
+func (c *Client) ctx(cid int64, ino uint64) context.Context {
+	_, ctx := trace.StartSpanFromContextWithTraceID(context.Background(), "", fmt.Sprintf("cid=%v,ino=%v", cid, ino))
+	return ctx
+}
+
+func parseLogLevel(loglvl string) log.Level {
+	var level log.Level
+	switch strings.ToLower(loglvl) {
+	case "debug":
+		level = log.DebugLevel
+	case "info":
+		level = log.InfoLevel
+	case "warn":
+		level = log.WarnLevel
+	case "error":
+		level = log.ErrorLevel
+	case "fatal":
+		level = log.FatalLevel
+	default:
+		level = log.ErrorLevel
+	}
+	return level
+}
+
+func (c *Client) SymLink(srcPath, dstPath string) error {
+	fullSrcPath := c.absPath(srcPath)
+	fullDstPath := c.absPath(dstPath)
+	parentDir := gopath.Dir(fullDstPath)
+	filename := gopath.Base(fullDstPath)
+
+	info, err := c.lookupPath(parentDir)
+	if err != nil {
+		return err
+	}
+
+	parentIno := info.Inode
+	info, err = c.mw.Create_ll(parentIno, filename, proto.Mode(os.ModeSymlink|os.ModePerm), 0, 0, []byte(fullSrcPath), fullDstPath, false)
+	if err != nil {
+		log.LogErrorf("Symlink: parent(%v) NewName(%v) err(%v)\n", parentIno, filename, err)
+		return err
+	}
+
+	c.ic.Put(info)
+	log.LogDebugf("Symlink: src_path(%s) dst_path(%s)\n", fullSrcPath, fullDstPath)
+
+	return nil
+}
+
+func (c *Client) Link(srcPath, dstPath string) error {
+	fullSrcPath := c.absPath(srcPath)
+	info, err := c.lookupPath(fullSrcPath)
+	if err != nil {
+		return err
+	}
+
+	srcIno := info.Inode
+	if !proto.IsRegular(info.Mode) {
+		log.LogErrorf("Link: not regular, src_path(%s) src_ino(%v) mode(%v)\n", fullSrcPath, srcIno, proto.OsMode(info.Mode))
+		return syscall.EPERM
+	}
+
+	fullDstPath := c.absPath(dstPath)
+	parentDir := gopath.Dir(fullDstPath)
+	filename := gopath.Base(fullDstPath)
+	info, err = c.lookupPath(parentDir)
+	if err != nil {
+		return err
+	}
+	parentIno := info.Inode
+
+	info, err = c.mw.Link(parentIno, filename, srcIno, fullDstPath)
+	if err != nil {
+		log.LogErrorf("Link: src_path(%s) src_ino(%v) dst_path(%s) parent(%v) err(%v)\n", fullSrcPath, srcIno, fullDstPath, parentIno, err)
+		return err
+	}
+
+	c.ic.Put(info)
+	log.LogDebugf("Link: src_path(%s) src_ino(%v) dst_path(%s) dst_ino(%v) parent(%v)\n", fullSrcPath, srcIno, fullDstPath, info.Inode, parentIno)
+
+	return nil
+}
+
+func (f *File) Fd() uint {
+	return f.fd
+}

--- a/lcnode/server.go
+++ b/lcnode/server.go
@@ -88,10 +88,9 @@ func doStart(s common.Server, cfg *config.Config) (err error) {
 		return
 	}
 
-	exporter.Init(ModuleName, cfg)
 	exporter.RegistConsul(l.clusterID, ModuleName, cfg)
-
 	log.LogInfo("lcnode start successfully")
+
 	return
 }
 

--- a/libsdk/libcfs.h
+++ b/libsdk/libcfs.h
@@ -155,6 +155,8 @@ extern int cfs_unlock_dir(int64_t id, char *path);
 extern int cfs_get_dir_lock(int64_t id, char *path, int64_t *lock_id, char **valid_time);
 extern int cfs_symlink(int64_t id, char *src_path, char *dst_path);
 extern int cfs_link(int64_t id, char *src_path, char *dst_path);
+extern char cfs_IsDir(mode_t mode);
+extern char cfs_IsRegular(mode_t mode);
 
 #ifdef __cplusplus
 }

--- a/libsdk/libsdk.go
+++ b/libsdk/libsdk.go
@@ -256,6 +256,24 @@ type client struct {
 	mu   sync.Mutex
 }
 
+//export cfs_IsDir
+func cfs_IsDir(mode C.mode_t) C.char {
+	var isDir uint8 = 0
+	if (mode & C.S_IFMT) == C.S_IFDIR {
+		isDir = 1
+	}
+	return C.char(isDir)
+}
+
+//export cfs_IsRegular
+func cfs_IsRegular(mode C.mode_t) C.char {
+	var isRegular uint8 = 0
+	if (mode & C.S_IFMT) == C.S_IFREG {
+		isRegular = 1
+	}
+	return C.char(isRegular)
+}
+
 //export cfs_symlink
 func cfs_symlink(id C.int64_t, src_path *C.char, dst_path *C.char) C.int {
 	c, exist := getClient(int64(id))

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -1324,6 +1324,17 @@ func parseAndExtractSetNodeInfoParams(r *http.Request) (params map[string]interf
 		params[markDiskBrokenThresholdKey] = val
 	}
 
+	if value = r.FormValue(autoDpMetaRepairKey); value != "" {
+		noParams = false
+		val := false
+		val, err = strconv.ParseBool(value)
+		if err != nil {
+			err = unmatchedKey(autoDpMetaRepairKey)
+			return
+		}
+		params[autoDpMetaRepairKey] = val
+	}
+
 	if noParams {
 		err = keyNotFound(nodeDeleteBatchCountKey)
 		return

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -1340,6 +1340,17 @@ func parseAndExtractSetNodeInfoParams(r *http.Request) (params map[string]interf
 		params[autoDpMetaRepairKey] = val
 	}
 
+	if value = r.FormValue(dpTimeoutKey); value != "" {
+		noParams = false
+		val := int64(0)
+		val, err = strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			err = unmatchedKey(dpTimeoutKey)
+			return
+		}
+		params[dpTimeoutKey] = val
+	}
+
 	if noParams {
 		err = keyNotFound(nodeDeleteBatchCountKey)
 		return

--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -397,6 +397,7 @@ type updateVolReq struct {
 	dpReadOnlyWhenVolFull   bool
 	enableQuota             bool
 	crossZone               bool
+	enableAutoDpMetaRepair  bool
 }
 
 func parseColdVolUpdateArgs(r *http.Request, vol *Vol) (args *coldVolArgs, err error) {
@@ -529,6 +530,10 @@ func parseVolUpdateReq(r *http.Request, vol *Vol, req *updateVolReq) (err error)
 	}
 
 	if req.dpReadOnlyWhenVolFull, err = extractBoolWithDefault(r, dpReadOnlyWhenVolFull, vol.DpReadOnlyWhenVolFull); err != nil {
+		return
+	}
+
+	if req.enableAutoDpMetaRepair, err = extractBoolWithDefault(r, autoDpMetaRepairKey, vol.EnableAutoMetaRepair.Load()); err != nil {
 		return
 	}
 

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1472,6 +1472,7 @@ func (m *Server) createDataPartition(w http.ResponseWriter, r *http.Request) {
 	}
 	if reqCreateCount > maxInitDataPartitionCnt {
 		err = fmt.Errorf("count[%d] exceeds maximum limit[%d]", reqCreateCount, maxInitDataPartitionCnt)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
 	if vol, err = m.cluster.getVol(volName); err != nil {

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -1627,6 +1627,21 @@ func (m *Server) addDataReplica(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	retry := 0
+	for {
+		if !dp.setRestoreReplicaForbidden() {
+			retry++
+			if retry > defaultDecommissionRetryLimit {
+			} else {
+				err = errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+			time.Sleep(1 * time.Second)
+		}
+		break
+	}
+
 	if err = m.cluster.addDataReplica(dp, addr, false); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
@@ -1636,7 +1651,6 @@ func (m *Server) addDataReplica(w http.ResponseWriter, r *http.Request) {
 	dp.DecommissionType = ManualAddReplica
 	dp.RecoverStartTime = time.Now()
 	dp.SetDecommissionStatus(DecommissionRunning)
-	dp.setRestoreReplicaForbidden()
 
 	dp.Status = proto.ReadOnly
 	dp.isRecover = true
@@ -1895,6 +1909,15 @@ func (m *Server) decommissionDataPartition(w http.ResponseWriter, r *http.Reques
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
+	decommissionType, err := parseUintParam(r, DecommissionType)
+	if err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+	// default is ManualDecommission
+	if decommissionType == 0 {
+		decommissionType = int(ManualDecommission)
+	}
 	node, err := c.dataNode(addr)
 	if err != nil {
 		rstMsg = fmt.Sprintf(" dataPartitionID :%v not find datanode for addr %v",
@@ -1902,7 +1925,7 @@ func (m *Server) decommissionDataPartition(w http.ResponseWriter, r *http.Reques
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: rstMsg})
 		return
 	}
-	err = m.cluster.markDecommissionDataPartition(dp, node, raftForce, ManualDecommission)
+	err = m.cluster.markDecommissionDataPartition(dp, node, raftForce, uint32(decommissionType))
 	if err != nil {
 		rstMsg = err.Error()
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: rstMsg})
@@ -7052,4 +7075,88 @@ func (m *Server) getAllMetaNodes(w http.ResponseWriter, r *http.Request) {
 	}()
 	metaNodes := m.cluster.allMetaNodes()
 	sendOkReply(w, r, newSuccessHTTPReply(metaNodes))
+}
+
+func (m *Server) recoverDiskErrorReplica(w http.ResponseWriter, r *http.Request) {
+	var (
+		msg         string
+		addr        string
+		dp          *DataPartition
+		dataNode    *DataNode
+		partitionID uint64
+		err         error
+	)
+	metric := exporter.NewTPCnt(apiToMetricsName(proto.AdminRecoverDiskErrorReplica))
+	defer func() {
+		doStatAndMetric(proto.AdminRecoverDiskErrorReplica, metric, err, nil)
+	}()
+
+	if partitionID, addr, err = parseRequestToAddDataReplica(r); err != nil {
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
+		return
+	}
+
+	if dp, err = m.cluster.getDataPartitionByID(partitionID); err != nil {
+		sendErrReply(w, r, newErrHTTPReply(proto.ErrDataPartitionNotExists))
+		return
+	}
+
+	dataNode, err = m.cluster.dataNode(addr)
+	if err != nil {
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+
+	if !proto.IsNormalDp(dp.PartitionType) {
+		err = fmt.Errorf("action[recoverDiskErrorReplica] [%d] is not normal dp, not support add or delete replica", dp.PartitionID)
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+
+	if dp.ReplicaNum == uint8(len(dp.Replicas)) {
+		err = fmt.Errorf("action[recoverDiskErrorReplica] [%d] already have %v replicas", dp.PartitionID, dp.ReplicaNum)
+		sendErrReply(w, r, newErrHTTPReply(err))
+	}
+
+	retry := 0
+	for {
+		if !dp.setRestoreReplicaForbidden() {
+			retry++
+			if retry > defaultDecommissionRetryLimit {
+			} else {
+				err = errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+			time.Sleep(1 * time.Second)
+		}
+		break
+	}
+	defer dp.setRestoreReplicaStop()
+	// restore raft member first
+	addPeer := proto.Peer{ID: dataNode.ID, Addr: addr}
+
+	log.LogInfof("action[recoverDiskErrorReplica] dp %v dst addr %v try add raft member, node id %v", dp.PartitionID, addr, dataNode.ID)
+	if err = m.cluster.addDataPartitionRaftMember(dp, addPeer); err != nil {
+		log.LogWarnf("action[recoverDiskErrorReplica] dp %v addr %v try add raft member err [%v]", dp.PartitionID, addr, err)
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	// find replica disk path
+	backupInfo, err := dataNode.getBackupDataPartitionInfo(partitionID)
+	if err != nil {
+		log.LogWarnf("action[recoverDiskErrorReplica] cannot find backup info for dp %v on dataNode %v", partitionID, dataNode.Addr)
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+
+	err = m.cluster.syncRecoverBackupDataPartitionReplica(addr, backupInfo.Disk, dp)
+	if err != nil {
+		log.LogWarnf("action[recoverDiskErrorReplica] dp(%v)  recover replica [%v_%v] fail %v", dp.PartitionID, addr, backupInfo.Disk, err)
+		sendErrReply(w, r, newErrHTTPReply(err))
+		return
+	}
+	msg = fmt.Sprintf("action[recoverDiskErrorReplica] dp(%v)  recover replica [%v_%v] successfully", dp.decommissionInfo(), backupInfo.Addr, backupInfo.Disk)
+	log.LogInfof("%v", msg)
+	sendOkReply(w, r, newSuccessHTTPReply(msg))
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -795,7 +795,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 		VolDeletionDelayTimeHour: m.cluster.cfg.volDelayDeleteTimeHour,
 		DpRepairTimeout:          m.cluster.GetDecommissionDataPartitionRecoverTimeOut(),
 		MarkDiskBrokenThreshold:  m.cluster.getMarkDiskBrokenThreshold(),
-		DisableAutoDpMetaRepair:  m.cluster.getDisableAutoDpMetaRepair(),
+		EnableAutoDpMetaRepair:   m.cluster.getEnableAutoDpMetaRepair(),
 		EnableAutoDecommission:   m.cluster.AutoDecommissionDiskIsEnabled(),
 		DecommissionDiskLimit:    m.cluster.GetDecommissionDiskLimit(),
 		MasterNodes:              make([]proto.NodeView, 0),
@@ -2306,6 +2306,7 @@ func (m *Server) updateVol(w http.ResponseWriter, r *http.Request) {
 
 	newArgs.dpReplicaNum = uint8(req.replicaNum)
 	newArgs.dpReadOnlyWhenVolFull = req.dpReadOnlyWhenVolFull
+	newArgs.enableAutoDpMetaRepair = req.enableAutoDpMetaRepair
 
 	log.LogWarnf("[updateVolOut] name [%s], z1 [%s], z2[%s] replicaNum[%v]", req.name, req.zoneName, vol.Name, req.replicaNum)
 	if err = m.cluster.updateVol(req.name, req.authKey, newArgs); err != nil {
@@ -2691,6 +2692,7 @@ func newSimpleView(vol *Vol) (view *proto.SimpleVolView) {
 		Forbidden:               vol.Forbidden,
 		DeleteExecTime:          vol.DeleteExecTime,
 		DpRepairBlockSize:       vol.dpRepairBlockSize,
+		EnableAutoDpMetaRepair:  vol.EnableAutoMetaRepair.Load(),
 	}
 
 	vol.uidSpaceManager.rwMutex.RLock()
@@ -3117,7 +3119,7 @@ func (m *Server) setNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 
 	if val, ok := params[autoDpMetaRepairKey]; ok {
 		if autoRepair, ok := val.(bool); ok {
-			if err = m.cluster.setDisableAutoDpMetaRepair(!autoRepair); err != nil {
+			if err = m.cluster.setEnableAutoDpMetaRepair(autoRepair); err != nil {
 				sendErrReply(w, r, newErrHTTPReply(err))
 				return
 			}

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/cubefs/cubefs/util/auditlog"
 	"io"
 	"math"
 	"net/http"
@@ -2982,6 +2983,8 @@ func (m *Server) cancelDecommissionDataNode(w http.ResponseWriter, r *http.Reque
 		err         error
 		// dps         []uint64
 		node *DataNode
+		zone *Zone
+		ns   *nodeSet
 	)
 
 	metric := exporter.NewTPCnt(apiToMetricsName(proto.PauseDecommissionDataNode))
@@ -2993,21 +2996,28 @@ func (m *Server) cancelDecommissionDataNode(w http.ResponseWriter, r *http.Reque
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: err.Error()})
 		return
 	}
-	//partitions := m.cluster.getAllDataPartitionByDataNode(offLineAddr)
-	//for _, dp := range partitions {
-	//	dps = append(dps, dp.PartitionID)
-	//}
-	//if len(partitions) != 0 {
-	//	rstMsg = fmt.Sprintf("cancel decommission data node [%v] failed: %v dp [%v] left", offLineAddr,
-	//		len(dps), dps)
-	//	sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: rstMsg})
-	//	return
-	//}
+
 	if node, err = m.cluster.dataNode(offLineAddr); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}
-	node.resetDecommissionStatus()
+	if zone, err = m.cluster.t.getZone(node.ZoneName); err != nil {
+		ret := fmt.Sprintf("action[queryDataNodeDecoProgress] find datanode[%s] zone failed[%v]",
+			node.Addr, err.Error())
+		log.LogWarnf("%v", ret)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: ret})
+		return
+	}
+
+	if ns, err = zone.getNodeSet(node.NodeSetID); err != nil {
+		ret := fmt.Sprintf("action[queryDataNodeDecoProgress] find datanode[%s] nodeset[%v] failed[%v]",
+			node.Addr, node.NodeSetID, err.Error())
+		log.LogWarnf("%v", ret)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: ret})
+		return
+	}
+	// can alloc dp
+	node.ToBeOffline = false
 	if err = m.cluster.syncUpdateDataNode(node); err != nil {
 		sendErrReply(w, r, newErrHTTPReply(proto.ErrDataNodeNotExists))
 		return
@@ -3015,7 +3025,13 @@ func (m *Server) cancelDecommissionDataNode(w http.ResponseWriter, r *http.Reque
 	// find all decommission failed data partitions for this node
 	leftPartitions := m.cluster.getAllDecommissionDataPartitionByDataNode(offLineAddr)
 	for _, dp := range leftPartitions {
+		if dp.GetDecommissionStatus() == DecommissionSuccess || dp.IsRollbackFailed() || ns.HasDecommissionToken(dp.PartitionID) {
+			continue
+		}
+		msg := fmt.Sprintf("dp(%v) cancel decommission", dp.decommissionInfo())
 		dp.ResetDecommissionStatus()
+		dp.setRestoreReplicaStop()
+		auditlog.LogMasterOp("CancelDataPartitionDecommission", msg, nil)
 	}
 
 	rstMsg = fmt.Sprintf("cancel decommission data node [%v] success", offLineAddr)
@@ -7005,6 +7021,9 @@ func (m *Server) cancelDisableDisk(w http.ResponseWriter, r *http.Request) {
 	var (
 		offLineAddr, diskPath string
 		err                   error
+		dataNode              *DataNode
+		zone                  *Zone
+		ns                    *nodeSet
 	)
 
 	metric := exporter.NewTPCnt("req_cancelDecommissionDisk")
@@ -7024,12 +7043,40 @@ func (m *Server) cancelDisableDisk(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: ret})
 		return
 	}
+	if dataNode, err = m.cluster.dataNode(offLineAddr); err != nil {
+		ret := fmt.Sprintf("action[queryDiskDecoProgress]cannot find dataNode[%s]", offLineAddr)
+		log.LogWarnf("%v", ret)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: ret})
+		return
+	}
+
+	if zone, err = m.cluster.t.getZone(dataNode.ZoneName); err != nil {
+		ret := fmt.Sprintf("action[queryDiskDecoProgress] find datanode[%s] zone failed[%v]",
+			dataNode.Addr, err.Error())
+		log.LogWarnf("%v", ret)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: ret})
+		return
+	}
+	if ns, err = zone.getNodeSet(dataNode.NodeSetID); err != nil {
+		ret := fmt.Sprintf("action[queryDiskDecoProgress] find datanode[%s] nodeset[%v] failed[%v]",
+			dataNode.Addr, dataNode.NodeSetID, err.Error())
+		log.LogWarnf("%v", ret)
+		sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeParamError, Msg: ret})
+		return
+	}
 	disk := value.(*DecommissionDisk)
 	dps := m.cluster.getAllDecommissionDataPartitionByDiskAndTerm(disk.SrcAddr, disk.DiskPath, disk.DecommissionTerm)
 	for _, dp := range dps {
+		if dp.GetDecommissionStatus() == DecommissionSuccess || dp.IsRollbackFailed() || ns.HasDecommissionToken(dp.PartitionID) {
+			continue
+		}
+		msg := fmt.Sprintf("dp(%v) cancel decommission", dp.decommissionInfo())
 		dp.ResetDecommissionStatus()
+		dp.setRestoreReplicaStop()
+		auditlog.LogMasterOp("CancelDataPartitionDecommission", msg, nil)
 	}
-	m.cluster.DecommissionDisks.Delete(key)
+	//m.cluster.DecommissionDisks.Delete(key)
+	disk.SetDecommissionStatus(DecommissionCancel)
 	rstMsg := fmt.Sprintf("cancel decommission disk[%s] successfully ", key)
 	sendOkReply(w, r, newSuccessHTTPReply(rstMsg))
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -793,6 +793,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 		MaxMetaNodeID:            m.cluster.idAlloc.commonID,
 		MaxMetaPartitionID:       m.cluster.idAlloc.metaPartitionID,
 		VolDeletionDelayTimeHour: m.cluster.cfg.volDelayDeleteTimeHour,
+		DpRepairTimeout:          m.cluster.GetDecommissionDataPartitionRecoverTimeOut(),
 		MarkDiskBrokenThreshold:  m.cluster.getMarkDiskBrokenThreshold(),
 		EnableAutoDecommission:   m.cluster.AutoDecommissionDiskIsEnabled(),
 		DecommissionDiskLimit:    m.cluster.GetDecommissionDiskLimit(),
@@ -3907,7 +3908,6 @@ func (m *Server) getNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	resp[nodeMarkDeleteRateKey] = fmt.Sprintf("%v", m.cluster.cfg.DataNodeDeleteLimitRate)
 	resp[nodeDeleteWorkerSleepMs] = fmt.Sprintf("%v", m.cluster.cfg.MetaNodeDeleteWorkerSleepMs)
 	resp[nodeAutoRepairRateKey] = fmt.Sprintf("%v", m.cluster.cfg.DataNodeAutoRepairLimitRate)
-	resp[nodeDpRepairTimeOutKey] = fmt.Sprintf("%v", m.cluster.cfg.DpRepairTimeOut)
 	resp[nodeDpMaxRepairErrCntKey] = fmt.Sprintf("%v", m.cluster.cfg.DpMaxRepairErrCnt)
 	resp[clusterLoadFactorKey] = fmt.Sprintf("%v", m.cluster.cfg.ClusterLoadFactor)
 	resp[maxDpCntLimitKey] = fmt.Sprintf("%v", m.cluster.getMaxDpCntLimit())

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -798,6 +798,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 		EnableAutoDpMetaRepair:   m.cluster.getEnableAutoDpMetaRepair(),
 		EnableAutoDecommission:   m.cluster.AutoDecommissionDiskIsEnabled(),
 		DecommissionDiskLimit:    m.cluster.GetDecommissionDiskLimit(),
+		DpTimeout:                time.Duration(m.cluster.getDataPartitionTimeoutSec()) * time.Second,
 		MasterNodes:              make([]proto.NodeView, 0),
 		MetaNodes:                make([]proto.NodeView, 0),
 		DataNodes:                make([]proto.NodeView, 0),
@@ -3120,6 +3121,15 @@ func (m *Server) setNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if val, ok := params[autoDpMetaRepairKey]; ok {
 		if autoRepair, ok := val.(bool); ok {
 			if err = m.cluster.setEnableAutoDpMetaRepair(autoRepair); err != nil {
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+		}
+	}
+
+	if val, ok := params[dpTimeoutKey]; ok {
+		if dpTimeout, ok := val.(int64); ok {
+			if err = m.cluster.setDataPartitionTimeout(dpTimeout); err != nil {
 				sendErrReply(w, r, newErrHTTPReply(err))
 				return
 			}

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -2818,6 +2818,7 @@ func (m *Server) getDataNode(w http.ResponseWriter, r *http.Request) {
 		CpuUtil:                   dataNode.CpuUtil.Load(),
 		IoUtils:                   dataNode.GetIoUtils(),
 		DecommissionedDisk:        dataNode.getDecommissionedDisks(),
+		BackupDataPartitions:      dataNode.getBackupDataPartitionIDs(),
 	}
 
 	sendOkReply(w, r, newSuccessHTTPReply(dataNodeInfo))

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -368,7 +368,7 @@ func (m *Server) getTopology(w http.ResponseWriter, r *http.Request) {
 				dataNode := value.(*DataNode)
 				nsView.DataNodes = append(nsView.DataNodes, proto.NodeView{
 					ID: dataNode.ID, Addr: dataNode.Addr,
-					DomainAddr: dataNode.DomainAddr, IsActive: dataNode.isActive, IsWritable: dataNode.isWriteAble(),
+					DomainAddr: dataNode.DomainAddr, IsActive: dataNode.isActive, IsWritable: dataNode.IsWriteAble(),
 				})
 				return true
 			})
@@ -376,7 +376,7 @@ func (m *Server) getTopology(w http.ResponseWriter, r *http.Request) {
 				metaNode := value.(*MetaNode)
 				nsView.MetaNodes = append(nsView.MetaNodes, proto.NodeView{
 					ID: metaNode.ID, Addr: metaNode.Addr,
-					DomainAddr: metaNode.DomainAddr, IsActive: metaNode.IsActive, IsWritable: metaNode.isWritable(),
+					DomainAddr: metaNode.DomainAddr, IsActive: metaNode.IsActive, IsWritable: metaNode.IsWriteAble(),
 				})
 				return true
 			})
@@ -480,8 +480,8 @@ func (m *Server) listNodeSets(w http.ResponseWriter, r *http.Request) {
 				ID:                  ns.ID,
 				Capacity:            ns.Capacity,
 				Zone:                zone.name,
-				CanAllocDataNodeCnt: ns.canAllocDataNodeCnt(),
-				CanAllocMetaNodeCnt: ns.canAllocMetaNodeCnt(),
+				CanAllocDataNodeCnt: ns.calcNodesForAlloc(ns.dataNodes),
+				CanAllocMetaNodeCnt: ns.calcNodesForAlloc(ns.metaNodes),
 				DataNodeNum:         ns.dataNodeLen(),
 				MetaNodeNum:         ns.metaNodeLen(),
 			}
@@ -521,8 +521,8 @@ func (m *Server) getNodeSet(w http.ResponseWriter, r *http.Request) {
 		ID:                  ns.ID,
 		Capacity:            ns.Capacity,
 		Zone:                ns.zoneName,
-		CanAllocDataNodeCnt: ns.canAllocDataNodeCnt(),
-		CanAllocMetaNodeCnt: ns.canAllocMetaNodeCnt(),
+		CanAllocDataNodeCnt: ns.calcNodesForAlloc(ns.dataNodes),
+		CanAllocMetaNodeCnt: ns.calcNodesForAlloc(ns.metaNodes),
 		DataNodeSelector:    ns.GetDataNodeSelector(),
 		MetaNodeSelector:    ns.GetMetaNodeSelector(),
 	}
@@ -533,7 +533,7 @@ func (m *Server) getNodeSet(w http.ResponseWriter, r *http.Request) {
 			Status:     dn.isActive,
 			DomainAddr: dn.DomainAddr,
 			ID:         dn.ID,
-			IsWritable: dn.isWriteAble(),
+			IsWritable: dn.IsWriteAble(),
 			Total:      dn.Total,
 			Used:       dn.Used,
 			Avail:      dn.Total - dn.Used,
@@ -547,7 +547,7 @@ func (m *Server) getNodeSet(w http.ResponseWriter, r *http.Request) {
 			Status:     mn.IsActive,
 			DomainAddr: mn.DomainAddr,
 			ID:         mn.ID,
-			IsWritable: mn.isWritable(),
+			IsWritable: mn.IsWriteAble(),
 			Total:      mn.Total,
 			Used:       mn.Used,
 			Avail:      mn.Total - mn.Used,
@@ -2827,7 +2827,7 @@ func (m *Server) getDataNode(w http.ResponseWriter, r *http.Request) {
 		ReportTime:                dataNode.ReportTime,
 		IsActive:                  dataNode.isActive,
 		ToBeOffline:               dataNode.ToBeOffline,
-		IsWriteAble:               dataNode.isWriteAble(),
+		IsWriteAble:               dataNode.IsWriteAble(),
 		UsageRatio:                dataNode.UsageRatio,
 		SelectedTimes:             dataNode.SelectedTimes,
 		DataPartitionReports:      dataNode.DataPartitionReports,
@@ -2837,7 +2837,7 @@ func (m *Server) getDataNode(w http.ResponseWriter, r *http.Request) {
 		BadDisks:                  dataNode.BadDisks,
 		RdOnly:                    dataNode.RdOnly,
 		CanAllocPartition:         dataNode.canAlloc() && dataNode.canAllocDp(),
-		MaxDpCntLimit:             dataNode.GetDpCntLimit(),
+		MaxDpCntLimit:             dataNode.GetPartitionLimitCnt(),
 		CpuUtil:                   dataNode.CpuUtil.Load(),
 		IoUtils:                   dataNode.GetIoUtils(),
 		DecommissionedDisk:        dataNode.getDecommissionedDisks(),
@@ -2927,7 +2927,7 @@ func (m *Server) migrateDataNodeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !targetNode.isWriteAble() || !targetNode.dpCntInLimit() {
+	if !targetNode.IsWriteAble() || !targetNode.PartitionCntLimited() {
 		err = fmt.Errorf("[%s] is not writable, can't used as target addr for migrate", targetAddr)
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
@@ -3472,7 +3472,7 @@ func (m *Server) buildNodeSetGrpInfo(nsg *nodeSetGroup) *proto.SimpleNodeSetGrpI
 		nsg.nodeSets[i].dataNodes.Range(func(key, value interface{}) bool {
 			node := value.(*DataNode)
 			nsStat.DataTotal += node.Total
-			if node.isWriteAble() {
+			if node.IsWriteAble() {
 				nsStat.DataUsed += node.Used
 			} else {
 				nsStat.DataUsed += node.Total
@@ -3489,7 +3489,7 @@ func (m *Server) buildNodeSetGrpInfo(nsg *nodeSetGroup) *proto.SimpleNodeSetGrpI
 				Addr:               node.Addr,
 				ReportTime:         node.ReportTime,
 				IsActive:           node.isActive,
-				IsWriteAble:        node.isWriteAble(),
+				IsWriteAble:        node.IsWriteAble(),
 				UsageRatio:         node.UsageRatio,
 				SelectedTimes:      node.SelectedTimes,
 				DataPartitionCount: node.DataPartitionCount,
@@ -3512,7 +3512,7 @@ func (m *Server) buildNodeSetGrpInfo(nsg *nodeSetGroup) *proto.SimpleNodeSetGrpI
 				ID:                 node.ID,
 				Addr:               node.Addr,
 				IsActive:           node.IsActive,
-				IsWriteAble:        node.isWritable(),
+				IsWriteAble:        node.IsWriteAble(),
 				ZoneName:           node.ZoneName,
 				MaxMemAvailWeight:  node.MaxMemAvailWeight,
 				Total:              node.Total,
@@ -4466,7 +4466,7 @@ func (m *Server) getMetaNode(w http.ResponseWriter, r *http.Request) {
 		Addr:                      metaNode.Addr,
 		DomainAddr:                metaNode.DomainAddr,
 		IsActive:                  metaNode.IsActive,
-		IsWriteAble:               metaNode.isWritable(),
+		IsWriteAble:               metaNode.IsWriteAble(),
 		ZoneName:                  metaNode.ZoneName,
 		MaxMemAvailWeight:         metaNode.MaxMemAvailWeight,
 		Total:                     metaNode.Total,
@@ -4478,8 +4478,8 @@ func (m *Server) getMetaNode(w http.ResponseWriter, r *http.Request) {
 		MetaPartitionCount:        metaNode.MetaPartitionCount,
 		NodeSetID:                 metaNode.NodeSetID,
 		PersistenceMetaPartitions: metaNode.PersistenceMetaPartitions,
-		CanAllowPartition:         metaNode.isWritable() && metaNode.mpCntInLimit(),
-		MaxMpCntLimit:             metaNode.GetMpCntLimit(),
+		CanAllowPartition:         metaNode.IsWriteAble() && metaNode.PartitionCntLimited(),
+		MaxMpCntLimit:             metaNode.GetPartitionLimitCnt(),
 		CpuUtil:                   metaNode.CpuUtil.Load(),
 	}
 	sendOkReply(w, r, newSuccessHTTPReply(metaNodeInfo))
@@ -4636,7 +4636,7 @@ func (m *Server) migrateMetaNodeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if !targetNode.isWritable() || !targetNode.mpCntInLimit() {
+	if !targetNode.IsWriteAble() || !targetNode.PartitionCntLimited() {
 		err = fmt.Errorf("[%s] is not writable, can't used as target addr for migrate", targetAddr)
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/cubefs/cubefs/util/auditlog"
 	"io"
 	"math"
 	"net/http"
@@ -32,6 +31,7 @@ import (
 
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util"
+	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/compressor"
 	"github.com/cubefs/cubefs/util/cryptoutil"
 	"github.com/cubefs/cubefs/util/errors"
@@ -1639,6 +1639,7 @@ func (m *Server) addDataReplica(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			time.Sleep(1 * time.Second)
+			continue
 		}
 		break
 	}
@@ -5448,10 +5449,10 @@ func (m *Server) GetAllVersionInfo(w http.ResponseWriter, r *http.Request) {
 		sendErrReply(w, r, newErrHTTPReply(proto.ErrVolNotExists))
 		return
 	}
-	//if !proto.IsHot(vol.VolType) {
+	// if !proto.IsHot(vol.VolType) {
 	//	sendErrReply(w, r, &proto.HTTPReply{Code: proto.ErrCodeVersionOpError, Msg: "vol need be hot one"})
 	//	return
-	//}
+	// }
 
 	verList = vol.VersionMgr.getVersionList()
 
@@ -7075,7 +7076,6 @@ func (m *Server) cancelDisableDisk(w http.ResponseWriter, r *http.Request) {
 		dp.setRestoreReplicaStop()
 		auditlog.LogMasterOp("CancelDataPartitionDecommission", msg, nil)
 	}
-	//m.cluster.DecommissionDisks.Delete(key)
 	disk.SetDecommissionStatus(DecommissionCancel)
 	rstMsg := fmt.Sprintf("cancel decommission disk[%s] successfully ", key)
 	sendOkReply(w, r, newSuccessHTTPReply(rstMsg))
@@ -7170,12 +7170,12 @@ func (m *Server) recoverDiskErrorReplica(w http.ResponseWriter, r *http.Request)
 		if !dp.setRestoreReplicaForbidden() {
 			retry++
 			if retry > defaultDecommissionRetryLimit {
-			} else {
 				err = errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
 				sendErrReply(w, r, newErrHTTPReply(err))
 				return
 			}
 			time.Sleep(1 * time.Second)
+			continue
 		}
 		break
 	}

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -477,11 +477,13 @@ func (m *Server) listNodeSets(w http.ResponseWriter, r *http.Request) {
 		nsc := zone.getAllNodeSet()
 		for _, ns := range nsc {
 			nsStat := &proto.NodeSetStat{
-				ID:          ns.ID,
-				Capacity:    ns.Capacity,
-				Zone:        zone.name,
-				DataNodeNum: ns.dataNodeLen(),
-				MetaNodeNum: ns.metaNodeLen(),
+				ID:                  ns.ID,
+				Capacity:            ns.Capacity,
+				Zone:                zone.name,
+				CanAllocDataNodeCnt: ns.canAllocDataNodeCnt(),
+				CanAllocMetaNodeCnt: ns.canAllocMetaNodeCnt(),
+				DataNodeNum:         ns.dataNodeLen(),
+				MetaNodeNum:         ns.metaNodeLen(),
 			}
 			nodeSetStats = append(nodeSetStats, nsStat)
 		}
@@ -516,11 +518,13 @@ func (m *Server) getNodeSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	nsStat := &proto.NodeSetStatInfo{
-		ID:               ns.ID,
-		Capacity:         ns.Capacity,
-		Zone:             ns.zoneName,
-		DataNodeSelector: ns.GetDataNodeSelector(),
-		MetaNodeSelector: ns.GetMetaNodeSelector(),
+		ID:                  ns.ID,
+		Capacity:            ns.Capacity,
+		Zone:                ns.zoneName,
+		CanAllocDataNodeCnt: ns.canAllocDataNodeCnt(),
+		CanAllocMetaNodeCnt: ns.canAllocMetaNodeCnt(),
+		DataNodeSelector:    ns.GetDataNodeSelector(),
+		MetaNodeSelector:    ns.GetMetaNodeSelector(),
 	}
 	ns.dataNodes.Range(func(key, value interface{}) bool {
 		dn := value.(*DataNode)

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -795,6 +795,7 @@ func (m *Server) getCluster(w http.ResponseWriter, r *http.Request) {
 		VolDeletionDelayTimeHour: m.cluster.cfg.volDelayDeleteTimeHour,
 		DpRepairTimeout:          m.cluster.GetDecommissionDataPartitionRecoverTimeOut(),
 		MarkDiskBrokenThreshold:  m.cluster.getMarkDiskBrokenThreshold(),
+		DisableAutoDpMetaRepair:  m.cluster.getDisableAutoDpMetaRepair(),
 		EnableAutoDecommission:   m.cluster.AutoDecommissionDiskIsEnabled(),
 		DecommissionDiskLimit:    m.cluster.GetDecommissionDiskLimit(),
 		MasterNodes:              make([]proto.NodeView, 0),
@@ -3108,6 +3109,15 @@ func (m *Server) setNodeInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if val, ok := params[markDiskBrokenThresholdKey]; ok {
 		if markDiskBrokenThreshold, ok := val.(float64); ok {
 			if err = m.cluster.setMarkDiskBrokenThreshold(markDiskBrokenThreshold); err != nil {
+				sendErrReply(w, r, newErrHTTPReply(err))
+				return
+			}
+		}
+	}
+
+	if val, ok := params[autoDpMetaRepairKey]; ok {
+		if autoRepair, ok := val.(bool); ok {
+			if err = m.cluster.setDisableAutoDpMetaRepair(!autoRepair); err != nil {
 				sendErrReply(w, r, newErrHTTPReply(err))
 				return
 			}

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -1645,14 +1645,14 @@ func TestSetMarkDiskBrokenThreshold(t *testing.T) {
 
 func TestSetEnableAutoDpMetaRepair(t *testing.T) {
 	reqUrl := fmt.Sprintf("%v%v", hostAddr, proto.AdminSetNodeInfo)
-	oldVal := server.cluster.getDisableAutoDpMetaRepair()
+	oldVal := server.cluster.getEnableAutoDpMetaRepair()
 	setVal := !oldVal
 	setUrl := fmt.Sprintf("%v?%v=%v&dirSizeLimit=0", reqUrl, autoDpMetaRepairKey, setVal)
 	unsetUrl := fmt.Sprintf("%v?%v=%v&dirSizeLimit=0", reqUrl, autoDpMetaRepairKey, oldVal)
 	process(setUrl, t)
-	require.EqualValues(t, !setVal, server.cluster.getDisableAutoDpMetaRepair())
+	require.EqualValues(t, setVal, server.cluster.getEnableAutoDpMetaRepair())
 	process(unsetUrl, t)
-	require.EqualValues(t, !oldVal, server.cluster.getDisableAutoDpMetaRepair())
+	require.EqualValues(t, oldVal, server.cluster.getEnableAutoDpMetaRepair())
 }
 
 func TestSetDiscardDp(t *testing.T) {
@@ -1700,4 +1700,29 @@ func TestSetDecommissionDiskLimit(t *testing.T) {
 
 	process(unsetUrl, t)
 	require.EqualValues(t, oldVal, server.cluster.GetDecommissionDiskLimit())
+}
+
+func TestUpdateVolAutoDpMetaRepair(t *testing.T) {
+	name := "enableAutoDpMetaRepairVol"
+	createVol(map[string]interface{}{nameKey: name}, t)
+	vol, err := server.cluster.getVol(name)
+	if err != nil {
+		t.Errorf("failed to get vol %v, err %v", name, err)
+		return
+	}
+	defer func() {
+		reqURL := fmt.Sprintf("%v%v?name=%v&authKey=%v", hostAddr, proto.AdminDeleteVol, name, buildAuthKey(testOwner))
+		process(reqURL, t)
+	}()
+	reqUrl := fmt.Sprintf("%v%v?%v=%v&%v=%v", hostAddr, proto.AdminUpdateVol, nameKey, vol.Name, volAuthKey, buildAuthKey(testOwner))
+	oldVal := vol.EnableAutoMetaRepair.Load()
+	setVal := !oldVal
+	setUrl := fmt.Sprintf("%v&%v=%v", reqUrl, autoDpMetaRepairKey, setVal)
+	unsetUrl := fmt.Sprintf("%v&%v=%v", reqUrl, autoDpMetaRepairKey, oldVal)
+
+	process(setUrl, t)
+	require.EqualValues(t, setVal, vol.EnableAutoMetaRepair.Load())
+
+	process(unsetUrl, t)
+	require.EqualValues(t, oldVal, vol.EnableAutoMetaRepair.Load())
 }

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -1655,6 +1655,30 @@ func TestSetEnableAutoDpMetaRepair(t *testing.T) {
 	require.EqualValues(t, oldVal, server.cluster.getEnableAutoDpMetaRepair())
 }
 
+func TestSetDpTimeout(t *testing.T) {
+	reqUrl := fmt.Sprintf("%v%v", hostAddr, proto.AdminSetNodeInfo)
+	oldVal := server.cluster.getDataPartitionTimeoutSec()
+	setVal := int64(10)
+	setUrl := fmt.Sprintf("%v?%v=%v&dirSizeLimit=0", reqUrl, dpTimeoutKey, setVal)
+	unsetUrl := fmt.Sprintf("%v?%v=%v&dirSizeLimit=0", reqUrl, dpTimeoutKey, oldVal)
+	process(setUrl, t)
+	require.EqualValues(t, setVal, server.cluster.getDataPartitionTimeoutSec())
+	process(unsetUrl, t)
+	require.EqualValues(t, oldVal, server.cluster.getDataPartitionTimeoutSec())
+}
+
+func TestSetDpRepairTimeout(t *testing.T) {
+	reqUrl := fmt.Sprintf("%v%v", hostAddr, proto.AdminSetNodeInfo)
+	oldVal := server.cluster.cfg.DpRepairTimeOut
+	setVal := 4 * time.Hour
+	setUrl := fmt.Sprintf("%v?%v=%v", reqUrl, nodeDpRepairTimeOutKey, uint64(setVal))
+	unsetUrl := fmt.Sprintf("%v?%v=%v", reqUrl, nodeDpRepairTimeOutKey, oldVal)
+	process(setUrl, t)
+	require.EqualValues(t, setVal, time.Duration(server.cluster.cfg.DpRepairTimeOut))
+	process(unsetUrl, t)
+	require.EqualValues(t, oldVal, server.cluster.cfg.DpRepairTimeOut)
+}
+
 func TestSetDiscardDp(t *testing.T) {
 	name := "setDiscardVol"
 	createVol(map[string]interface{}{nameKey: name}, t)

--- a/master/api_service_test.go
+++ b/master/api_service_test.go
@@ -1643,6 +1643,18 @@ func TestSetMarkDiskBrokenThreshold(t *testing.T) {
 	require.EqualValues(t, oldVal, server.cluster.getMarkDiskBrokenThreshold())
 }
 
+func TestSetEnableAutoDpMetaRepair(t *testing.T) {
+	reqUrl := fmt.Sprintf("%v%v", hostAddr, proto.AdminSetNodeInfo)
+	oldVal := server.cluster.getDisableAutoDpMetaRepair()
+	setVal := !oldVal
+	setUrl := fmt.Sprintf("%v?%v=%v&dirSizeLimit=0", reqUrl, autoDpMetaRepairKey, setVal)
+	unsetUrl := fmt.Sprintf("%v?%v=%v&dirSizeLimit=0", reqUrl, autoDpMetaRepairKey, oldVal)
+	process(setUrl, t)
+	require.EqualValues(t, !setVal, server.cluster.getDisableAutoDpMetaRepair())
+	process(unsetUrl, t)
+	require.EqualValues(t, !oldVal, server.cluster.getDisableAutoDpMetaRepair())
+}
+
 func TestSetDiscardDp(t *testing.T) {
 	name := "setDiscardVol"
 	createVol(map[string]interface{}{nameKey: name}, t)

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -1773,7 +1773,6 @@ func (c *Cluster) getHostFromNormalZone(nodeType uint32, excludeZones []string, 
 	zoneNumNeed int, specifiedZoneName string) (hosts []string, peers []proto.Peer, err error,
 ) {
 	var zonesQualified []*Zone
-	zonesQualified = make([]*Zone, 0)
 	if replicaNum <= zoneNumNeed {
 		zoneNumNeed = replicaNum
 	}
@@ -5037,8 +5036,7 @@ func (c *Cluster) syncRecoverBackupDataPartitionReplica(host, disk string, dp *D
 	if err != nil {
 		return
 	}
-	var task *proto.AdminTask
-	task = dp.createTaskToRecoverBackupDataPartitionReplica(host, disk)
+	task := dp.createTaskToRecoverBackupDataPartitionReplica(host, disk)
 	if _, err = dataNode.TaskManager.syncSendAdminTask(task); err != nil {
 		return
 	}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -4847,9 +4847,8 @@ func (c *Cluster) SetAutoDecommissionDisk(flag bool) {
 func (c *Cluster) GetDecommissionDataPartitionRecoverTimeOut() time.Duration {
 	if c.cfg.DpRepairTimeOut == 0 {
 		return time.Hour * 2
-	} else {
-		return time.Second * time.Duration(c.cfg.DpRepairTimeOut)
 	}
+	return time.Duration(c.cfg.DpRepairTimeOut)
 }
 
 func (c *Cluster) GetDecommissionDiskLimit() (limit uint32) {

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -4407,6 +4407,12 @@ func (c *Cluster) TryDecommissionDisk(disk *DecommissionDisk) {
 				ns.AddToDecommissionDataPartitionList(dp, c)
 				ignoreIDs = append(ignoreIDs, dp.PartitionID)
 				continue
+			} else if strings.Contains(err.Error(), proto.ErrPerformingDecommission.Error()) {
+				disk.DecommissionDpTotal -= 1
+				ignoreIDs = append(ignoreIDs, dp.PartitionID)
+				log.LogWarnf("action[TryDecommissionDisk] disk(%v) dp(%v) is decommissioning",
+					disk.decommissionInfo(), dp.PartitionID)
+				continue
 			} else {
 				// mark as failed and set decommission src, make sure it can be included in the calculation of progress
 				dp.DecommissionSrcAddr = node.Addr

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2787,7 +2787,8 @@ func (c *Cluster) deleteDataReplica(dp *DataPartition, dataNode *DataNode, raftF
 	// in case dataNode is unreachable,update meta first.
 	dp.removeReplicaByAddr(dataNode.Addr)
 	dp.checkAndRemoveMissReplica(dataNode.Addr)
-
+	log.LogDebugf("action[deleteDataReplica] vol[%v],data partition[%v] remove replica[%v] force(%v)",
+		dp.VolName, dp.decommissionInfo(), dataNode.Addr, raftForceDel)
 	if err = dp.update("deleteDataReplica", dp.VolName, dp.Peers, dp.Hosts, c); err != nil {
 		dp.Unlock()
 		return
@@ -5018,4 +5019,19 @@ func (c *Cluster) RetryDecommissionDisk(addr string, diskPath string) bool {
 		return status == DecommissionFail
 	}
 	return false
+}
+
+func (c *Cluster) syncRecoverBackupDataPartitionReplica(host, disk string, dp *DataPartition) (err error) {
+	log.LogInfof("action[syncRecoverBackupDataPartitionReplica] dp [%v] to recover replica on %v_%v", dp.PartitionID, host, disk)
+	var dataNode *DataNode
+	dataNode, err = c.dataNode(host)
+	if err != nil {
+		return
+	}
+	var task *proto.AdminTask
+	task = dp.createTaskToRecoverBackupDataPartitionReplica(host, disk)
+	if _, err = dataNode.TaskManager.syncSendAdminTask(task); err != nil {
+		return
+	}
+	return
 }

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -105,6 +105,7 @@ type Cluster struct {
 	DecommissionDiskLimit        uint32
 	S3ApiQosQuota                *sync.Map // (api,uid,limtType) -> limitQuota
 	MarkDiskBrokenThreshold      atomicutil.Float64
+	DisableAutoDpMetaRepair      atomicutil.Bool
 }
 
 type delayDeleteVolInfo struct {
@@ -369,6 +370,7 @@ func newCluster(name string, leaderInfo *LeaderInfo, fsm *MetadataFsm, partition
 	c.snapshotMgr.cluster = c
 	c.S3ApiQosQuota = new(sync.Map)
 	c.MarkDiskBrokenThreshold.Store(defaultMarkDiskBrokenThreshold)
+	c.DisableAutoDpMetaRepair.Store(defaultDisableDpMetaRepair)
 	return
 }
 
@@ -3774,6 +3776,23 @@ func (c *Cluster) getMarkDiskBrokenThreshold() (v float64) {
 	if v < 0 || v > 1 {
 		v = defaultMarkDiskBrokenThreshold
 	}
+	return
+}
+
+func (c *Cluster) setDisableAutoDpMetaRepair(val bool) (err error) {
+	oldVal := c.DisableAutoDpMetaRepair.Load()
+	c.DisableAutoDpMetaRepair.Store(val)
+	if err = c.syncPutCluster(); err != nil {
+		log.LogErrorf("[setEnableAutoDpMetaRepair] failed to set enable auto dp meta, err(%v)", err)
+		c.DisableAutoDpMetaRepair.Store(oldVal)
+		err = proto.ErrPersistenceByRaft
+		return
+	}
+	return
+}
+
+func (c *Cluster) getDisableAutoDpMetaRepair() (v bool) {
+	v = c.DisableAutoDpMetaRepair.Load()
 	return
 }
 

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2054,7 +2054,7 @@ func (c *Cluster) decommissionSingleDp(dp *DataPartition, newAddr, offlineAddr s
 	// 1. add new replica first
 	if dp.GetSpecialReplicaDecommissionStep() == SpecialDecommissionEnter {
 		if err = c.addDataReplica(dp, newAddr, false); err != nil {
-			err = fmt.Errorf("action[decommissionSingleDp] dp %v addDataReplica fail err %v", dp.PartitionID, err)
+			err = fmt.Errorf("action[decommissionSingleDp] dp %v addDataReplica %v fail err %v", dp.PartitionID, newAddr, err)
 			goto ERR
 		}
 		// if addDataReplica is success, can add to BadDataPartitionIds

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -105,7 +105,7 @@ type Cluster struct {
 	DecommissionDiskLimit        uint32
 	S3ApiQosQuota                *sync.Map // (api,uid,limtType) -> limitQuota
 	MarkDiskBrokenThreshold      atomicutil.Float64
-	DisableAutoDpMetaRepair      atomicutil.Bool
+	EnableAutoDpMetaRepair       atomicutil.Bool
 }
 
 type delayDeleteVolInfo struct {
@@ -370,7 +370,7 @@ func newCluster(name string, leaderInfo *LeaderInfo, fsm *MetadataFsm, partition
 	c.snapshotMgr.cluster = c
 	c.S3ApiQosQuota = new(sync.Map)
 	c.MarkDiskBrokenThreshold.Store(defaultMarkDiskBrokenThreshold)
-	c.DisableAutoDpMetaRepair.Store(defaultDisableDpMetaRepair)
+	c.EnableAutoDpMetaRepair.Store(defaultEnableDpMetaRepair)
 	return
 }
 
@@ -3304,6 +3304,7 @@ func (c *Cluster) doCreateVol(req *createVolReq) (vol *Vol, err error) {
 		FlowWlimit:   req.qosLimitArgs.flowWVal,
 
 		DpReadOnlyWhenVolFull: req.DpReadOnlyWhenVolFull,
+		EnableAutoMetaRepair:  false,
 	}
 
 	log.LogInfof("[doCreateVol] volView, %v", vv)
@@ -3783,20 +3784,20 @@ func (c *Cluster) getMarkDiskBrokenThreshold() (v float64) {
 	return
 }
 
-func (c *Cluster) setDisableAutoDpMetaRepair(val bool) (err error) {
-	oldVal := c.DisableAutoDpMetaRepair.Load()
-	c.DisableAutoDpMetaRepair.Store(val)
+func (c *Cluster) setEnableAutoDpMetaRepair(val bool) (err error) {
+	oldVal := c.EnableAutoDpMetaRepair.Load()
+	c.EnableAutoDpMetaRepair.Store(val)
 	if err = c.syncPutCluster(); err != nil {
 		log.LogErrorf("[setEnableAutoDpMetaRepair] failed to set enable auto dp meta, err(%v)", err)
-		c.DisableAutoDpMetaRepair.Store(oldVal)
+		c.EnableAutoDpMetaRepair.Store(oldVal)
 		err = proto.ErrPersistenceByRaft
 		return
 	}
 	return
 }
 
-func (c *Cluster) getDisableAutoDpMetaRepair() (v bool) {
-	v = c.DisableAutoDpMetaRepair.Load()
+func (c *Cluster) getEnableAutoDpMetaRepair() (v bool) {
+	v = c.EnableAutoDpMetaRepair.Load()
 	return
 }
 

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -4395,7 +4395,6 @@ func (c *Cluster) TryDecommissionDisk(disk *DecommissionDisk) {
 				if strings.Contains(err.Error(), proto.ErrAllReplicaUnavailable.Error()) {
 					dp.DecommissionNeedRollbackTimes = defaultDecommissionRollbackLimit
 					dp.DecommissionNeedRollback = false
-					dp.IsDiscard = true
 				} else {
 					dp.markRollbackFailed(false)
 					dp.DecommissionErrorMessage = err.Error()
@@ -4889,7 +4888,6 @@ func (c *Cluster) markDecommissionDataPartition(dp *DataPartition, src *DataNode
 			if strings.Contains(err.Error(), proto.ErrAllReplicaUnavailable.Error()) {
 				dp.DecommissionNeedRollbackTimes = defaultDecommissionRollbackLimit
 				dp.DecommissionNeedRollback = false
-				dp.IsDiscard = true
 			} else {
 				dp.markRollbackFailed(false)
 				dp.DecommissionErrorMessage = err.Error()

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2473,6 +2473,9 @@ func (c *Cluster) addDataReplica(dp *DataPartition, addr string, ignoreDecommiss
 
 // update datanode size with to replica size
 func (c *Cluster) updateDataNodeSize(addr string, dp *DataPartition) error {
+	if len(dp.Replicas) == 0 {
+		return errors.NewErrorf("dp %v has empty replica", dp.decommissionInfo())
+	}
 	leaderSize := dp.Replicas[0].Used
 	dataNode, err := c.dataNode(addr)
 	if err != nil {
@@ -2576,7 +2579,17 @@ func (c *Cluster) addDataPartitionRaftMember(dp *DataPartition, addPeer proto.Pe
 		_, err = c.buildAddDataPartitionRaftMemberTaskAndSyncSendTask(dp, addPeer, host)
 		if err == nil {
 			break
+		} else {
+			// if send to leader raise err, it may send to follower ,then follower forward
+			// this request to leader, return nil. so when leader encounter en error, should
+			//  return err
+			if leaderAddr != "" && leaderAddr == host {
+				dp.Hosts = oldHosts
+				dp.Peers = oldPeers
+				return err
+			}
 		}
+
 		if index < len(candidateAddrs)-1 {
 			time.Sleep(retrySendSyncTaskInternal)
 		}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -2090,7 +2090,7 @@ func (c *Cluster) decommissionSingleDp(dp *DataPartition, newAddr, offlineAddr s
 				}
 			}
 			// check new replica status
-			liveReplicas := dp.getLiveReplicasFromHosts(c.cfg.DataPartitionTimeOutSec)
+			liveReplicas := dp.getLiveReplicasFromHosts(c.getDataPartitionTimeoutSec())
 			newReplica, err = dp.getReplica(newAddr)
 			if err != nil {
 				err = fmt.Errorf("action[decommissionSingleDp] dp %v replica %v not found",
@@ -3709,6 +3709,18 @@ func (c *Cluster) setDataNodeAutoRepairLimitRate(val uint64) (err error) {
 	return
 }
 
+func (c *Cluster) setDataPartitionTimeout(val int64) (err error) {
+	oldVal := atomic.LoadInt64(&c.cfg.DataPartitionTimeOutSec)
+	atomic.StoreInt64(&c.cfg.DataPartitionTimeOutSec, val)
+	if err = c.syncPutCluster(); err != nil {
+		log.LogErrorf("[setDataPartitionTimeout] failed to set dp timeout, err(%v)", err)
+		atomic.StoreInt64(&c.cfg.DataPartitionTimeOutSec, oldVal)
+		err = proto.ErrPersistenceByRaft
+		return
+	}
+	return
+}
+
 func (c *Cluster) setMetaNodeDeleteWorkerSleepMs(val uint64) (err error) {
 	oldVal := atomic.LoadUint64(&c.cfg.MetaNodeDeleteWorkerSleepMs)
 	atomic.StoreUint64(&c.cfg.MetaNodeDeleteWorkerSleepMs, val)
@@ -3792,6 +3804,14 @@ func (c *Cluster) setEnableAutoDpMetaRepair(val bool) (err error) {
 		c.EnableAutoDpMetaRepair.Store(oldVal)
 		err = proto.ErrPersistenceByRaft
 		return
+	}
+	return
+}
+
+func (c *Cluster) getDataPartitionTimeoutSec() (val int64) {
+	val = atomic.LoadInt64(&c.cfg.DataPartitionTimeOutSec)
+	if val == 0 {
+		val = defaultDataPartitionTimeOutSec
 	}
 	return
 }

--- a/master/cluster_stat.go
+++ b/master/cluster_stat.go
@@ -73,7 +73,7 @@ func (c *Cluster) updateZoneStatInfo() {
 		zone.dataNodes.Range(func(key, value interface{}) bool {
 			zs.DataNodeStat.TotalNodes++
 			node := value.(*DataNode)
-			if node.isActive && node.isWriteAble() {
+			if node.isActive && node.IsWriteAble() {
 				zs.DataNodeStat.WritableNodes++
 			}
 			zs.DataNodeStat.Total += float64(node.Total) / float64(util.GB)
@@ -90,7 +90,7 @@ func (c *Cluster) updateZoneStatInfo() {
 		zone.metaNodes.Range(func(key, value interface{}) bool {
 			zs.MetaNodeStat.TotalNodes++
 			node := value.(*MetaNode)
-			if node.IsActive && node.isWritable() {
+			if node.IsActive && node.IsWriteAble() {
 				zs.MetaNodeStat.WritableNodes++
 			}
 			zs.MetaNodeStat.Total += float64(node.Total) / float64(util.GB)

--- a/master/cluster_task.go
+++ b/master/cluster_task.go
@@ -661,7 +661,7 @@ func (c *Cluster) doLoadDataPartition(dp *DataPartition) {
 	c.addDataNodeTasks(loadTasks)
 	success := false
 	for i := 0; i < timeToWaitForResponse; i++ {
-		if dp.checkLoadResponse(c.cfg.DataPartitionTimeOutSec) {
+		if dp.checkLoadResponse(c.getDataPartitionTimeoutSec()) {
 			success = true
 			break
 		}

--- a/master/config.go
+++ b/master/config.go
@@ -68,7 +68,9 @@ const (
 	defaultNodeTimeOutSec                      = noHeartBeatTimes * defaultIntervalToCheckHeartbeat
 	defaultDataPartitionTimeOutSec             = 5 * defaultIntervalToCheckHeartbeat
 	defaultMissingDataPartitionInterval        = 24 * 3600
-	defaultDpNoLeaderReportIntervalSec         = 10 * 60
+	// defaultDpNoLeaderReportIntervalSec         = 10 * 60
+	// TODO-chi: for test
+	defaultDpNoLeaderReportIntervalSec         = 10
 	defaultMpNoLeaderReportIntervalSec         = 5
 	defaultIntervalToAlarmMissingDataPartition = 60 * 60
 	timeToWaitForResponse                      = 120         // time to wait for response by the master during loading partition

--- a/master/config.go
+++ b/master/config.go
@@ -66,7 +66,7 @@ const (
 	defaultIntervalToCheckCrc                  = 20 * defaultIntervalToCheck // in terms of seconds
 	noHeartBeatTimes                           = 3                           // number of times that no heartbeat reported
 	defaultNodeTimeOutSec                      = noHeartBeatTimes * defaultIntervalToCheckHeartbeat
-	defaultDataPartitionTimeOutSec             = 5 * defaultIntervalToCheckHeartbeat
+	defaultDataPartitionTimeOutSec             = 200 * defaultIntervalToCheckHeartbeat //datanode with massive amount of dp may cost 10-min
 	defaultMissingDataPartitionInterval        = 24 * 3600
 	// defaultDpNoLeaderReportIntervalSec         = 10 * 60
 	// TODO-chi: for test

--- a/master/config.go
+++ b/master/config.go
@@ -66,7 +66,7 @@ const (
 	defaultIntervalToCheckCrc                  = 20 * defaultIntervalToCheck // in terms of seconds
 	noHeartBeatTimes                           = 3                           // number of times that no heartbeat reported
 	defaultNodeTimeOutSec                      = noHeartBeatTimes * defaultIntervalToCheckHeartbeat
-	defaultDataPartitionTimeOutSec             = 200 * defaultIntervalToCheckHeartbeat //datanode with massive amount of dp may cost 10-min
+	defaultDataPartitionTimeOutSec             = 200 * defaultIntervalToCheckHeartbeat // datanode with massive amount of dp may cost 10-min
 	defaultMissingDataPartitionInterval        = 24 * 3600
 	// defaultDpNoLeaderReportIntervalSec         = 10 * 60
 	// TODO-chi: for test

--- a/master/const.go
+++ b/master/const.go
@@ -139,6 +139,7 @@ const (
 	dpRepairBlockSizeKey       = "dpRepairBlockSize"
 	markDiskBrokenThresholdKey = "markDiskBrokenThreshold"
 	decommissionTypeKey        = "decommissionType"
+	autoDpMetaRepairKey        = "autoDpMetaRepair"
 )
 
 const (
@@ -211,6 +212,7 @@ const (
 	defaultMaxQuotaNumPerVol                     = 100
 	defaultVolDelayDeleteTimeHour                = 48
 	defaultMarkDiskBrokenThreshold               = 0 // decommission all dp from disk
+	defaultDisableDpMetaRepair                   = false
 	maxMpCreationCount                           = 10
 )
 

--- a/master/const.go
+++ b/master/const.go
@@ -212,7 +212,7 @@ const (
 	defaultMaxQuotaNumPerVol                     = 100
 	defaultVolDelayDeleteTimeHour                = 48
 	defaultMarkDiskBrokenThreshold               = 0 // decommission all dp from disk
-	defaultDisableDpMetaRepair                   = false
+	defaultEnableDpMetaRepair                    = false
 	maxMpCreationCount                           = 10
 )
 

--- a/master/const.go
+++ b/master/const.go
@@ -140,6 +140,7 @@ const (
 	markDiskBrokenThresholdKey = "markDiskBrokenThreshold"
 	decommissionTypeKey        = "decommissionType"
 	autoDpMetaRepairKey        = "autoDpMetaRepair"
+	dpTimeoutKey               = "dpTimeout"
 )
 
 const (

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -524,6 +524,7 @@ func (dataNode *DataNode) resetDecommissionStatus() {
 	dataNode.DecommissionLimit = 0
 	dataNode.DecommissionCompleteTime = 0
 	dataNode.DecommissionDiskList = make([]string, 0)
+	dataNode.ToBeOffline = false
 }
 
 func (dataNode *DataNode) createVersionTask(volume string, version uint64, op uint8, addr string, verList []*proto.VolVersionInfo) (task *proto.AdminTask) {

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -16,7 +16,6 @@ package master
 
 import (
 	"fmt"
-	"github.com/cubefs/cubefs/util/auditlog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util"
 	"github.com/cubefs/cubefs/util/atomicutil"
+	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/log"
 )
 

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -405,10 +405,6 @@ func (dataNode *DataNode) updateDecommissionStatus(c *Cluster, debug bool) (uint
 			failedNum++
 			failedPartitionIds = append(failedPartitionIds, dp.PartitionID)
 		}
-		if dp.GetDecommissionStatus() == DecommissionNeedManualFix {
-			failedNum++
-			failedPartitionIds = append(failedPartitionIds, dp.PartitionID)
-		}
 		if dp.GetDecommissionStatus() == DecommissionRunning {
 			runningNum++
 			runningPartitionIds = append(runningPartitionIds, dp.PartitionID)
@@ -473,7 +469,7 @@ func (dataNode *DataNode) GetDecommissionFailedDPByTerm(c *Cluster) []proto.Fail
 	partitions := dataNode.GetLatestDecommissionDataPartition(c)
 	log.LogDebugf("action[GetDecommissionDataNodeFailedDP] partitions len %v", len(partitions))
 	for _, dp := range partitions {
-		if dp.IsRollbackFailed() || dp.GetDecommissionStatus() == DecommissionNeedManualFix {
+		if dp.IsRollbackFailed() {
 			failedDps = append(failedDps, proto.FailedDpInfo{PartitionID: dp.PartitionID, ErrMsg: dp.DecommissionErrorMessage})
 			log.LogWarnf("action[GetDecommissionDataNodeFailedDP] dp[%v] failed", dp.PartitionID)
 		}

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -72,6 +72,7 @@ type DataNode struct {
 	DecommissionDiskList      []string           // NOTE: the disks that running decommission
 	DecommissionDpTotal       int
 	DecommissionSyncMutex     sync.Mutex
+	BackupDataPartitions      []proto.BackupDataPartitionInfo
 }
 
 func newDataNode(addr, zoneName, clusterID string) (dataNode *DataNode) {
@@ -161,6 +162,7 @@ func (dataNode *DataNode) updateNodeMetric(resp *proto.DataNodeHeartbeatResponse
 	dataNode.BadDisks = resp.BadDisks
 	dataNode.BadDiskStats = resp.BadDiskStats
 	dataNode.DiskStats = resp.DiskStats
+	dataNode.BackupDataPartitions = resp.BackupDataPartitions
 
 	dataNode.StartTime = resp.StartTime
 	if dataNode.Total == 0 {
@@ -562,4 +564,14 @@ func (dataNode *DataNode) delDecommissionDiskFromCache(c *Cluster) {
 		c.DecommissionDisks.Delete(key)
 		log.LogDebugf("action[delDecommissionDiskFromCache] remove  %v", key)
 	}
+}
+
+func (dataNode *DataNode) getBackupDataPartitionIDs() (ids []uint64) {
+	dataNode.RLock()
+	dataNode.RUnlock()
+	ids = make([]uint64, 0)
+	for _, info := range dataNode.BackupDataPartitions {
+		ids = append(ids, info.PartitionID)
+	}
+	return ids
 }

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -16,6 +16,7 @@ package master
 
 import (
 	"fmt"
+	"github.com/cubefs/cubefs/util/auditlog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -99,10 +100,12 @@ func (dataNode *DataNode) SetIoUtils(used map[string]float64) {
 func (dataNode *DataNode) checkLiveness() {
 	dataNode.Lock()
 	defer dataNode.Unlock()
-	log.LogInfof("action[checkLiveness] datanode[%v] report time[%v],since report time[%v], need gap [%v]",
-		dataNode.Addr, dataNode.ReportTime, time.Since(dataNode.ReportTime), time.Second*time.Duration(defaultNodeTimeOutSec))
 	if time.Since(dataNode.ReportTime) > time.Second*time.Duration(defaultNodeTimeOutSec) {
 		dataNode.isActive = false
+		msg := fmt.Sprintf("datanode[%v] report time[%v],since report time[%v], need gap [%v]",
+			dataNode.Addr, dataNode.ReportTime, time.Since(dataNode.ReportTime), time.Second*time.Duration(defaultNodeTimeOutSec))
+		log.LogWarnf("action[checkLiveness]  %v", msg)
+		auditlog.LogMasterOp("DataNodeLive", msg, nil)
 	}
 }
 

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -260,13 +260,6 @@ func (dataNode *DataNode) isWriteAbleWithSizeNoLock(size uint64) (ok bool) {
 	return
 }
 
-func (dataNode *DataNode) isWriteAbleWithSize(size uint64) (ok bool) {
-	dataNode.RLock()
-	defer dataNode.RUnlock()
-
-	return dataNode.isWriteAbleWithSizeNoLock(size)
-}
-
 func (dataNode *DataNode) GetUsed() uint64 {
 	dataNode.RLock()
 	defer dataNode.RUnlock()
@@ -591,7 +584,7 @@ func (dataNode *DataNode) delDecommissionDiskFromCache(c *Cluster) {
 
 func (dataNode *DataNode) getBackupDataPartitionIDs() (ids []uint64) {
 	dataNode.RLock()
-	dataNode.RUnlock()
+	defer dataNode.RUnlock()
 	ids = make([]uint64, 0)
 	for _, info := range dataNode.BackupDataPartitions {
 		ids = append(ids, info.PartitionID)
@@ -601,7 +594,7 @@ func (dataNode *DataNode) getBackupDataPartitionIDs() (ids []uint64) {
 
 func (dataNode *DataNode) getBackupDataPartitionInfo(id uint64) (proto.BackupDataPartitionInfo, error) {
 	dataNode.RLock()
-	dataNode.RUnlock()
+	defer dataNode.RUnlock()
 	for _, info := range dataNode.BackupDataPartitions {
 		if info.PartitionID == id {
 			return info, nil

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -226,7 +226,12 @@ func (dataNode *DataNode) GetDpCntLimit() uint32 {
 }
 
 func (dataNode *DataNode) dpCntInLimit() bool {
-	return dataNode.DataPartitionCount <= dataNode.GetDpCntLimit()
+	inLimit := dataNode.DataPartitionCount <= dataNode.GetDpCntLimit()
+	if !inLimit {
+		log.LogInfof("dpCntInLimit: dp count is already over limit for node %s, cnt %d, limit %d",
+			dataNode.Addr, dataNode.DataPartitionCount, dataNode.GetDpCntLimit())
+	}
+	return inLimit
 }
 
 func (dataNode *DataNode) isWriteAbleWithSizeNoLock(size uint64) (ok bool) {

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cubefs/cubefs/util"
 	"github.com/cubefs/cubefs/util/atomicutil"
 	"github.com/cubefs/cubefs/util/auditlog"
+	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/log"
 )
 
@@ -570,4 +571,16 @@ func (dataNode *DataNode) getBackupDataPartitionIDs() (ids []uint64) {
 		ids = append(ids, info.PartitionID)
 	}
 	return ids
+}
+
+func (dataNode *DataNode) getBackupDataPartitionInfo(id uint64) (proto.BackupDataPartitionInfo, error) {
+	dataNode.RLock()
+	dataNode.RUnlock()
+	for _, info := range dataNode.BackupDataPartitions {
+		if info.PartitionID == id {
+			return info, nil
+		}
+	}
+	return proto.BackupDataPartitionInfo{}, errors.NewErrorf("cannot find backup info "+
+		"for dp (%v) on datanode (%v)", id, dataNode.Addr)
 }

--- a/master/data_node.go
+++ b/master/data_node.go
@@ -395,6 +395,10 @@ func (dataNode *DataNode) updateDecommissionStatus(c *Cluster, debug bool) (uint
 			failedNum++
 			failedPartitionIds = append(failedPartitionIds, dp.PartitionID)
 		}
+		if dp.GetDecommissionStatus() == DecommissionNeedManualFix {
+			failedNum++
+			failedPartitionIds = append(failedPartitionIds, dp.PartitionID)
+		}
 		if dp.GetDecommissionStatus() == DecommissionRunning {
 			runningNum++
 			runningPartitionIds = append(runningPartitionIds, dp.PartitionID)
@@ -459,7 +463,7 @@ func (dataNode *DataNode) GetDecommissionFailedDPByTerm(c *Cluster) []proto.Fail
 	partitions := dataNode.GetLatestDecommissionDataPartition(c)
 	log.LogDebugf("action[GetDecommissionDataNodeFailedDP] partitions len %v", len(partitions))
 	for _, dp := range partitions {
-		if dp.IsRollbackFailed() {
+		if dp.IsRollbackFailed() || dp.GetDecommissionStatus() == DecommissionNeedManualFix {
 			failedDps = append(failedDps, proto.FailedDpInfo{PartitionID: dp.PartitionID, ErrMsg: dp.DecommissionErrorMessage})
 			log.LogWarnf("action[GetDecommissionDataNodeFailedDP] dp[%v] failed", dp.PartitionID)
 		}

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -2289,3 +2289,11 @@ func (partition *DataPartition) getSpecifyStatusReplicaNum(status int8) uint8 {
 	}
 	return count
 }
+
+func (partition *DataPartition) createTaskToRecoverBackupDataPartitionReplica(addr, disk string) (task *proto.AdminTask,
+) {
+	task = proto.NewAdminTask(proto.OpRecoverBackupDataReplica, addr, newRecoverBackupDataPartitionReplicaRequest(
+		partition.PartitionID, disk))
+	partition.resetTaskID(task)
+	return
+}

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -978,8 +978,6 @@ func GetDecommissionStatusMessage(status uint32) string {
 		return "Success"
 	case DecommissionFail:
 		return "Failed"
-	case DecommissionNeedManualFix:
-		return "DecommissionNeedManualFix"
 	case DecommissionPrepare:
 		return "DecommissionPrepare"
 	default:
@@ -1050,9 +1048,6 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 	if partition.IsDiscard {
 		goto directly
 	}
-	if partition.needManualFix() {
-		return proto.ErrAllReplicaUnavailable
-	}
 	// TODO-chi:can delete this block
 	// 1 or 2 replica can always add new replica if retrying decommission
 	// for 3 replica,
@@ -1081,7 +1076,6 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 			if partition.getReplicaDiskErrorNum() == partition.ReplicaNum {
 				log.LogWarnf("action[MarkDecommissionStatus] dp[%v] all replica is unavaliable, cannot handle in auto decommission mode",
 					partition.PartitionID)
-				partition.SetDecommissionStatus(DecommissionNeedManualFix)
 				partition.DecommissionErrorMessage = "all replica is unavailable, cannot handle in auto decommission mode"
 				return proto.ErrAllReplicaUnavailable
 			}
@@ -1121,7 +1115,6 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 			if partition.getReplicaDiskErrorNum() == partition.ReplicaNum {
 				log.LogWarnf("action[MarkDecommissionStatus] dp[%v] all replica is unavaliable, cannot handle in manual decommission mode",
 					partition.PartitionID)
-				partition.SetDecommissionStatus(DecommissionNeedManualFix)
 				partition.DecommissionErrorMessage = "all replica is unavailable, cannot handle in manual decommission mode"
 				return proto.ErrAllReplicaUnavailable
 			}
@@ -1970,10 +1963,6 @@ func (partition *DataPartition) getDiskErrorReplica() *DataReplica {
 		}
 	}
 	return nil
-}
-
-func (partition *DataPartition) needManualFix() bool {
-	return partition.GetDecommissionStatus() == DecommissionNeedManualFix
 }
 
 func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1974,6 +1974,11 @@ func (partition *DataPartition) needManualFix() bool {
 func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 	var auditMsg string
 
+	if c.getDisableAutoDpMetaRepair() {
+		log.LogDebugf("[checkReplicaMeta] cluster disable auto dp meta repair, skip dp(%v)", partition.PartitionID)
+		return
+	}
+
 	if partition.isPerformingDecommission(c) {
 		log.LogDebugf("action[checkReplicaMeta]dp(%v) is performing decommission, skip it",
 			partition.PartitionID)

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1996,6 +1996,34 @@ func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 		c.syncUpdateDataPartition(partition)
 	}()
 	log.LogDebugf("action[checkReplicaMeta]dp %v", partition.decommissionInfo())
+
+	// for add/delete replica, add/delete raft member first, then add/delete replica
+	// when retry is 4, then executing
+	// or replica is not loaded for unexpected error
+	//var redundantPeers []proto.Peer
+	//if len(partition.Peers) == int(partition.ReplicaNum) && len(partition.Peers) > len(partition.Replicas) {
+	//	for _, peer := range partition.Peers {
+	//		found := false
+	//		for _, replica := range partition.Replicas {
+	//			if replica.Addr == peer.Addr {
+	//				found = true
+	//			}
+	//		}
+	//		if !found {
+	//			redundantPeers = append(redundantPeers, peer)
+	//		}
+	//	}
+	//	// remove from hosts and peers only
+	//	for _, peer := range redundantPeers {
+	//		err = c.removeHostMember(partition, peer)
+	//		auditMsg = fmt.Sprintf("dp(%v) remove unloaded peer %v for master", partition.PartitionID, peer)
+	//		log.LogDebugf("action[checkReplicaMeta]%v: err %v", auditMsg, err)
+	//		auditlog.LogMasterOp("RestoreReplicaMeta", auditMsg, err)
+	//		if err != nil {
+	//			return
+	//		}
+	//	}
+	//}
 	// find redundant peers from replica meta
 	force := false
 	for _, replica := range partition.Replicas {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -2071,12 +2071,12 @@ func (partition *DataPartition) lostLeader(c *Cluster) bool {
 
 func (partition *DataPartition) decommissionInfo() string {
 	return fmt.Sprintf("vol(%v)_dp(%v)_src(%v)_dst(%v)_hosts(%v)_retry(%v)_isRecover(%v)_status(%v)_specialStatus(%v)"+
-		"_needRollback(%v)_rollbackTimes(%v)_force(%v)_type(%v)_RestoreReplica(%v)_errMsg(%v)",
+		"_needRollback(%v)_rollbackTimes(%v)_force(%v)_type(%v)_RestoreReplica(%v)_errMsg(%v)_discard(%v)",
 		partition.VolName, partition.PartitionID, partition.DecommissionSrcAddr, partition.DecommissionDstAddr,
 		partition.Hosts, partition.DecommissionRetry, partition.isRecover, GetDecommissionStatusMessage(partition.GetDecommissionStatus()),
 		GetSpecialDecommissionStatusMessage(partition.GetSpecialReplicaDecommissionStep()), partition.DecommissionNeedRollback,
 		partition.DecommissionNeedRollbackTimes, partition.DecommissionRaftForce, GetDecommissionTypeMessage(partition.DecommissionType),
-		GetRestoreReplicaMessage(partition.RestoreReplica), partition.DecommissionErrorMessage)
+		GetRestoreReplicaMessage(partition.RestoreReplica), partition.DecommissionErrorMessage, partition.IsDiscard)
 }
 
 func (partition *DataPartition) isPerformingDecommission(c *Cluster) bool {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -616,12 +616,12 @@ func (partition *DataPartition) getLiveReplicasFromHosts(timeOutSec int64) (repl
 		if replica.isLive(partition.PartitionID, timeOutSec) {
 			replicas = append(replicas, replica)
 		} else {
-			msg := fmt.Sprintf("dp %v replica addr %v is unavailable, datanode active %v replica status %v and is active %v",
-				partition.PartitionID, replica.Addr, replica.dataNode.isActive, replica.Status, replica.isActive(timeOutSec))
+			// msg := fmt.Sprintf("dp %v replica addr %v is unavailable, datanode active %v replica status %v and is active %v",
+			//	partition.PartitionID, replica.Addr, replica.dataNode.isActive, replica.Status, replica.isActive(timeOutSec))
 			replica.Status = proto.Unavailable
-			log.LogWarnf("action[getLiveReplicasFromHosts] vol %v dp %v replica %v is unavailable",
+			log.LogDebugf("action[getLiveReplicasFromHosts] vol %v dp %v replica %v is unavailable",
 				partition.VolName, partition.PartitionID, replica.Addr)
-			auditlog.LogMasterOp("DataPartitionReplicaStatus", msg, nil)
+			// auditlog.LogMasterOp("DataPartitionReplicaStatus", msg, nil)
 		}
 	}
 
@@ -1086,15 +1086,16 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 			}
 			raftForce = true
 			diskErrReplica := partition.getDiskErrorReplica()
-			log.LogWarnf("action[MarkDecommissionStatus] dp[%v] has disk error replica %v",
-				partition.PartitionID, diskErrReplica)
 			if diskErrReplica != nil {
+				log.LogWarnf("action[MarkDecommissionStatus] dp[%v] has disk error replica %v:%v",
+					partition.PartitionID, diskErrReplica.Addr, diskErrReplica.DiskPath)
 				// decommission disk err replica first
 				if diskErrReplica.Addr != srcAddr {
 					srcAddr = diskErrReplica.Addr
 					srcDisk = diskErrReplica.DiskPath
-					log.LogWarnf("action[MarkDecommissionStatus] dp[%v] decommission bad replica %v_%v first",
-						partition.PartitionID, diskErrReplica.Addr, diskErrReplica.DiskPath)
+					log.LogWarnf("action[MarkDecommissionStatus] dp[%v] decommission bad replica %v_%v first, expect"+
+						"to decommission %v",
+						partition.PartitionID, diskErrReplica.Addr, diskErrReplica.DiskPath, srcAddr)
 					err = proto.ErrDecommissionDiskErrDPFirst
 				}
 			}

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1557,7 +1557,7 @@ func (partition *DataPartition) canMarkDecommission(status uint32, ns *nodeSet) 
 	// make sure dp release the token
 	rollbackTimes := atomic.LoadUint32(&partition.DecommissionNeedRollbackTimes)
 	if ns.processDataPartitionDecommission(partition.PartitionID) {
-		return errors.NewErrorf("dp[%v]cannot mark decommission for decommission progress is not ended", partition.PartitionID)
+		return errors.NewErrorf("dp[%v] %v", partition.PartitionID, proto.ErrPerformingDecommission.Error())
 	}
 	if status == DecommissionInitial ||
 		status == DecommissionPause {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1974,11 +1974,6 @@ func (partition *DataPartition) needManualFix() bool {
 func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 	var auditMsg string
 
-	if c.getDisableAutoDpMetaRepair() {
-		log.LogDebugf("[checkReplicaMeta] cluster disable auto dp meta repair, skip dp(%v)", partition.PartitionID)
-		return
-	}
-
 	if partition.isPerformingDecommission(c) {
 		log.LogDebugf("action[checkReplicaMeta]dp(%v) is performing decommission, skip it",
 			partition.PartitionID)

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1041,6 +1041,11 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 		}
 	}()
 
+	var status uint32
+	// if mark discard, decommission it directly to delete replica
+	if partition.IsDiscard {
+		goto directly
+	}
 	if partition.needManualFix() {
 		return proto.ErrAllReplicaUnavailable
 	}
@@ -1057,7 +1062,7 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 			partition.PartitionID, err)
 		return err
 	}
-	status := partition.GetDecommissionStatus()
+	status = partition.GetDecommissionStatus()
 	if err = partition.canMarkDecommission(status, ns); err != nil {
 		log.LogWarnf("action[MarkDecommissionStatus] dp[%v] cannot make decommission:%v",
 			partition.PartitionID, err)
@@ -1069,7 +1074,7 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 		log.LogDebugf("action[MarkDecommissionStatus] dp[%v] lostLeader %v leader %v interval %v",
 			partition.PartitionID, partition.lostLeader(c), partition.getLeaderAddr(), time.Now().Unix()-partition.LeaderReportTime)
 		if partition.lostLeader(c) {
-			if partition.getReplicaEqualStatusNum(proto.Unavailable) == partition.ReplicaNum {
+			if partition.getReplicaDiskErrorNum() == partition.ReplicaNum {
 				log.LogWarnf("action[MarkDecommissionStatus] dp[%v] all replica is unavaliable, cannot handle in auto decommission mode",
 					partition.PartitionID)
 				partition.SetDecommissionStatus(DecommissionNeedManualFix)
@@ -1092,7 +1097,7 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 			}
 		} else {
 			// for special dp , if no replica is disk err, leader should not be none, so decommission the replica it hoped
-			if partition.ReplicaNum == 3 && partition.getReplicaEqualStatusNum(proto.Unavailable) == 1 {
+			if partition.ReplicaNum == 3 && partition.getReplicaDiskErrorNum() == 1 {
 				diskErrReplica := partition.getDiskErrorReplica()
 				if diskErrReplica != nil {
 					// decommission disk err replica first
@@ -1106,7 +1111,18 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 				}
 			}
 		}
+	} else {
+		if partition.lostLeader(c) {
+			if partition.getReplicaDiskErrorNum() == partition.ReplicaNum {
+				log.LogWarnf("action[MarkDecommissionStatus] dp[%v] all replica is unavaliable, cannot handle in manual decommission mode",
+					partition.PartitionID)
+				partition.SetDecommissionStatus(DecommissionNeedManualFix)
+				partition.DecommissionErrorMessage = "all replica is unavailable, cannot handle in manual decommission mode"
+				return proto.ErrAllReplicaUnavailable
+			}
+		}
 	}
+directly:
 	if partition.IsDecommissionPaused() {
 		if !partition.pauseReplicaRepair(partition.DecommissionDstAddr, false, c) {
 			log.LogWarnf("action[MarkDecommissionStatus] dp [%d] recover from stop failed", partition.PartitionID)
@@ -1115,9 +1131,18 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 		// forbidden dp to restore meta for replica
 		// if migrateType is AutoAddReplica, RestoreReplica is already RestoreReplicaMetaRunning, so do not need to check
 		// this flag again
-		if !partition.setRestoreReplicaForbidden() && migrateType != AutoAddReplica {
-			return errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
+		for {
+			if !partition.setRestoreReplicaForbidden() && migrateType != AutoAddReplica {
+				partition.DecommissionRetry++
+				if partition.DecommissionRetry >= defaultDecommissionRetryLimit {
+					return errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
+				}
+				// wait for checkReplicaMeta ended
+				time.Sleep(3 * time.Second)
+			}
+			break
 		}
+		partition.DecommissionRetry = 0
 		partition.SetDecommissionStatus(markDecommission)
 		// update decommissionTerm for next time query
 		partition.DecommissionTerm = term
@@ -1126,8 +1151,16 @@ func (partition *DataPartition) MarkDecommissionStatus(srcAddr, dstAddr, srcDisk
 		return
 	}
 	// forbidden dp to restore meta for replica
-	if !partition.setRestoreReplicaForbidden() && migrateType != AutoAddReplica {
-		return errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
+	for {
+		if !partition.setRestoreReplicaForbidden() && migrateType != AutoAddReplica {
+			partition.DecommissionRetry++
+			if partition.DecommissionRetry >= defaultDecommissionRetryLimit {
+				return errors.NewErrorf("set RestoreReplicaMetaForbidden failed")
+			}
+			// wait for checkReplicaMeta ended
+			time.Sleep(3 * time.Second)
+		}
+		break
 	}
 	// initial or failed restart
 	partition.ResetDecommissionStatus()
@@ -1909,12 +1942,12 @@ func (partition *DataPartition) createTaskToRecoverDataReplicaMeta(addr string, 
 	return
 }
 
-func (partition *DataPartition) getReplicaEqualStatusNum(status int8) uint8 {
+func (partition *DataPartition) getReplicaDiskErrorNum() uint8 {
 	partition.RLock()
 	defer partition.RUnlock()
 	var count uint8 = 0
 	for _, replica := range partition.Replicas {
-		if replica.Status == status {
+		if replica.TriggerDiskError {
 			count++
 		}
 	}

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -1881,6 +1881,8 @@ func (partition *DataPartition) removeReplicaByForce(c *Cluster, peerAddr string
 	log.LogInfof("action[removeReplicaByForce]dp[%v] rollback to del peer %v force %v", partition.PartitionID, peerAddr, force)
 	err := c.removeDataReplica(partition, peerAddr, false, force)
 	if err != nil {
+		log.LogWarnf("action[removeReplicaByForce]dp[%v] rollback to del peer %v force %v failed:%v, delete peer on master"+
+			"", partition.PartitionID, peerAddr, force, err)
 		// to ensure hosts for master is always correct
 		// redundant replica can be deleted by checkReplicaMeta
 		partition.removeHostByForce(c, peerAddr)
@@ -2007,9 +2009,9 @@ func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 		}
 		redundantPeers := findPeersToDeleteByConfig(replica.LocalPeers, partition.Peers)
 		for _, peer := range redundantPeers {
-			// 1-replica rollback failed due to new replica is unavailable(no leader),
-			// use raftForce in this case(the left replica should be rw or ro status).
-			if partition.ReplicaNum == 1 && partition.DecommissionDstAddr == peer.Addr && partition.Status != proto.Unavailable {
+			// use raftForce to delete redundant peer when dp is leaderless. This progress maybe keep executing util
+			// wal logs with member change be truncated
+			if partition.lostLeader(c) && partition.getReplicaDiskErrorNum() == 0 && partition.getSpecifyStatusReplicaNum(proto.Unavailable) == 0 {
 				force = true
 			}
 			// remove raft member
@@ -2104,12 +2106,13 @@ func (partition *DataPartition) lostLeader(c *Cluster) bool {
 
 func (partition *DataPartition) decommissionInfo() string {
 	return fmt.Sprintf("vol(%v)_dp(%v)_src(%v)_dst(%v)_hosts(%v)_retry(%v)_isRecover(%v)_status(%v)_specialStatus(%v)"+
-		"_needRollback(%v)_rollbackTimes(%v)_force(%v)_type(%v)_RestoreReplica(%v)_errMsg(%v)_discard(%v)",
+		"_needRollback(%v)_rollbackTimes(%v)_force(%v)_type(%v)_RestoreReplica(%v)_errMsg(%v)_discard(%v)_term(%v)",
 		partition.VolName, partition.PartitionID, partition.DecommissionSrcAddr, partition.DecommissionDstAddr,
 		partition.Hosts, partition.DecommissionRetry, partition.isRecover, GetDecommissionStatusMessage(partition.GetDecommissionStatus()),
 		GetSpecialDecommissionStatusMessage(partition.GetSpecialReplicaDecommissionStep()), partition.DecommissionNeedRollback,
 		partition.DecommissionNeedRollbackTimes, partition.DecommissionRaftForce, GetDecommissionTypeMessage(partition.DecommissionType),
-		GetRestoreReplicaMessage(partition.RestoreReplica), partition.DecommissionErrorMessage, partition.IsDiscard)
+		GetRestoreReplicaMessage(partition.RestoreReplica), partition.DecommissionErrorMessage, partition.IsDiscard,
+		partition.DecommissionTerm)
 }
 
 func (partition *DataPartition) isPerformingDecommission(c *Cluster) bool {
@@ -2213,4 +2216,16 @@ func (partition *DataPartition) tryRestoreReplicaMeta(c *Cluster, migrateType ui
 	}
 
 	return nil
+}
+
+func (partition *DataPartition) getSpecifyStatusReplicaNum(status int8) uint8 {
+	partition.RLock()
+	defer partition.RUnlock()
+	var count uint8 = 0
+	for _, replica := range partition.Replicas {
+		if replica.Status == status {
+			count++
+		}
+	}
+	return count
 }

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -295,7 +295,7 @@ func (partition *DataPartition) createTaskToCreateDataPartition(addr string, dat
 
 func (partition *DataPartition) createTaskToDeleteDataPartition(addr string, raftForceDel bool) (task *proto.AdminTask) {
 	task = proto.NewAdminTask(proto.OpDeleteDataPartition, addr,
-		newDeleteDataPartitionRequest(partition.PartitionID, partition.DecommissionType, raftForceDel, partition.isSpecialReplicaCnt()))
+		newDeleteDataPartitionRequest(partition.PartitionID, partition.DecommissionType, raftForceDel))
 	partition.resetTaskID(task)
 	return
 }
@@ -1143,6 +1143,7 @@ directly:
 				}
 				// wait for checkReplicaMeta ended
 				time.Sleep(3 * time.Second)
+				continue
 			}
 			break
 		}
@@ -1163,6 +1164,7 @@ directly:
 			}
 			// wait for checkReplicaMeta ended
 			time.Sleep(3 * time.Second)
+			continue
 		}
 		break
 	}
@@ -2026,7 +2028,7 @@ func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 		}
 	}
 
-	//if len(partition.Peers) == int(partition.ReplicaNum) && len(partition.Peers) > len(partition.Replicas) {
+	// if len(partition.Peers) == int(partition.ReplicaNum) && len(partition.Peers) > len(partition.Replicas) {
 	//	for _, peer := range partition.Peers {
 	//		found := false
 	//		for _, replica := range partition.Replicas {
@@ -2048,7 +2050,7 @@ func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 	//			return
 	//		}
 	//	}
-	//}
+	// }
 	// find redundant peers from replica meta
 	force := false
 	for _, replica := range partition.Replicas {

--- a/master/data_partition.go
+++ b/master/data_partition.go
@@ -293,8 +293,9 @@ func (partition *DataPartition) createTaskToCreateDataPartition(addr string, dat
 	return
 }
 
-func (partition *DataPartition) createTaskToDeleteDataPartition(addr string) (task *proto.AdminTask) {
-	task = proto.NewAdminTask(proto.OpDeleteDataPartition, addr, newDeleteDataPartitionRequest(partition.PartitionID))
+func (partition *DataPartition) createTaskToDeleteDataPartition(addr string, raftForceDel bool) (task *proto.AdminTask) {
+	task = proto.NewAdminTask(proto.OpDeleteDataPartition, addr,
+		newDeleteDataPartitionRequest(partition.PartitionID, partition.DecommissionType, raftForceDel, partition.isSpecialReplicaCnt()))
 	partition.resetTaskID(task)
 	return
 }
@@ -1380,7 +1381,7 @@ errHandler:
 		partition.ReleaseDecommissionToken(c)
 	}
 
-	// if need rollback, set to fail,reset DecommissionDstAddr
+	// if need rollback, set to fail
 	// do not reset DecommissionDstAddr outside the rollback operation, as it may cause rollback failure
 	if partition.DecommissionNeedRollback {
 		partition.SetDecommissionStatus(DecommissionFail)
@@ -2094,7 +2095,7 @@ func (partition *DataPartition) checkReplicaMeta(c *Cluster) (err error) {
 			if err != nil {
 				return
 			}
-			err = c.deleteDataReplica(partition, dataNode)
+			err = c.deleteDataReplica(partition, dataNode, false)
 			auditMsg = fmt.Sprintf("dp(%v) remove redundant replica on %v for master,base on replica %v,localPeers(%v) ",
 				partition.decommissionInfo(), peer.Addr, replica.Addr, replica.LocalPeers)
 			auditlog.LogMasterOp("RestoreReplicaMeta", auditMsg, err)
@@ -2269,7 +2270,9 @@ func (partition *DataPartition) tryRestoreReplicaMeta(c *Cluster, migrateType ui
 		}
 		return nil
 	}
-	//
+	// auto decommission need to decommission replica with disk error first.
+	// 2-replica is leaderless,with 1 disk error and 1 normal , cannot be meta repaired because has
+	// disk error replica, it results raftForce always false
 	if migrateType == AutoDecommission && partition.getDiskErrorReplica() != nil {
 		return nil
 	}

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -152,33 +152,34 @@ func (partition *DataPartition) checkLeader(c *Cluster, clusterID string, timeOu
 		WarnMetrics.WarnDpNoLeader(clusterID, partition.PartitionID, partition.ReplicaNum, report)
 	}
 	partition.Unlock()
-	if report && partition.ReplicaNum == 1 && partition.GetDecommissionStatus() == DecommissionInitial &&
-		len(partition.Hosts) == 1 && len(partition.Peers) == 1 {
-		replica := partition.Replicas[0]
-		// heart beat is not arrived
-		if len(replica.LocalPeers) == 0 {
-			return
-		}
-		redundantPeers := findRedundantPeers(partition.Hosts, replica.LocalPeers)
-		log.LogInfof("action[checkLeader] partition %v try to recover leader local peers(%v) redundantPeers(%v)",
-			partition.PartitionID, replica.LocalPeers, redundantPeers)
-		for _, peer := range redundantPeers {
-			log.LogInfof("action[checkLeader] partition %v remove peer (%v)",
-				partition.PartitionID, peer)
-			dataNode, err := c.dataNode(peer)
-			if err != nil {
-				log.LogInfof("action[checkLeader] partition %v find data node for peer (%v) failed %v",
-					partition.PartitionID, peer, err)
-				continue
-			}
-			removePeer := proto.Peer{ID: dataNode.ID, Addr: peer}
-			if err := c.removeDataPartitionRaftMember(partition, removePeer, true); err != nil {
-				log.LogInfof("action[checkLeader] partition %v remove peer (%v) failed %v",
-					partition.PartitionID, peer, err)
-				continue
-			}
-		}
-	}
+	// if report && partition.ReplicaNum == 1 && partition.GetDecommissionStatus() == DecommissionInitial &&
+	//	len(partition.Hosts) == 1 && len(partition.Peers) == 1 {
+	//	replica := partition.Replicas[0]
+	//	// heart beat is not arrived
+	//	if len(replica.LocalPeers) == 0 {
+	//		return
+	//	}
+	//	redundantPeers := findRedundantPeers(partition.Hosts, replica.LocalPeers)
+	//	log.LogInfof("action[checkLeader] partition %v try to recover leader local peers(%v) redundantPeers(%v)",
+	//		partition.PartitionID, replica.LocalPeers, redundantPeers)
+	//	for _, peer := range redundantPeers {
+	//		log.LogInfof("action[checkLeader] partition %v remove peer (%v)",
+	//			partition.PartitionID, peer)
+	//		dataNode, err := c.dataNode(peer)
+	//		if err != nil {
+	//			log.LogInfof("action[checkLeader] partition %v find data node for peer (%v) failed %v",
+	//				partition.PartitionID, peer, err)
+	//			continue
+	//		}
+	//		removePeer := proto.Peer{ID: dataNode.ID, Addr: peer}
+	//		if err := c.removeDataPartitionRaftMember(partition, removePeer, true); err != nil {
+	//			log.LogInfof("action[checkLeader] partition %v remove peer (%v) failed %v",
+	//				partition.PartitionID, peer, err)
+	//			continue
+	//		}
+	//	}
+	// }
+	return
 }
 
 func findRedundantPeers(a []string, b []proto.Peer) []string {

--- a/master/data_partition_check.go
+++ b/master/data_partition_check.go
@@ -152,51 +152,6 @@ func (partition *DataPartition) checkLeader(c *Cluster, clusterID string, timeOu
 		WarnMetrics.WarnDpNoLeader(clusterID, partition.PartitionID, partition.ReplicaNum, report)
 	}
 	partition.Unlock()
-	// if report && partition.ReplicaNum == 1 && partition.GetDecommissionStatus() == DecommissionInitial &&
-	//	len(partition.Hosts) == 1 && len(partition.Peers) == 1 {
-	//	replica := partition.Replicas[0]
-	//	// heart beat is not arrived
-	//	if len(replica.LocalPeers) == 0 {
-	//		return
-	//	}
-	//	redundantPeers := findRedundantPeers(partition.Hosts, replica.LocalPeers)
-	//	log.LogInfof("action[checkLeader] partition %v try to recover leader local peers(%v) redundantPeers(%v)",
-	//		partition.PartitionID, replica.LocalPeers, redundantPeers)
-	//	for _, peer := range redundantPeers {
-	//		log.LogInfof("action[checkLeader] partition %v remove peer (%v)",
-	//			partition.PartitionID, peer)
-	//		dataNode, err := c.dataNode(peer)
-	//		if err != nil {
-	//			log.LogInfof("action[checkLeader] partition %v find data node for peer (%v) failed %v",
-	//				partition.PartitionID, peer, err)
-	//			continue
-	//		}
-	//		removePeer := proto.Peer{ID: dataNode.ID, Addr: peer}
-	//		if err := c.removeDataPartitionRaftMember(partition, removePeer, true); err != nil {
-	//			log.LogInfof("action[checkLeader] partition %v remove peer (%v) failed %v",
-	//				partition.PartitionID, peer, err)
-	//			continue
-	//		}
-	//	}
-	// }
-	return
-}
-
-func findRedundantPeers(a []string, b []proto.Peer) []string {
-	var redundantPeers []string
-	for _, item := range b {
-		found := false
-		for _, value := range a {
-			if item.Addr == value {
-				found = true
-				break
-			}
-		}
-		if !found {
-			redundantPeers = append(redundantPeers, item.Addr)
-		}
-	}
-	return redundantPeers
 }
 
 // Check if there is any missing replica for a data partition.

--- a/master/data_partition_map.go
+++ b/master/data_partition_map.go
@@ -151,6 +151,8 @@ func (dpMap *DataPartitionMap) setDataPartitionCompressCache(responseCompress []
 }
 
 func (dpMap *DataPartitionMap) updateResponseCache(needsUpdate bool, minPartitionID uint64, vol *Vol) (body []byte, err error) {
+	log.LogInfof("[updateResponseCache] get vol(%v) dp cache", vol.Name)
+
 	responseCache := dpMap.getDataPartitionResponseCache()
 	if responseCache == nil || needsUpdate || len(responseCache) == 0 {
 		dpMap.readMutex.Lock()
@@ -178,6 +180,7 @@ func (dpMap *DataPartitionMap) updateResponseCache(needsUpdate bool, minPartitio
 			return nil, proto.ErrMarshalData
 		}
 		dpMap.setDataPartitionResponseCache(body)
+		log.LogInfof("[updateResponseCache] update vol(%v) dp cache cnt(%v)", vol.Name, len(dpResps))
 		return
 	}
 

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -191,8 +191,9 @@ func (c *Cluster) checkDiskRecoveryProgress() {
 				} else {
 					partition.DecommissionErrorMessage = ""
 					partition.SetDecommissionStatus(DecommissionSuccess) // can be readonly or readwrite
-					Warn(c.Name, fmt.Sprintf("action[checkDiskRecoveryProgress]clusterID[%v],partitionID[%v] replica %v has recovered success",
-						c.Name, partitionID, partition.DecommissionDstAddr))
+					Warn(c.Name, fmt.Sprintf("action[checkDiskRecoveryProgress]clusterID[%v],partitionID[%v] "+
+						"replica %v has recovered success,cost(%v)",
+						c.Name, partitionID, partition.DecommissionDstAddr, time.Since(partition.RecoverStartTime).String()))
 				}
 				partition.RLock()
 				err = c.syncUpdateDataPartition(partition)

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -262,12 +262,12 @@ func (c *Cluster) decommissionDisk(dataNode *DataNode, raftForce bool, badDiskPa
 }
 
 const (
-	InitialDecommission uint32 = iota
-	ManualDecommission         // used for queryAllDecommissionDisk
-	AutoDecommission
-	AllDecommission
-	AutoAddReplica
-	ManualAddReplica
+	InitialDecommission = proto.InitialDecommission
+	ManualDecommission  = proto.ManualDecommission
+	AutoDecommission    = proto.AutoDecommission
+	AllDecommission     = proto.AllDecommission
+	AutoAddReplica      = proto.AutoAddReplica
+	ManualAddReplica    = proto.ManualAddReplica
 )
 
 type DecommissionDisk struct {

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -142,8 +142,8 @@ func (c *Cluster) checkDiskRecoveryProgress() {
 							partition.SetDecommissionStatus(DecommissionFail)
 						}
 						partition.DecommissionErrorMessage = fmt.Sprintf("Decommission target node %v repair timeout", partition.DecommissionDstAddr)
-						Warn(c.Name, fmt.Sprintf("action[checkDiskRecoveryProgress]clusterID[%v],partitionID[%v]  recovered timeout %s",
-							c.Name, partitionID, time.Since(partition.RecoverStartTime)))
+						Warn(c.Name, fmt.Sprintf("action[checkDiskRecoveryProgress]clusterID[%v],partitionID[%v] replica %v_%v recovered timeout %s",
+							c.Name, partitionID, newReplica.Addr, newReplica.DiskPath, time.Since(partition.RecoverStartTime)))
 						partition.RLock()
 						err = c.syncUpdateDataPartition(partition)
 						if err != nil {

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -221,6 +221,8 @@ func (c *Cluster) addAndSyncDecommissionedDisk(dataNode *DataNode, diskPath stri
 	}
 	if err = c.syncUpdateDataNode(dataNode); err != nil {
 		dataNode.deleteDecommissionedDisk(diskPath)
+		log.LogWarnf("action[addAndSyncDecommissionedDisk]submit raft failed: %v, delete disks[%v], dataNode[%v]",
+			err, diskPath, dataNode.Addr)
 		return
 	}
 	log.LogInfof("action[addAndSyncDecommissionedDisk] finish, remaining decommissioned disks[%v], dataNode[%v]", dataNode.getDecommissionedDisks(), dataNode.Addr)

--- a/master/disk_manager.go
+++ b/master/disk_manager.go
@@ -351,11 +351,6 @@ func (dd *DecommissionDisk) updateDecommissionStatus(c *Cluster, debug bool) (ui
 			failedPartitionIds = append(failedPartitionIds, dp.PartitionID)
 		}
 
-		if dp.GetDecommissionStatus() == DecommissionNeedManualFix {
-			failedNum++
-			failedPartitionIds = append(failedPartitionIds, dp.PartitionID)
-		}
-
 		if dp.GetDecommissionStatus() == DecommissionRunning {
 			runningNum++
 			runningPartitionIds = append(runningPartitionIds, dp.PartitionID)
@@ -427,7 +422,7 @@ func (dd *DecommissionDisk) GetDecommissionFailedDPByTerm(c *Cluster) []proto.Fa
 	var failedDps []proto.FailedDpInfo
 	log.LogDebugf("action[GetDecommissionFailedDPByTerm] partitions len %v", len(partitions))
 	for _, dp := range partitions {
-		if dp.IsRollbackFailed() || dp.GetDecommissionStatus() == DecommissionNeedManualFix {
+		if dp.IsRollbackFailed() {
 			failedDps = append(failedDps, proto.FailedDpInfo{PartitionID: dp.PartitionID, ErrMsg: dp.DecommissionErrorMessage})
 			log.LogWarnf("action[GetDecommissionFailedDPByTerm] dp[%v] failed", dp.PartitionID)
 		}

--- a/master/filecrc.go
+++ b/master/filecrc.go
@@ -89,7 +89,7 @@ func (fc *FileInCore) needCrcRepair(liveReplicas []*DataReplica, getInfoCallback
 			return
 		}
 		if fm.ApplyID == baseApplyId && fm.getFileCrc() != baseCrc {
-			log.LogErrorf("needCrcRepair. getInfoCallback %v, extent %v, applyID(%v:%v), crc %v",
+			log.LogWarnf("needCrcRepair. getInfoCallback %v, extent %v, applyID(%v:%v), crc %v",
 				getInfoCallback(), fc.Name, fm.ApplyID, baseApplyId, baseCrc)
 			needRepair = true
 			return

--- a/master/gapi_cluster.go
+++ b/master/gapi_cluster.go
@@ -300,12 +300,12 @@ func (m *ClusterService) getTopology(ctx context.Context, args struct{}) (*proto
 			cv.NodeSet[ns.ID] = nsView
 			ns.dataNodes.Range(func(key, value interface{}) bool {
 				dataNode := value.(*DataNode)
-				nsView.DataNodes = append(nsView.DataNodes, proto.NodeView{ID: dataNode.ID, Addr: dataNode.Addr, IsActive: dataNode.isActive, IsWritable: dataNode.isWriteAble()})
+				nsView.DataNodes = append(nsView.DataNodes, proto.NodeView{ID: dataNode.ID, Addr: dataNode.Addr, IsActive: dataNode.isActive, IsWritable: dataNode.IsWriteAble()})
 				return true
 			})
 			ns.metaNodes.Range(func(key, value interface{}) bool {
 				metaNode := value.(*MetaNode)
-				nsView.MetaNodes = append(nsView.MetaNodes, proto.NodeView{ID: metaNode.ID, Addr: metaNode.Addr, IsActive: metaNode.IsActive, IsWritable: metaNode.isWritable()})
+				nsView.MetaNodes = append(nsView.MetaNodes, proto.NodeView{ID: metaNode.ID, Addr: metaNode.Addr, IsActive: metaNode.IsActive, IsWritable: metaNode.IsWriteAble()})
 				return true
 			})
 		}

--- a/master/http_server.go
+++ b/master/http_server.go
@@ -565,6 +565,9 @@ func (m *Server) registerAPIRoutes(router *mux.Router) {
 	router.NewRoute().Methods(http.MethodGet).
 		Path(proto.AdminRecoverReplicaMeta).
 		HandlerFunc(m.recoverReplicaMeta)
+	router.NewRoute().Methods(http.MethodGet).
+		Path(proto.AdminRecoverDiskErrorReplica).
+		HandlerFunc(m.recoverDiskErrorReplica)
 
 	// meta node management APIs
 	router.NewRoute().Methods(http.MethodGet, http.MethodPost).

--- a/master/master_manager.go
+++ b/master/master_manager.go
@@ -38,7 +38,7 @@ func (m *Server) handleLeaderChange(leader uint64) {
 		return
 	}
 
-	oldLeaderAddr := m.leaderInfo.addr
+	// oldLeaderAddr := m.leaderInfo.addr
 	m.leaderInfo.addr = AddrDatabase[leader]
 	log.LogWarnf("action[handleLeaderChange]  [%v] ", m.leaderInfo.addr)
 	m.reverseProxy = m.newReverseProxy()
@@ -46,13 +46,13 @@ func (m *Server) handleLeaderChange(leader uint64) {
 	if m.id == leader {
 		Warn(m.clusterName, fmt.Sprintf("clusterID[%v] leader is changed to %v",
 			m.clusterName, m.leaderInfo.addr))
-		if oldLeaderAddr != m.leaderInfo.addr {
-			m.cluster.checkPersistClusterValue()
+		// if oldLeaderAddr != m.leaderInfo.addr {
+		m.cluster.checkPersistClusterValue()
 
-			m.loadMetadata()
-			m.cluster.metaReady = true
-			m.metaReady = true
-		}
+		m.loadMetadata()
+		m.cluster.metaReady = true
+		m.metaReady = true
+		// }
 		m.cluster.checkDataNodeHeartbeat()
 		m.cluster.checkMetaNodeHeartbeat()
 		m.cluster.checkLcNodeHeartbeat()

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -64,7 +64,7 @@ type clusterValue struct {
 	DecommissionDiskLimit       uint32
 	VolDeletionDelayTimeHour    int64
 	MarkDiskBrokenThreshold     float64
-	DisableAutoDpMetaRepair     bool
+	EnableAutoDpMetaRepair      bool
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -98,7 +98,7 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		DecommissionDiskLimit:       c.GetDecommissionDiskLimit(),
 		VolDeletionDelayTimeHour:    c.cfg.volDelayDeleteTimeHour,
 		MarkDiskBrokenThreshold:     c.getMarkDiskBrokenThreshold(),
-		DisableAutoDpMetaRepair:     c.getDisableAutoDpMetaRepair(),
+		EnableAutoDpMetaRepair:      c.getEnableAutoDpMetaRepair(),
 	}
 	return cv
 }
@@ -315,8 +315,9 @@ type volValue struct {
 	TrashInterval                                          int64
 	DisableAuditLog                                        bool
 
-	Forbidden         bool
-	DpRepairBlockSize uint64
+	Forbidden            bool
+	DpRepairBlockSize    uint64
+	EnableAutoMetaRepair bool
 }
 
 func (v *volValue) Bytes() (raw []byte, err error) {
@@ -385,6 +386,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		DeleteExecTime:        vol.DeleteExecTime,
 		User:                  vol.user,
 		DpRepairBlockSize:     vol.dpRepairBlockSize,
+		EnableAutoMetaRepair:  vol.EnableAutoMetaRepair.Load(),
 	}
 
 	return
@@ -1045,8 +1047,8 @@ func (c *Cluster) updateMarkDiskBrokenThreshold(val float64) {
 	c.MarkDiskBrokenThreshold.Store(val)
 }
 
-func (c *Cluster) updateDisableAutoDpMetaRepair(val bool) {
-	c.DisableAutoDpMetaRepair.Store(val)
+func (c *Cluster) updateEnableAutoDpMetaRepair(val bool) {
+	c.EnableAutoDpMetaRepair.Store(val)
 }
 
 func (c *Cluster) updateDecommissionDiskLimit(val uint32) {
@@ -1199,7 +1201,7 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.updateDecommissionDiskLimit(cv.DecommissionDiskLimit)
 		c.checkDataReplicasEnable = cv.CheckDataReplicasEnable
 		c.updateMarkDiskBrokenThreshold(cv.MarkDiskBrokenThreshold)
-		c.updateDisableAutoDpMetaRepair(cv.DisableAutoDpMetaRepair)
+		c.updateEnableAutoDpMetaRepair(cv.EnableAutoDpMetaRepair)
 	}
 	return
 }

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -64,6 +64,7 @@ type clusterValue struct {
 	DecommissionDiskLimit       uint32
 	VolDeletionDelayTimeHour    int64
 	MarkDiskBrokenThreshold     float64
+	DisableAutoDpMetaRepair     bool
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -97,6 +98,7 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		DecommissionDiskLimit:       c.GetDecommissionDiskLimit(),
 		VolDeletionDelayTimeHour:    c.cfg.volDelayDeleteTimeHour,
 		MarkDiskBrokenThreshold:     c.getMarkDiskBrokenThreshold(),
+		DisableAutoDpMetaRepair:     c.getDisableAutoDpMetaRepair(),
 	}
 	return cv
 }
@@ -1043,6 +1045,10 @@ func (c *Cluster) updateMarkDiskBrokenThreshold(val float64) {
 	c.MarkDiskBrokenThreshold.Store(val)
 }
 
+func (c *Cluster) updateDisableAutoDpMetaRepair(val bool) {
+	c.DisableAutoDpMetaRepair.Store(val)
+}
+
 func (c *Cluster) updateDecommissionDiskLimit(val uint32) {
 	if val < 1 {
 		val = 1
@@ -1193,6 +1199,7 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.updateDecommissionDiskLimit(cv.DecommissionDiskLimit)
 		c.checkDataReplicasEnable = cv.CheckDataReplicasEnable
 		c.updateMarkDiskBrokenThreshold(cv.MarkDiskBrokenThreshold)
+		c.updateDisableAutoDpMetaRepair(cv.DisableAutoDpMetaRepair)
 	}
 	return
 }

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -1182,6 +1182,11 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.EnableAutoDecommissionDisk = cv.EnableAutoDecommissionDisk
 		c.DecommissionLimit = cv.DecommissionLimit
 		c.cfg.volDelayDeleteTimeHour = cv.VolDeletionDelayTimeHour
+
+		if c.cfg.volDelayDeleteTimeHour <= 0 {
+			c.cfg.volDelayDeleteTimeHour = defaultVolDelayDeleteTimeHour
+		}
+
 		if c.cfg.QosMasterAcceptLimit < QosMasterAcceptCnt {
 			c.cfg.QosMasterAcceptLimit = QosMasterAcceptCnt
 		}

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -65,6 +65,7 @@ type clusterValue struct {
 	VolDeletionDelayTimeHour    int64
 	MarkDiskBrokenThreshold     float64
 	EnableAutoDpMetaRepair      bool
+	DataPartitionTimeoutSec     int64
 }
 
 func newClusterValue(c *Cluster) (cv *clusterValue) {
@@ -99,6 +100,7 @@ func newClusterValue(c *Cluster) (cv *clusterValue) {
 		VolDeletionDelayTimeHour:    c.cfg.volDelayDeleteTimeHour,
 		MarkDiskBrokenThreshold:     c.getMarkDiskBrokenThreshold(),
 		EnableAutoDpMetaRepair:      c.getEnableAutoDpMetaRepair(),
+		DataPartitionTimeoutSec:     c.getDataPartitionTimeoutSec(),
 	}
 	return cv
 }
@@ -1020,6 +1022,10 @@ func (c *Cluster) updateDataPartitionRepairTimeOut(val uint64) {
 	atomic.StoreUint64(&c.cfg.DpRepairTimeOut, val)
 }
 
+func (c *Cluster) updateDataPartitionTimeoutSec(val int64) {
+	atomic.StoreInt64(&c.cfg.DataPartitionTimeOutSec, val)
+}
+
 func (c *Cluster) updateDataNodeAutoRepairLimit(val uint64) {
 	atomic.StoreUint64(&c.cfg.DataNodeAutoRepairLimitRate, val)
 }
@@ -1202,6 +1208,7 @@ func (c *Cluster) loadClusterValue() (err error) {
 		c.checkDataReplicasEnable = cv.CheckDataReplicasEnable
 		c.updateMarkDiskBrokenThreshold(cv.MarkDiskBrokenThreshold)
 		c.updateEnableAutoDpMetaRepair(cv.EnableAutoDpMetaRepair)
+		c.updateDataPartitionTimeoutSec(cv.DataPartitionTimeoutSec)
 	}
 	return
 }

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -820,7 +820,7 @@ func (mm *monitorMetrics) updateMetaNodesStat() {
 		mm.nodeStat.SetWithLabelValues(float64(metaNode.Used), MetricRoleMetaNode, metaNode.Addr, "memUsed")
 		mm.nodeStat.SetWithLabelValues(float64(metaNode.MetaPartitionCount), MetricRoleMetaNode, metaNode.Addr, "mpCount")
 		mm.nodeStat.SetWithLabelValues(float64(metaNode.Threshold), MetricRoleMetaNode, metaNode.Addr, "threshold")
-		mm.nodeStat.SetBoolWithLabelValues(metaNode.isWritable(), MetricRoleMetaNode, metaNode.Addr, "writable")
+		mm.nodeStat.SetBoolWithLabelValues(metaNode.IsWriteAble(), MetricRoleMetaNode, metaNode.Addr, "writable")
 		mm.nodeStat.SetBoolWithLabelValues(metaNode.IsActive, MetricRoleMetaNode, metaNode.Addr, "active")
 
 		return true
@@ -871,7 +871,7 @@ func (mm *monitorMetrics) updateDataNodesStat() {
 		mm.nodeStat.SetWithLabelValues(dataNode.UsageRatio, MetricRoleDataNode, dataNode.Addr, "usageRatio")
 		mm.nodeStat.SetWithLabelValues(float64(len(dataNode.BadDisks)), MetricRoleDataNode, dataNode.Addr, "badDiskCount")
 		mm.nodeStat.SetBoolWithLabelValues(dataNode.isActive, MetricRoleDataNode, dataNode.Addr, "active")
-		mm.nodeStat.SetBoolWithLabelValues(dataNode.isWriteAble(), MetricRoleDataNode, dataNode.Addr, "writable")
+		mm.nodeStat.SetBoolWithLabelValues(dataNode.IsWriteAble(), MetricRoleDataNode, dataNode.Addr, "writable")
 		return true
 	})
 	mm.dataNodesInactive.Set(float64(inactiveDataNodesCount))
@@ -897,7 +897,7 @@ func (mm *monitorMetrics) setNotWritableMetaNodesCount() {
 		if !ok {
 			return true
 		}
-		if !metaNode.isWritable() {
+		if !metaNode.IsWriteAble() {
 			notWritabelMetaNodesCount++
 		}
 		return true
@@ -912,7 +912,7 @@ func (mm *monitorMetrics) setNotWritableDataNodesCount() {
 		if !ok {
 			return true
 		}
-		if !dataNode.isWriteAble() {
+		if !dataNode.IsWriteAble() {
 			notWritabelDataNodesCount++
 		}
 		return true

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -380,13 +380,14 @@ func (m *warningMetrics) deleteMissingMp(missingMpAddrSet addrSet, clusterName, 
 // leader only
 func (m *warningMetrics) WarnMissingMp(clusterName, addr string, partitionID uint64, report bool) {
 	m.mpMissingReplicaMutex.Lock()
-	defer m.mpMissingReplicaMutex.Unlock()
+
 	if clusterName != m.cluster.Name {
 		return
 	}
 
 	id := strconv.FormatUint(partitionID, 10)
 	if !report {
+		m.mpMissingReplicaMutex.Unlock()
 		m.deleteMissingMp(m.mpMissingReplicaInfo[id], clusterName, id, addr)
 		return
 	}
@@ -399,6 +400,7 @@ func (m *warningMetrics) WarnMissingMp(clusterName, addr string, partitionID uin
 		// m.mpMissingReplicaInfo[id] = make(addrSet)
 	}
 	m.mpMissingReplicaInfo[id].addrs[addr] = voidVal
+	m.mpMissingReplicaMutex.Unlock()
 }
 
 // leader only

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -382,6 +382,7 @@ func (m *warningMetrics) WarnMissingMp(clusterName, addr string, partitionID uin
 	m.mpMissingReplicaMutex.Lock()
 
 	if clusterName != m.cluster.Name {
+		m.mpMissingReplicaMutex.Unlock()
 		return
 	}
 

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -356,6 +356,8 @@ func (m *warningMetrics) WarnDpNoLeader(clusterName string, partitionID uint64, 
 
 // The caller is responsible for lock
 func (m *warningMetrics) deleteMissingMp(missingMpAddrSet addrSet, clusterName, mpId, addr string) {
+	m.mpMissingReplicaMutex.Lock()
+	defer m.mpMissingReplicaMutex.Unlock()
 	if len(missingMpAddrSet.addrs) == 0 {
 		return
 	}
@@ -393,7 +395,7 @@ func (m *warningMetrics) WarnMissingMp(clusterName, addr string, partitionID uin
 		m.missingMp.SetWithLabelValues(1, clusterName, id, addr)
 	}
 	if _, ok := m.mpMissingReplicaInfo[id]; !ok {
-		m.dpMissingReplicaInfo[id] = addrSet{addrs: make(map[string]voidType)}
+		m.mpMissingReplicaInfo[id] = addrSet{addrs: make(map[string]voidType)}
 		// m.mpMissingReplicaInfo[id] = make(addrSet)
 	}
 	m.mpMissingReplicaInfo[id].addrs[addr] = voidVal

--- a/master/monitor_metrics.go
+++ b/master/monitor_metrics.go
@@ -403,18 +403,18 @@ func (m *warningMetrics) WarnMissingMp(clusterName, addr string, partitionID uin
 
 // leader only
 func (m *warningMetrics) CleanObsoleteMpMissing(clusterName string, mp *MetaPartition) {
-	m.mpMissingReplicaMutex.Lock()
-	defer m.mpMissingReplicaMutex.Unlock()
 	if clusterName != m.cluster.Name {
 		return
 	}
 	id := strconv.FormatUint(mp.PartitionID, 10)
 
+	m.mpMissingReplicaMutex.Lock()
 	missingRepAddrs, ok := m.mpMissingReplicaInfo[id]
 	if !ok {
+		m.mpMissingReplicaMutex.Unlock()
 		return
 	}
-
+	m.mpMissingReplicaMutex.Unlock()
 	for addr := range missingRepAddrs.addrs {
 		if _, err := mp.getMetaReplica(addr); err != nil {
 			log.LogDebugf("action[warningMetrics] delete obsolete Mp missing record: dpId(%v), addr(%v)", id, addr)

--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -191,17 +191,8 @@ func (s *CarryWeightNodeSelector) getCarryDataNodes(maxTotal uint64, excludeHost
 			// log.LogDebugf("[getAvailCarryDataNodeTab] dataNode [%v] is excludeHosts", dataNode.Addr)
 			return true
 		}
-		if !dataNode.canAllocDp() {
-			log.LogWarnf("[getAvailCarryDataNodeTab] dataNode [%v] writeable(%v), isActive(%v) AvailableSpace(%v) "+
-				"RdOnly(%v) Total(%v) Used(%v) offline(%v), availableDiskCnt(%v) dpCnt(%v) excludeHosts[%v]",
-				dataNode.Addr, dataNode.isWriteAble(), dataNode.isActive, dataNode.AvailableSpace, dataNode.RdOnly,
-				dataNode.Total, dataNode.Used, dataNode.ToBeOffline, dataNode.availableDiskCount(),
-				dataNode.DataPartitionCount, excludeHosts)
-			return true
-		}
-
-		if !dataNode.canAlloc() {
-			log.LogWarnf("[getAvailCarryDataNodeTab] dataNode [%v] is overSold excludeHosts[%v]", dataNode.Addr, excludeHosts)
+		if !canAllocPartition(dataNode, s.nodeType) {
+			log.LogWarnf("[getCarryDataNodes] data node(%v) cannot alloc dp, total space(%v) avaliable space(%v) used space(%v), offline(%v), avaliable disk cnt(%v), dp count(%v), over sold(%v), exclude hosts(%v)", dataNode.Addr, dataNode.Total, dataNode.AvailableSpace, dataNode.Used, dataNode.ToBeOffline, dataNode.availableDiskCount(), dataNode.DataPartitionCount, !dataNode.canAlloc(), excludeHosts)
 			return true
 		}
 		if s.carry[dataNode.ID] >= 1.0 {
@@ -225,7 +216,8 @@ func (s *CarryWeightNodeSelector) getCarryMetaNodes(maxTotal uint64, excludeHost
 		if contains(excludeHosts, metaNode.Addr) {
 			return true
 		}
-		if !metaNode.isWritable() {
+		if !canAllocPartition(metaNode, s.nodeType) {
+			log.LogWarnf("[getCarryMetaNodes] meta node(%v) cannot alloc mp, total space(%v) used space(%v), offline(%v), mp count(%v), exclude hosts(%v)", metaNode.Addr, metaNode.Total, metaNode.Used, metaNode.ToBeOffline, metaNode.MetaPartitionCount, excludeHosts)
 			return true
 		}
 		if s.carry[metaNode.ID] >= 1.0 {

--- a/master/node_selector.go
+++ b/master/node_selector.go
@@ -65,6 +65,14 @@ type Node interface {
 	SelectNodeForWrite()
 	GetID() uint64
 	GetAddr() string
+	PartitionCntLimited() bool
+	IsActiveNode() bool
+	IsWriteAble() bool
+	GetPartitionLimitCnt() uint32
+	GetTotal() uint64
+	GetUsed() uint64
+	GetAvailableSpace() uint64
+	GetStorageInfo() string
 }
 
 // SortedWeightedNodes defines an array sorted by carry
@@ -82,17 +90,8 @@ func (nodes SortedWeightedNodes) Swap(i, j int) {
 	nodes[i], nodes[j] = nodes[j], nodes[i]
 }
 
-func canAllocPartition(node interface{}, nodeType NodeType) bool {
-	switch nodeType {
-	case DataNodeType:
-		dataNode := node.(*DataNode)
-		return dataNode.canAlloc() && dataNode.canAllocDp()
-	case MetaNodeType:
-		metaNode := node.(*MetaNode)
-		return metaNode.isWritable() && metaNode.mpCntInLimit()
-	default:
-		panic("unknown node type")
-	}
+func canAllocPartition(node Node) bool {
+	return node.IsWriteAble() && node.PartitionCntLimited()
 }
 
 func asNodeWrap(node interface{}, nodeType NodeType) Node {
@@ -118,130 +117,63 @@ func (s *CarryWeightNodeSelector) GetName() string {
 	return CarryWeightNodeSelectorName
 }
 
-func (s *CarryWeightNodeSelector) prepareCarryForDataNodes(nodes *sync.Map, total uint64) {
-	nodes.Range(func(key, value interface{}) bool {
-		dataNode := value.(*DataNode)
-		if _, ok := s.carry[dataNode.ID]; !ok {
-			// use available space to calculate initial weight
-			s.carry[dataNode.ID] = float64(dataNode.AvailableSpace) / float64(total)
-		}
-		return true
-	})
-}
-
-func (s *CarryWeightNodeSelector) prepareCarryForMetaNodes(nodes *sync.Map, total uint64) {
-	nodes.Range(func(key, value interface{}) bool {
-		metaNode := value.(*MetaNode)
-		if _, ok := s.carry[metaNode.ID]; !ok {
-			// use available space to calculate initial weight
-			s.carry[metaNode.ID] = float64(metaNode.Total-metaNode.Used) / float64(total)
-		}
-		return true
-	})
-}
-
 func (s *CarryWeightNodeSelector) prepareCarry(nodes *sync.Map, total uint64) {
-	switch s.nodeType {
-	case DataNodeType:
-		s.prepareCarryForDataNodes(nodes, total)
-	case MetaNodeType:
-		s.prepareCarryForMetaNodes(nodes, total)
-	default:
-	}
-}
-
-func (s *CarryWeightNodeSelector) getTotalMaxForDataNodes(nodes *sync.Map) (total uint64) {
 	nodes.Range(func(key, value interface{}) bool {
-		dataNode := value.(*DataNode)
-		if dataNode.Total > total {
-			total = dataNode.Total
+		node := value.(Node)
+		if _, ok := s.carry[node.GetID()]; !ok {
+			// use available space to calculate initial weight
+			s.carry[node.GetID()] = float64(node.GetAvailableSpace()) / float64(total)
 		}
 		return true
 	})
-	return
-}
-
-func (s *CarryWeightNodeSelector) getTotalMaxForMetaNodes(nodes *sync.Map) (total uint64) {
-	nodes.Range(func(key, value interface{}) bool {
-		metaNode := value.(*MetaNode)
-		if metaNode.Total > total {
-			total = metaNode.Total
-		}
-		return true
-	})
-	return
 }
 
 func (s *CarryWeightNodeSelector) getTotalMax(nodes *sync.Map) (total uint64) {
-	switch s.nodeType {
-	case DataNodeType:
-		total = s.getTotalMaxForDataNodes(nodes)
-	case MetaNodeType:
-		total = s.getTotalMaxForMetaNodes(nodes)
-	default:
-	}
-	return
-}
-
-func (s *CarryWeightNodeSelector) getCarryDataNodes(maxTotal uint64, excludeHosts []string, dataNodes *sync.Map) (nodeTabs SortedWeightedNodes, availCount int) {
-	nodeTabs = make(SortedWeightedNodes, 0)
-	dataNodes.Range(func(key, value interface{}) bool {
-		dataNode := value.(*DataNode)
-		if contains(excludeHosts, dataNode.Addr) {
-			// log.LogDebugf("[getAvailCarryDataNodeTab] dataNode [%v] is excludeHosts", dataNode.Addr)
-			return true
+	nodes.Range(func(key, value interface{}) bool {
+		dataNode := value.(Node)
+		if dataNode.GetTotal() > total {
+			total = dataNode.GetTotal()
 		}
-		if !canAllocPartition(dataNode, s.nodeType) {
-			log.LogWarnf("[getCarryDataNodes] data node(%v) cannot alloc dp, total space(%v) avaliable space(%v) used space(%v), offline(%v), avaliable disk cnt(%v), dp count(%v), over sold(%v), exclude hosts(%v)", dataNode.Addr, dataNode.Total, dataNode.AvailableSpace, dataNode.Used, dataNode.ToBeOffline, dataNode.availableDiskCount(), dataNode.DataPartitionCount, !dataNode.canAlloc(), excludeHosts)
-			return true
-		}
-		if s.carry[dataNode.ID] >= 1.0 {
-			availCount++
-		}
-
-		nt := new(weightedNode)
-		nt.Carry = s.carry[dataNode.ID]
-		nt.Weight = float64(dataNode.Total-dataNode.Used) / float64(maxTotal)
-		nt.Ptr = dataNode
-		nodeTabs = append(nodeTabs, nt)
-		return true
-	})
-	return
-}
-
-func (s *CarryWeightNodeSelector) getCarryMetaNodes(maxTotal uint64, excludeHosts []string, metaNodes *sync.Map) (nodes SortedWeightedNodes, availCount int) {
-	nodes = make(SortedWeightedNodes, 0)
-	metaNodes.Range(func(key, value interface{}) bool {
-		metaNode := value.(*MetaNode)
-		if contains(excludeHosts, metaNode.Addr) {
-			return true
-		}
-		if !canAllocPartition(metaNode, s.nodeType) {
-			log.LogWarnf("[getCarryMetaNodes] meta node(%v) cannot alloc mp, total space(%v) used space(%v), offline(%v), mp count(%v), exclude hosts(%v)", metaNode.Addr, metaNode.Total, metaNode.Used, metaNode.ToBeOffline, metaNode.MetaPartitionCount, excludeHosts)
-			return true
-		}
-		if s.carry[metaNode.ID] >= 1.0 {
-			availCount++
-		}
-		nt := new(weightedNode)
-		nt.Carry = s.carry[metaNode.ID]
-		nt.Weight = (float64)(metaNode.Total-metaNode.Used) / (float64)(maxTotal)
-		nt.Ptr = metaNode
-		nodes = append(nodes, nt)
 		return true
 	})
 	return
 }
 
 func (s *CarryWeightNodeSelector) getCarryNodes(nset *nodeSet, maxTotal uint64, excludeHosts []string) (SortedWeightedNodes, int) {
+	var nodes *sync.Map
 	switch s.nodeType {
 	case DataNodeType:
-		return s.getCarryDataNodes(maxTotal, excludeHosts, nset.dataNodes)
+		nodes = nset.dataNodes
 	case MetaNodeType:
-		return s.getCarryMetaNodes(maxTotal, excludeHosts, nset.metaNodes)
+		nodes = nset.metaNodes
 	default:
 		panic("unknown node type")
 	}
+
+	nodeTabs := make(SortedWeightedNodes, 0)
+	availCount := 0
+	nodes.Range(func(key, value interface{}) bool {
+		node := value.(Node)
+		if contains(excludeHosts, node.GetAddr()) {
+			// log.LogDebugf("[getAvailCarryDataNodeTab] dataNode [%v] is excludeHosts", dataNode.Addr)
+			return true
+		}
+		if !canAllocPartition(node) {
+			log.LogWarnf("[getCarryDataNodes] nodeType (%v) storage info (%v)  exclude hosts(%v)", s.nodeType, node.GetStorageInfo(), excludeHosts)
+			return true
+		}
+		if s.carry[node.GetID()] >= 1.0 {
+			availCount++
+		}
+
+		nt := new(weightedNode)
+		nt.Carry = s.carry[node.GetID()]
+		nt.Weight = float64(node.GetTotal()-node.GetUsed()) / float64(maxTotal)
+		nt.Ptr = node
+		nodeTabs = append(nodeTabs, nt)
+		return true
+	})
+	return nodeTabs, availCount
 }
 
 func (s *CarryWeightNodeSelector) setNodeCarry(nodes SortedWeightedNodes, availCarryCount, replicaNum int) {
@@ -322,16 +254,7 @@ type AvailableSpaceFirstNodeSelector struct {
 }
 
 func (s *AvailableSpaceFirstNodeSelector) getNodeAvailableSpace(node interface{}) uint64 {
-	switch s.nodeType {
-	case DataNodeType:
-		dataNode := node.(*DataNode)
-		return dataNode.AvailableSpace
-	case MetaNodeType:
-		metaNode := node.(*MetaNode)
-		return metaNode.Total - metaNode.Used
-	default:
-		panic("unkown node type")
-	}
+	return node.(Node).GetAvailableSpace()
 }
 
 func (s *AvailableSpaceFirstNodeSelector) GetName() string {
@@ -349,7 +272,7 @@ func (s *AvailableSpaceFirstNodeSelector) Select(ns *nodeSet, excludeHosts []str
 	nodes := ns.getNodes(s.nodeType)
 	sortedNodes := make([]Node, 0)
 	nodes.Range(func(key, value interface{}) bool {
-		sortedNodes = append(sortedNodes, asNodeWrap(value, s.nodeType))
+		sortedNodes = append(sortedNodes, value.(Node))
 		return true
 	})
 	// if we cannot get enough nodes, return error
@@ -370,7 +293,7 @@ func (s *AvailableSpaceFirstNodeSelector) Select(ns *nodeSet, excludeHosts []str
 		for nodeIndex < len(sortedNodes) {
 			node := sortedNodes[nodeIndex]
 			nodeIndex += 1
-			if canAllocPartition(node, s.nodeType) {
+			if canAllocPartition(node) {
 				if excludeHosts == nil || !contains(excludeHosts, node.GetAddr()) {
 					selectedIndex = nodeIndex - 1
 					break
@@ -428,7 +351,7 @@ func (s *RoundRobinNodeSelector) Select(ns *nodeSet, excludeHosts []string, repl
 	nodes := ns.getNodes(s.nodeType)
 	sortedNodes := make([]Node, 0)
 	nodes.Range(func(key, value interface{}) bool {
-		sortedNodes = append(sortedNodes, asNodeWrap(value, s.nodeType))
+		sortedNodes = append(sortedNodes, value.(Node))
 		return true
 	})
 	// if we cannot get enough nodes, return error
@@ -449,7 +372,7 @@ func (s *RoundRobinNodeSelector) Select(ns *nodeSet, excludeHosts []string, repl
 		for nodeIndex < len(sortedNodes) {
 			node := sortedNodes[(nodeIndex+s.index)%len(sortedNodes)]
 			nodeIndex += 1
-			if canAllocPartition(node, s.nodeType) {
+			if canAllocPartition(node) {
 				if excludeHosts == nil || !contains(excludeHosts, node.GetAddr()) {
 					selectedIndex = nodeIndex - 1
 					break
@@ -503,16 +426,7 @@ func (s *StrawNodeSelector) GetName() string {
 }
 
 func (s *StrawNodeSelector) getWeight(node Node) float64 {
-	switch s.nodeType {
-	case DataNodeType:
-		dataNode := node.(*DataNode)
-		return float64(dataNode.AvailableSpace) / util.GB
-	case MetaNodeType:
-		metaNode := node.(*MetaNode)
-		return float64(metaNode.Total-metaNode.Used) / util.GB
-	default:
-		panic("unkown node type")
-	}
+	return float64(node.GetAvailableSpace()) / util.GB
 }
 
 func (s *StrawNodeSelector) selectOneNode(nodes []Node) (index int, maxNode Node) {
@@ -549,7 +463,7 @@ func (s *StrawNodeSelector) Select(ns *nodeSet, excludeHosts []string, replicaNu
 			nodes[0], nodes[index] = node, nodes[0]
 		}
 		nodes = nodes[1:]
-		if !canAllocPartition(node, s.nodeType) {
+		if !canAllocPartition(node) {
 			continue
 		}
 		orderHosts = append(orderHosts, node.GetAddr())

--- a/master/nodeset_selector.go
+++ b/master/nodeset_selector.go
@@ -77,9 +77,9 @@ func (ns *nodeSet) getMetaNodeTotalAvailableSpace() (space uint64) {
 func (ns *nodeSet) canWriteFor(nodeType NodeType, replica int) bool {
 	switch nodeType {
 	case DataNodeType:
-		return ns.canWriteForDataNode(replica)
+		return ns.canWriteForNode(ns.dataNodes, replica)
 	case MetaNodeType:
-		return ns.canWriteForMetaNode(replica)
+		return ns.canWriteForNode(ns.metaNodes, replica)
 	default:
 		panic("unknow node type")
 	}

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -49,9 +49,12 @@ func newCreateDataPartitionRequest(volName string, ID uint64, replicaNum int, me
 	return
 }
 
-func newDeleteDataPartitionRequest(ID uint64) (req *proto.DeleteDataPartitionRequest) {
+func newDeleteDataPartitionRequest(ID uint64, decommissionType uint32, raftForceDel, isSpecialReplica bool) (req *proto.DeleteDataPartitionRequest) {
 	req = &proto.DeleteDataPartitionRequest{
-		PartitionId: ID,
+		PartitionId:      ID,
+		DecommissionType: decommissionType,
+		Force:            raftForceDel,
+		IsSpecialReplica: isSpecialReplica,
 	}
 	return
 }

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -49,12 +49,11 @@ func newCreateDataPartitionRequest(volName string, ID uint64, replicaNum int, me
 	return
 }
 
-func newDeleteDataPartitionRequest(ID uint64, decommissionType uint32, raftForceDel, isSpecialReplica bool) (req *proto.DeleteDataPartitionRequest) {
+func newDeleteDataPartitionRequest(ID uint64, decommissionType uint32, raftForceDel bool) (req *proto.DeleteDataPartitionRequest) {
 	req = &proto.DeleteDataPartitionRequest{
 		PartitionId:      ID,
 		DecommissionType: decommissionType,
 		Force:            raftForceDel,
-		IsSpecialReplica: isSpecialReplica,
 	}
 	return
 }

--- a/master/operate_util.go
+++ b/master/operate_util.go
@@ -262,3 +262,11 @@ func matchKey(serverKey, clientKey string) bool {
 	cipherStr := h.Sum(nil)
 	return strings.EqualFold(clientKey, hex.EncodeToString(cipherStr))
 }
+
+func newRecoverBackupDataPartitionReplicaRequest(ID uint64, disk string) (req *proto.RecoverBackupDataReplicaRequest) {
+	req = &proto.RecoverBackupDataReplicaRequest{
+		PartitionId: ID,
+		Disk:        disk,
+	}
+	return
+}

--- a/master/topology.go
+++ b/master/topology.go
@@ -2196,6 +2196,7 @@ func (l *DecommissionDataPartitionList) traverse(c *Cluster) {
 						dp.decommissionInfo(), time.Since(dp.RecoverStartTime))
 					dp.ResetDecommissionStatus()
 					dp.setRestoreReplicaStop()
+
 					err := c.syncUpdateDataPartition(dp)
 					if err != nil {
 						log.LogWarnf("action[DecommissionListTraverse]Remove success dp[%v] failed for %v",
@@ -2215,6 +2216,7 @@ func (l *DecommissionDataPartitionList) traverse(c *Cluster) {
 					}
 					// rollback fail/success need release token
 					dp.ReleaseDecommissionToken(c)
+					dp.DecommissionType = InitialDecommission
 					c.syncUpdateDataPartition(dp)
 					msg := fmt.Sprintf("dp %v decommission failed", dp.decommissionInfo())
 					auditlog.LogMasterOp("TraverseDataPartition", msg, nil)
@@ -2224,6 +2226,7 @@ func (l *DecommissionDataPartitionList) traverse(c *Cluster) {
 					dp.ReleaseDecommissionToken(c)
 					l.Remove(dp)
 					dp.setRestoreReplicaStop()
+					dp.DecommissionType = InitialDecommission
 					c.syncUpdateDataPartition(dp)
 				} else if dp.IsDecommissionInitial() { // fixed done ,not release token
 					l.Remove(dp)

--- a/master/topology.go
+++ b/master/topology.go
@@ -1048,6 +1048,17 @@ func (ns *nodeSet) canWriteForDataNode(replicaNum int) bool {
 	return count >= replicaNum
 }
 
+func (ns *nodeSet) canAllocDataNodeCnt() (cnt int) {
+	ns.dataNodes.Range(func(key, value interface{}) bool {
+		node := value.(*DataNode)
+		if node.isWriteAble() && node.dpCntInLimit() {
+			cnt++
+		}
+		return true
+	})
+	return
+}
+
 func (ns *nodeSet) canWriteForMetaNode(replicaNum int) bool {
 	var count int
 	ns.metaNodes.Range(func(key, value interface{}) bool {
@@ -1063,6 +1074,17 @@ func (ns *nodeSet) canWriteForMetaNode(replicaNum int) bool {
 	log.LogInfof("canWriteForMetaNode zone[%v], ns[%v],count[%v] replicaNum[%v]",
 		ns.zoneName, ns.ID, count, replicaNum)
 	return count >= replicaNum
+}
+
+func (ns *nodeSet) canAllocMetaNodeCnt() (cnt int) {
+	ns.metaNodes.Range(func(key, value interface{}) bool {
+		node := value.(*MetaNode)
+		if node.isWritable() && node.mpCntInLimit() {
+			cnt++
+		}
+		return true
+	})
+	return
 }
 
 func (ns *nodeSet) putDataNode(dataNode *DataNode) {

--- a/master/topology.go
+++ b/master/topology.go
@@ -2182,7 +2182,7 @@ func (l *DecommissionDataPartitionList) traverse(c *Cluster) {
 			}
 			allDecommissionDP := l.GetAllDecommissionDataPartitions()
 			for _, dp := range allDecommissionDP {
-				log.LogDebugf("[DecommissionListTraverse] traverse dp(%v) discard(%v) decommission status(%v)", dp.PartitionID, dp.IsDiscard, dp.GetDecommissionStatus())
+				log.LogDebugf("[DecommissionListTraverse] traverse dp(%v)", dp.decommissionInfo())
 				if dp.IsDecommissionSuccess() {
 					l.Remove(dp)
 					dp.ReleaseDecommissionToken(c)

--- a/master/topology.go
+++ b/master/topology.go
@@ -2072,7 +2072,12 @@ func (l *DecommissionDataPartitionList) Put(id uint64, value *DataPartition, c *
 	// restore from rocksdb
 	// NOTE: if dp is discard, not need to get token, decommission will success directly
 	if value.checkConsumeToken() && !value.IsDiscard {
-		value.TryAcquireDecommissionToken(c)
+		// keep origin error msg, DecommissionErrorMessage would be replaced by "no node set available" e.g. if
+		// execute TryAcquireDecommissionToken failed
+		msg := value.DecommissionErrorMessage
+		if !value.TryAcquireDecommissionToken(c) {
+			value.DecommissionErrorMessage = msg
+		}
 	}
 
 	// restore special replica decommission progress

--- a/master/topology.go
+++ b/master/topology.go
@@ -17,7 +17,6 @@ package master
 import (
 	"container/list"
 	"fmt"
-	"github.com/cubefs/cubefs/util/auditlog"
 	"sort"
 	"strings"
 	"sync"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/util"
+	"github.com/cubefs/cubefs/util/auditlog"
 	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/log"
 )

--- a/master/topology_test.go
+++ b/master/topology_test.go
@@ -136,7 +136,7 @@ func TestAllocZones(t *testing.T) {
 	t.Logf("ChooseTargetDataHosts in single zone,hosts[%v]", hosts)
 
 	// cross zone
-	hosts, _, err = cluster.getHostFromNormalZone(TypeDataPartition, nil, nil, nil, replicaNum, 2, "")
+	_, _, err = cluster.getHostFromNormalZone(TypeDataPartition, nil, nil, nil, replicaNum, 2, "")
 	require.NoError(t, err)
 
 	// specific zone

--- a/master/vol.go
+++ b/master/vol.go
@@ -800,7 +800,7 @@ func (mp *MetaPartition) memUsedReachThreshold(clusterName, volName string) bool
 	if !foundReadonlyReplica || readonlyReplica == nil {
 		return false
 	}
-	if readonlyReplica.metaNode.isWritable() {
+	if readonlyReplica.metaNode.IsWriteAble() {
 		msg := fmt.Sprintf("action[checkSplitMetaPartition] vol[%v],max meta parition[%v] status is readonly\n",
 			volName, mp.PartitionID)
 		Warn(clusterName, msg)
@@ -1483,8 +1483,7 @@ func (vol *Vol) doCreateMetaPartition(c *Cluster, start, end uint64) (mp *MetaPa
 		}
 	} else {
 		var excludeZone []string
-		zoneNum := c.decideZoneNum(vol.crossZone)
-
+		zoneNum := c.decideZoneNum(vol)
 		if hosts, peers, err = c.getHostFromNormalZone(TypeMetaPartition, excludeZone, nil, nil, int(vol.mpReplicaNum), zoneNum, vol.zoneName); err != nil {
 			log.LogErrorf("action[doCreateMetaPartition] getHostFromNormalZone err[%v]", err)
 			return nil, errors.NewError(err)

--- a/master/vol.go
+++ b/master/vol.go
@@ -1158,7 +1158,7 @@ func (vol *Vol) deleteDataPartition(c *Cluster, dp *DataPartition) {
 	}
 
 	for _, addr := range addrs {
-		if err := vol.deleteDataPartitionFromDataNode(c, dp.createTaskToDeleteDataPartition(addr)); err != nil {
+		if err := vol.deleteDataPartitionFromDataNode(c, dp.createTaskToDeleteDataPartition(addr, false)); err != nil {
 			log.LogErrorf("[deleteDataPartitionFromDataNode] delete data replica from datanode fail, id %d, err %s", dp.PartitionID, err.Error())
 		}
 	}
@@ -1365,7 +1365,7 @@ func (vol *Vol) getTasksToDeleteDataPartitions() (tasks []*proto.AdminTask) {
 
 	for _, dp := range vol.dataPartitions.partitions {
 		for _, replica := range dp.Replicas {
-			tasks = append(tasks, dp.createTaskToDeleteDataPartition(replica.Addr))
+			tasks = append(tasks, dp.createTaskToDeleteDataPartition(replica.Addr, false))
 		}
 	}
 	return

--- a/master/vol.go
+++ b/master/vol.go
@@ -627,9 +627,9 @@ func (vol *Vol) checkDataPartitions(c *Cluster) (cnt int) {
 			totalPreloadCapacity += dp.total / util.GB
 		}
 
-		dp.checkReplicaStatus(c.cfg.DataPartitionTimeOutSec)
-		dp.checkStatus(c.Name, true, c.cfg.DataPartitionTimeOutSec, c, shouldDpInhibitWriteByVolFull, vol.Forbidden)
-		dp.checkLeader(c, c.Name, c.cfg.DataPartitionTimeOutSec)
+		dp.checkReplicaStatus(c.getDataPartitionTimeoutSec())
+		dp.checkStatus(c.Name, true, c.getDataPartitionTimeoutSec(), c, shouldDpInhibitWriteByVolFull, vol.Forbidden)
+		dp.checkLeader(c, c.Name, c.getDataPartitionTimeoutSec())
 		dp.checkMissingReplicas(c.Name, c.leaderInfo.addr, c.cfg.MissingDataPartitionInterval, c.cfg.IntervalToAlarmMissingDataPartition)
 		dp.checkReplicaNum(c, vol)
 

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -178,7 +178,7 @@ func TestCreateColdVol(t *testing.T) {
 	delVol(volName3, t)
 
 	// NOTE: check all vols
-	timeout := time.Now().Add(60 * time.Second)
+	timeout := time.Now().Add(100 * time.Second)
 	for time.Now().Before(timeout) {
 		_, err = server.cluster.getVol(volName1)
 		if err == nil {

--- a/master/vol_test.go
+++ b/master/vol_test.go
@@ -178,13 +178,32 @@ func TestCreateColdVol(t *testing.T) {
 	delVol(volName3, t)
 
 	// NOTE: check all vols
-	time.Sleep(20 * time.Second)
-	_, err = server.cluster.getVol(volName1)
-	require.ErrorIs(t, err, proto.ErrVolNotExists)
-	_, err = server.cluster.getVol(volName2)
-	require.ErrorIs(t, err, proto.ErrVolNotExists)
-	_, err = server.cluster.getVol(volName3)
-	require.ErrorIs(t, err, proto.ErrVolNotExists)
+	timeout := time.Now().Add(60 * time.Second)
+	for time.Now().Before(timeout) {
+		_, err = server.cluster.getVol(volName1)
+		if err == nil {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		require.ErrorIs(t, err, proto.ErrVolNotExists)
+
+		_, err = server.cluster.getVol(volName2)
+		if err == nil {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		require.ErrorIs(t, err, proto.ErrVolNotExists)
+
+		_, err = server.cluster.getVol(volName3)
+		if err == nil {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		require.ErrorIs(t, err, proto.ErrVolNotExists)
+		return
+	}
+
+	t.Errorf("Delete cold vols timeout")
 }
 
 func checkCreateVolParam(key string, req map[string]interface{}, wrong, correct interface{}, t *testing.T) {

--- a/metanode/metanode.go
+++ b/metanode/metanode.go
@@ -159,7 +159,6 @@ func doStart(s common.Server, cfg *config.Config) (err error) {
 
 	go m.startUpdateNodeInfo()
 
-	exporter.Init(cfg.GetString("role"), cfg)
 	m.startStat()
 
 	// check local partition compare with master ,if lack,then not start

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -500,7 +500,6 @@ type metaPartition struct {
 	vol                     *Vol
 	manager                 *metadataManager
 	isLoadingMetaPartition  bool
-	summaryLock             sync.Mutex
 	ebsClient               *blobstore.BlobStoreClient
 	volType                 int
 	isFollowerRead          bool
@@ -512,7 +511,6 @@ type metaPartition struct {
 	uniqChecker             *uniqChecker
 	verSeq                  uint64
 	multiVersionList        *proto.VolVersionInfoList
-	versionLock             sync.Mutex
 	verUpdateChan           chan []byte
 	enableAuditLog          bool
 	recycleInodeDelFileFlag atomicutil.Flag

--- a/metanode/partition.go
+++ b/metanode/partition.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cubefs/cubefs/raftstore"
 	"github.com/cubefs/cubefs/sdk/data/blobstore"
 	"github.com/cubefs/cubefs/util"
+	"github.com/cubefs/cubefs/util/atomicutil"
 	"github.com/cubefs/cubefs/util/errors"
 	"github.com/cubefs/cubefs/util/log"
 	"github.com/cubefs/cubefs/util/timeutil"
@@ -479,39 +480,42 @@ type OpQuota interface {
 //	| New | → Restore → | Ready |
 //	+-----+             +-------+
 type metaPartition struct {
-	config                 *MetaPartitionConfig
-	size                   uint64                // For partition all file size
-	applyID                uint64                // Inode/Dentry max applyID, this index will be update after restoring from the dumped data.
-	storedApplyId          uint64                // update after store snapshot to disk
-	dentryTree             *BTree                // btree for dentries
-	inodeTree              *BTree                // btree for inodes
-	extendTree             *BTree                // btree for inode extend (XAttr) management
-	multipartTree          *BTree                // collection for multipart management
-	txProcessor            *TransactionProcessor // transction processor
-	raftPartition          raftstore.Partition
-	stopC                  chan bool
-	storeChan              chan *storeMsg
-	state                  uint32
-	delInodeFp             *os.File
-	freeList               *freeList // free inode list
-	extDelCh               chan []proto.ExtentKey
-	extReset               chan struct{}
-	vol                    *Vol
-	manager                *metadataManager
-	isLoadingMetaPartition bool
-	ebsClient              *blobstore.BlobStoreClient
-	volType                int
-	isFollowerRead         bool
-	uidManager             *UidManager
-	xattrLock              sync.Mutex
-	fileRange              []int64
-	mqMgr                  *MetaQuotaManager
-	nonIdempotent          sync.Mutex
-	uniqChecker            *uniqChecker
-	verSeq                 uint64
-	multiVersionList       *proto.VolVersionInfoList
-	verUpdateChan          chan []byte
-	enableAuditLog         bool
+	config                  *MetaPartitionConfig
+	size                    uint64                // For partition all file size
+	applyID                 uint64                // Inode/Dentry max applyID, this index will be update after restoring from the dumped data.
+	storedApplyId           uint64                // update after store snapshot to disk
+	dentryTree              *BTree                // btree for dentries
+	inodeTree               *BTree                // btree for inodes
+	extendTree              *BTree                // btree for inode extend (XAttr) management
+	multipartTree           *BTree                // collection for multipart management
+	txProcessor             *TransactionProcessor // transction processor
+	raftPartition           raftstore.Partition
+	stopC                   chan bool
+	storeChan               chan *storeMsg
+	state                   uint32
+	delInodeFp              *os.File
+	freeList                *freeList // free inode list
+	extDelCh                chan []proto.ExtentKey
+	extReset                chan struct{}
+	vol                     *Vol
+	manager                 *metadataManager
+	isLoadingMetaPartition  bool
+	summaryLock             sync.Mutex
+	ebsClient               *blobstore.BlobStoreClient
+	volType                 int
+	isFollowerRead          bool
+	uidManager              *UidManager
+	xattrLock               sync.Mutex
+	fileRange               []int64
+	mqMgr                   *MetaQuotaManager
+	nonIdempotent           sync.Mutex
+	uniqChecker             *uniqChecker
+	verSeq                  uint64
+	multiVersionList        *proto.VolVersionInfoList
+	versionLock             sync.Mutex
+	verUpdateChan           chan []byte
+	enableAuditLog          bool
+	recycleInodeDelFileFlag atomicutil.Flag
 }
 
 func (mp *metaPartition) IsForbidden() bool {

--- a/metanode/partition_delete_extents.go
+++ b/metanode/partition_delete_extents.go
@@ -40,8 +40,7 @@ const (
 
 var extentsFileHeader = []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08}
 
-// / start metapartition delete extents work
-// /
+// start metapartition delete extents work
 func (mp *metaPartition) startToDeleteExtents() {
 	fileList := synclist.New()
 	go mp.appendDelExtentsToFile(fileList)

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -652,7 +652,12 @@ func (mp *metaPartition) recycleInodeDelFile() {
 			return
 		}
 		diskSpaceLeft = int64(stat.Bavail * uint64(stat.Bsize))
-		if diskSpaceLeft >= 50*util.GB && len(inodeDelFiles) < 5 {
+		// NOTE: 5% of disk space
+		spaceWaterMark := int64(stat.Blocks*uint64(stat.Bsize)) / 20
+		if spaceWaterMark > 50*util.GB {
+			spaceWaterMark = 50 * util.GB
+		}
+		if diskSpaceLeft >= spaceWaterMark && len(inodeDelFiles) < 5 {
 			log.LogDebugf("[recycleInodeDelFile] mp(%v) not need to recycle, return", mp.config.PartitionId)
 			return
 		}

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -657,8 +657,8 @@ func (mp *metaPartition) recycleInodeDelFile() {
 			return
 		}
 		// NOTE: delete a file and pop an item
-		oldestFile := inodeDelFiles[0]
-		inodeDelFiles = inodeDelFiles[1:]
+		oldestFile := inodeDelFiles[len(inodeDelFiles)-1]
+		inodeDelFiles = inodeDelFiles[:len(inodeDelFiles)-1]
 		err = os.Remove(oldestFile)
 		if err != nil {
 			log.LogErrorf("[recycleInodeDelFile] mp(%v) failed to remove file(%v)", mp.config.PartitionId, oldestFile)

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -657,8 +657,8 @@ func (mp *metaPartition) recycleInodeDelFile() {
 			return
 		}
 		// NOTE: delete a file and pop an item
-		oldestFile := inodeDelFiles[len(inodeDelFiles)-1]
-		inodeDelFiles = inodeDelFiles[:len(inodeDelFiles)-1]
+		oldestFile := inodeDelFiles[0]
+		inodeDelFiles = inodeDelFiles[1:]
 		err = os.Remove(oldestFile)
 		if err != nil {
 			log.LogErrorf("[recycleInodeDelFile] mp(%v) failed to remove file(%v)", mp.config.PartitionId, oldestFile)

--- a/metanode/partition_free_list.go
+++ b/metanode/partition_free_list.go
@@ -59,6 +59,7 @@ func (mp *metaPartition) startFreeList() (err error) {
 
 	go mp.updateVolWorker()
 	go mp.deleteWorker()
+	go mp.startRecycleInodeDelFile()
 	mp.startToDeleteExtents()
 	return
 }
@@ -624,7 +625,24 @@ func (mp *metaPartition) deleteObjExtents(oeks []proto.ObjExtentKey) (err error)
 	return err
 }
 
+func (mp *metaPartition) startRecycleInodeDelFile() {
+	timer := time.NewTicker(time.Minute)
+	defer timer.Stop()
+	for {
+		select {
+		case <-mp.stopC:
+			return
+		case <-timer.C:
+			mp.recycleInodeDelFile()
+		}
+	}
+}
+
 func (mp *metaPartition) recycleInodeDelFile() {
+	if !mp.recycleInodeDelFileFlag.TestAndSet() {
+		return
+	}
+	defer mp.recycleInodeDelFileFlag.Release()
 	// NOTE: get all files
 	dentries, err := os.ReadDir(mp.config.RootDir)
 	if err != nil {

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -485,8 +485,8 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 		return
 	}
 
-	log.LogDebugf("action[fsmAppendExtentsWithCheck] mp[%v] ver [%v] ino[%v] isSplit %v ek [%v] hist len %v discardExtentKey %v",
-		mp.config.PartitionId, mp.verSeq, fsmIno.Inode, isSplit, eks[0], fsmIno.getLayerLen(), discardExtentKey)
+	log.LogDebugf("action[fsmAppendExtentsWithCheck] mp[%v] ver [%v] ino[%v] isSplit %v ek [%v] hist len %v discardExtentKey %v, gen %d",
+		mp.config.PartitionId, mp.verSeq, fsmIno.Inode, isSplit, eks[0], fsmIno.getLayerLen(), discardExtentKey, fsmIno.Generation)
 
 	appendExtParam := &AppendExtParam{
 		mpId:             mp.config.PartitionId,
@@ -532,8 +532,8 @@ func (mp *metaPartition) fsmAppendExtentsWithCheck(ino *Inode, isSplit bool) (st
 	}
 
 	mp.updateUsedInfo(int64(fsmIno.Size)-oldSize, 0, fsmIno.Inode)
-	log.LogInfof("fsmAppendExtentWithCheck mp[%v] inode[%v] ek(%v) deleteExtents(%v) discardExtents(%v) status(%v)",
-		mp.config.PartitionId, fsmIno.Inode, eks[0], delExtents, discardExtentKey, status)
+	log.LogInfof("fsmAppendExtentWithCheck mp[%v] inode[%v] ek(%v) deleteExtents(%v) discardExtents(%v) status(%v), gen %d",
+		mp.config.PartitionId, fsmIno.Inode, eks[0], delExtents, discardExtentKey, status, fsmIno.Generation)
 
 	return
 }

--- a/objectnode/server.go
+++ b/objectnode/server.go
@@ -422,7 +422,6 @@ func handleStart(s common.Server, cfg *config.Config) (err error) {
 		return
 	}
 
-	exporter.Init(cfg.GetString("role"), cfg)
 	exporter.RegistConsul(ci.Cluster, cfg.GetString("role"), cfg)
 
 	log.LogInfo("object subsystem start success")

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1300,3 +1300,8 @@ type BackupDataPartitionInfo struct {
 	Disk        string
 	PartitionID uint64
 }
+
+type RecoverBackupDataReplicaRequest struct {
+	PartitionId uint64
+	Disk        string
+}

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -1136,11 +1136,12 @@ type SimpleVolView struct {
 	TrashInterval    int64
 
 	// multi version snapshot
-	LatestVer         uint64
-	Forbidden         bool
-	DisableAuditLog   bool
-	DeleteExecTime    time.Time
-	DpRepairBlockSize uint64
+	LatestVer              uint64
+	Forbidden              bool
+	DisableAuditLog        bool
+	DeleteExecTime         time.Time
+	DpRepairBlockSize      uint64
+	EnableAutoDpMetaRepair bool
 }
 
 type NodeSetInfo struct {

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -553,7 +553,6 @@ type DeleteDataPartitionRequest struct {
 	PartitionSize     int
 	Force             bool
 	DecommissionType  uint32
-	IsSpecialReplica  bool
 }
 
 // DeleteDataPartitionResponse defines the response to the request of deleting a data partition.

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -550,6 +550,9 @@ type DeleteDataPartitionRequest struct {
 	DataPartitionType string
 	PartitionId       uint64
 	PartitionSize     int
+	Force             bool
+	DecommissionType  uint32
+	IsSpecialReplica  bool
 }
 
 // DeleteDataPartitionResponse defines the response to the request of deleting a data partition.
@@ -759,24 +762,25 @@ type DiskStat struct {
 
 // DataNodeHeartbeatResponse defines the response to the data node heartbeat.
 type DataNodeHeartbeatResponse struct {
-	Total               uint64
-	Used                uint64
-	Available           uint64
-	TotalPartitionSize  uint64 // volCnt * volsize
-	RemainingCapacity   uint64 // remaining capacity to create partition
-	CreatedPartitionCnt uint32
-	MaxCapacity         uint64 // maximum capacity to create partition
-	StartTime           int64
-	ZoneName            string
-	PartitionReports    []*DataPartitionReport
-	Status              uint8
-	Result              string
-	AllDisks            []string
-	BadDisks            []string           // Keep this old field for compatibility
-	BadDiskStats        []BadDiskStat      // key: disk path
-	DiskStats           []DiskStat         // key: disk path
-	CpuUtil             float64            `json:"cpuUtil"`
-	IoUtils             map[string]float64 `json:"ioUtil"`
+	Total                uint64
+	Used                 uint64
+	Available            uint64
+	TotalPartitionSize   uint64 // volCnt * volsize
+	RemainingCapacity    uint64 // remaining capacity to create partition
+	CreatedPartitionCnt  uint32
+	MaxCapacity          uint64 // maximum capacity to create partition
+	StartTime            int64
+	ZoneName             string
+	PartitionReports     []*DataPartitionReport
+	Status               uint8
+	Result               string
+	AllDisks             []string
+	BadDisks             []string           // Keep this old field for compatibility
+	BadDiskStats         []BadDiskStat      // key: disk path
+	DiskStats            []DiskStat         // key: disk path
+	CpuUtil              float64            `json:"cpuUtil"`
+	IoUtils              map[string]float64 `json:"ioUtil"`
+	BackupDataPartitions []BackupDataPartitionInfo
 }
 
 // MetaPartitionReport defines the meta partition report.
@@ -1280,3 +1284,18 @@ const (
 const (
 	LFClient = 1 // low frequency client
 )
+
+const (
+	InitialDecommission uint32 = iota
+	ManualDecommission         // used for queryAllDecommissionDisk
+	AutoDecommission
+	AllDecommission
+	AutoAddReplica
+	ManualAddReplica
+)
+
+type BackupDataPartitionInfo struct {
+	Addr        string
+	Disk        string
+	PartitionID uint64
+}

--- a/proto/admin_proto.go
+++ b/proto/admin_proto.go
@@ -47,6 +47,7 @@ const (
 	AdminQueryDataPartitionDecommissionStatus = "/dataPartition/queryDecommissionStatus"
 	AdminCheckReplicaMeta                     = "/dataPartition/checkReplicaMeta"
 	AdminRecoverReplicaMeta                   = "/dataPartition/recoverReplicaMeta"
+	AdminRecoverDiskErrorReplica              = "/dataPartition/recoverDiskErrorReplica"
 	AdminDeleteDataReplica                    = "/dataReplica/delete"
 	AdminAddDataReplica                       = "/dataReplica/add"
 	AdminDeleteVol                            = "/vol/delete"

--- a/proto/model.go
+++ b/proto/model.go
@@ -132,6 +132,7 @@ type ClusterView struct {
 	EnableAutoDecommission   bool
 	DecommissionDiskLimit    uint32
 	DpRepairTimeout          time.Duration
+	DpTimeout                time.Duration
 	DataNodeStatInfo         *NodeStatInfo
 	MetaNodeStatInfo         *NodeStatInfo
 	VolStatInfo              []*VolStatInfo

--- a/proto/model.go
+++ b/proto/model.go
@@ -214,21 +214,25 @@ type ZoneNodesStat struct {
 }
 
 type NodeSetStat struct {
-	ID          uint64
-	Capacity    int
-	Zone        string
-	MetaNodeNum int
-	DataNodeNum int
+	ID                  uint64
+	Capacity            int
+	Zone                string
+	CanAllocMetaNodeCnt int
+	CanAllocDataNodeCnt int
+	MetaNodeNum         int
+	DataNodeNum         int
 }
 
 type NodeSetStatInfo struct {
-	ID               uint64
-	Capacity         int
-	Zone             string
-	MetaNodes        []*NodeStatView
-	DataNodes        []*NodeStatView
-	DataNodeSelector string
-	MetaNodeSelector string
+	ID                  uint64
+	Capacity            int
+	Zone                string
+	CanAllocMetaNodeCnt int
+	CanAllocDataNodeCnt int
+	MetaNodes           []*NodeStatView
+	DataNodes           []*NodeStatView
+	DataNodeSelector    string
+	MetaNodeSelector    string
 }
 
 type NodeStatView struct {

--- a/proto/model.go
+++ b/proto/model.go
@@ -76,6 +76,7 @@ type DataNodeInfo struct {
 	CpuUtil                   float64            `json:"cpuUtil"`
 	IoUtils                   map[string]float64 `json:"ioUtil"`
 	DecommissionedDisk        []string
+	BackupDataPartitions      []uint64
 }
 
 // MetaPartition defines the structure of a meta partition

--- a/proto/model.go
+++ b/proto/model.go
@@ -130,6 +130,7 @@ type ClusterView struct {
 	MarkDiskBrokenThreshold  float64
 	EnableAutoDecommission   bool
 	DecommissionDiskLimit    uint32
+	DpRepairTimeout          time.Duration
 	DataNodeStatInfo         *NodeStatInfo
 	MetaNodeStatInfo         *NodeStatInfo
 	VolStatInfo              []*VolStatInfo

--- a/proto/model.go
+++ b/proto/model.go
@@ -128,6 +128,7 @@ type ClusterView struct {
 	MaxMetaPartitionID       uint64
 	VolDeletionDelayTimeHour int64
 	MarkDiskBrokenThreshold  float64
+	DisableAutoDpMetaRepair  bool
 	EnableAutoDecommission   bool
 	DecommissionDiskLimit    uint32
 	DpRepairTimeout          time.Duration

--- a/proto/model.go
+++ b/proto/model.go
@@ -128,7 +128,7 @@ type ClusterView struct {
 	MaxMetaPartitionID       uint64
 	VolDeletionDelayTimeHour int64
 	MarkDiskBrokenThreshold  float64
-	DisableAutoDpMetaRepair  bool
+	EnableAutoDpMetaRepair   bool
 	EnableAutoDecommission   bool
 	DecommissionDiskLimit    uint32
 	DpRepairTimeout          time.Duration

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -150,6 +150,7 @@ const (
 	OpQos                           uint8 = 0x6A
 	OpStopDataPartitionRepair       uint8 = 0x6B
 	OpRecoverDataReplicaMeta        uint8 = 0x6C
+	OpRecoverBackupDataReplica      uint8 = 0x6D
 
 	// Operations: MultipartInfo
 	OpCreateMultipart  uint8 = 0x70

--- a/proto/packet.go
+++ b/proto/packet.go
@@ -257,8 +257,9 @@ const (
 	OpReadRepairExtentAgain uint8 = 0xEF
 
 	// io speed limit
-	OpLimitedIoErr uint8 = 0xB1
-	OpStoreClosed  uint8 = 0xB2
+	OpLimitedIoErr       uint8 = 0xB1
+	OpStoreClosed        uint8 = 0xB2
+	OpReachMaxExtentsErr uint8 = 0xB3
 )
 
 const (
@@ -710,6 +711,10 @@ func (p *Packet) GetResultMsg() (m string) {
 		m = "OpForbidErr"
 	case OpLimitedIoErr:
 		m = "OpLimitedIoErr"
+	case OpStoreClosed:
+		return "OpStoreClosed"
+	case OpReachMaxExtentsErr:
+		return "OpReachMaxExtentsErr"
 	default:
 		return fmt.Sprintf("Unknown ResultCode(%v)", p.ResultCode)
 	}

--- a/proto/version.go
+++ b/proto/version.go
@@ -24,3 +24,31 @@ func DumpVersion(role string) string {
 		CommitID,
 		runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildTime)
 }
+
+type VersionInfo struct {
+	Role    string
+	Version string
+	Branch  string
+	Commit  string
+	Build   string
+}
+
+func (v VersionInfo) ToMap() map[string]string {
+	return map[string]string{
+		"role":    v.Role,
+		"version": v.Version,
+		"branch":  v.Branch,
+		"commit":  v.Commit,
+		"build":   v.Build,
+	}
+}
+
+func GetVersion(role string) VersionInfo {
+	return VersionInfo{
+		Role:    role,
+		Version: Version,
+		Branch:  BranchName,
+		Commit:  CommitID,
+		Build:   fmt.Sprintf("%s %s %s %s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildTime),
+	}
+}

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -130,6 +130,8 @@ func (p *FollowerPacket) identificationErrorResultCode(errLog string, errMsg str
 		p.ResultCode = proto.OpTryOtherAddr
 	} else if strings.Contains(errMsg, storage.ErrStoreAlreadyClosed.Error()) {
 		p.ResultCode = proto.OpStoreClosed
+	} else if strings.Contains(errMsg, storage.ReachMaxExtentsCountError.Error()) {
+		p.ResultCode = proto.OpReachMaxExtentsErr
 	} else if strings.Contains(errLog, ActionReceiveFromFollower) || strings.Contains(errLog, ActionSendToFollowers) ||
 		strings.Contains(errLog, ConnIsNullErr) {
 		p.ResultCode = proto.OpIntraGroupNetErr
@@ -456,6 +458,8 @@ func (p *Packet) identificationErrorResultCode(errLog string, errMsg string) {
 		p.ResultCode = proto.OpReadRepairExtentAgain
 	} else if strings.Contains(errMsg, storage.ErrStoreAlreadyClosed.Error()) {
 		p.ResultCode = proto.OpStoreClosed
+	} else if strings.Contains(errMsg, storage.ReachMaxExtentsCountError.Error()) {
+		p.ResultCode = proto.OpReachMaxExtentsErr
 	} else {
 		log.LogErrorf("action[identificationErrorResultCode] error %v, errmsg %v", errLog, errMsg)
 		p.ResultCode = proto.OpIntraGroupNetErr

--- a/repl/packet.go
+++ b/repl/packet.go
@@ -494,7 +494,8 @@ func (p *Packet) IsMasterCommand() bool {
 		proto.OpDecommissionDataPartition,
 		proto.OpAddDataPartitionRaftMember,
 		proto.OpRemoveDataPartitionRaftMember,
-		proto.OpDataPartitionTryToLeader:
+		proto.OpDataPartitionTryToLeader,
+		proto.OpRecoverBackupDataReplica:
 		return true
 	default:
 		return false

--- a/sdk/data/blobstore/reader.go
+++ b/sdk/data/blobstore/reader.go
@@ -31,7 +31,21 @@ import (
 	"github.com/cubefs/cubefs/util/exporter"
 	"github.com/cubefs/cubefs/util/log"
 	"github.com/cubefs/cubefs/util/stat"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+var readerMetric = prometheus.NewSummaryVec(
+	prometheus.SummaryOpts{
+		Namespace:  "cubefs",
+		Subsystem:  "client",
+		Name:       "reader_cost_time",
+		Help:       "time cost in cubefs sdk",
+		Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.025, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001, 0.999: 0.0001, 0.9999: 0.00001},
+	}, []string{"api"})
+
+func init() {
+	prometheus.MustRegister(readerMetric)
+}
 
 type rwSlice struct {
 	index        int
@@ -123,6 +137,11 @@ func NewReader(config ClientConfig) (reader *Reader) {
 }
 
 func (reader *Reader) Read(ctx context.Context, buf []byte, offset int, size int) (int, error) {
+	beg := time.Now()
+	defer func() {
+		readerMetric.WithLabelValues("BlobstorRead").Observe(float64(time.Since(beg).Microseconds()))
+	}()
+
 	if reader == nil {
 		return 0, fmt.Errorf("reader is not opened yet")
 	}

--- a/sdk/data/blobstore/reader.go
+++ b/sdk/data/blobstore/reader.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/cubefs/cubefs/blockcache/bcache"
 	"github.com/cubefs/cubefs/proto"

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cubefs/cubefs/sdk/meta"
 	"github.com/cubefs/cubefs/util"
 	"github.com/cubefs/cubefs/util/errors"
-	"github.com/cubefs/cubefs/util/exporter"
 	"github.com/cubefs/cubefs/util/log"
 	"github.com/cubefs/cubefs/util/stat"
 	"github.com/prometheus/client_golang/prometheus"
@@ -543,7 +542,6 @@ func (client *ExtentClient) Write(inode uint64, offset int, data []byte, flags i
 	write, err = s.IssueWriteRequest(offset, data, flags, checkFunc)
 	if err != nil {
 		log.LogError(errors.Stack(err))
-		exporter.Warning(err.Error())
 	}
 	return
 }

--- a/sdk/data/stream/extent_client.go
+++ b/sdk/data/stream/extent_client.go
@@ -33,9 +33,30 @@ import (
 	"github.com/cubefs/cubefs/util/exporter"
 	"github.com/cubefs/cubefs/util/log"
 	"github.com/cubefs/cubefs/util/stat"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"golang.org/x/time/rate"
 )
+
+var (
+	clientMetric = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  "cubefs",
+			Subsystem:  "client",
+			Name:       "client_cost_time",
+			Help:       "time cost in cubefs sdk",
+			Objectives: map[float64]float64{0.5: 0.05, 0.75: 0.025, 0.9: 0.01, 0.95: 0.005, 0.99: 0.001, 0.999: 0.0001, 0.9999: 0.00001},
+		}, []string{"api"})
+	readReqCountMetric = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "read_req_cnt",
+		})
+)
+
+func init() {
+	prometheus.MustRegister(clientMetric)
+	prometheus.MustRegister(readReqCountMetric)
+}
 
 type (
 	SplitExtentKeyFunc  func(parentInode, inode uint64, key proto.ExtentKey) error
@@ -569,6 +590,12 @@ func (client *ExtentClient) Flush(inode uint64) error {
 func (client *ExtentClient) Read(inode uint64, data []byte, offset int, size int) (read int, err error) {
 	// log.LogErrorf("======> ExtentClient Read Enter, inode(%v), len(data)=(%v), offset(%v), size(%v).", inode, len(data), offset, size)
 	// t1 := time.Now()
+	beg := time.Now()
+	defer func() {
+		clientMetric.WithLabelValues("Read").Observe(float64(time.Since(beg).Microseconds()))
+	}()
+
+	readReqCountMetric.Inc()
 	if size == 0 {
 		return
 	}
@@ -580,16 +607,23 @@ func (client *ExtentClient) Read(inode uint64, data []byte, offset int, size int
 	}
 
 	s.once.Do(func() {
+		beg = time.Now()
 		s.GetExtents()
+		clientMetric.WithLabelValues("Read_GetExtents").Observe(float64(time.Since(beg).Microseconds()))
 	})
 
+	beg = time.Now()
 	err = s.IssueFlushRequest()
 	if err != nil {
 		return
 	}
+	clientMetric.WithLabelValues("Read_Flush").Observe(float64(time.Since(beg).Microseconds()))
 
+	beg = time.Now()
 	read, err = s.read(data, offset, size)
+	clientMetric.WithLabelValues("Read_read").Observe(float64(time.Since(beg).Microseconds()))
 	// log.LogErrorf("======> ExtentClient Read Exit, inode(%v), time[%v us].", inode, time.Since(t1).Microseconds())
+	readReqCountMetric.Dec()
 	return
 }
 

--- a/sdk/data/stream/stream_reader.go
+++ b/sdk/data/stream/stream_reader.go
@@ -230,7 +230,9 @@ func (s *Streamer) read(data []byte, offset int, size int) (total int, err error
 				}
 			}
 
+			beg := time.Now()
 			readBytes, err = reader.Read(req)
+			clientMetric.WithLabelValues("Streamer_read_Read").Observe(float64(time.Since(beg).Microseconds()))
 			log.LogDebugf("TRACE Stream read: ino(%v) req(%v) readBytes(%v) err(%v)", s.inode, req, readBytes, err)
 
 			total += readBytes

--- a/sdk/data/wrapper/default_random_selector.go
+++ b/sdk/data/wrapper/default_random_selector.go
@@ -44,6 +44,7 @@ type DefaultRandomSelector struct {
 	sync.RWMutex
 	localLeaderPartitions []*DataPartition
 	partitions            []*DataPartition
+	removeDpMutex         sync.Mutex
 }
 
 func (s *DefaultRandomSelector) Name() string {
@@ -87,6 +88,9 @@ func (s *DefaultRandomSelector) Select(exclude map[string]struct{}) (dp *DataPar
 }
 
 func (s *DefaultRandomSelector) RemoveDP(partitionID uint64) {
+	s.removeDpMutex.Lock()
+	defer s.removeDpMutex.Unlock()
+
 	s.RLock()
 	rwPartitionGroups := s.partitions
 	localLeaderPartitions := s.localLeaderPartitions

--- a/sdk/data/wrapper/default_random_selector.go
+++ b/sdk/data/wrapper/default_random_selector.go
@@ -140,8 +140,6 @@ func (s *DefaultRandomSelector) RemoveDP(partitionID uint64) {
 	s.localLeaderPartitions = newLocalLeaderPartitions
 	s.Unlock()
 	log.LogDebugf("RemoveDP: finish, partitionID[%v], len(s.localLeaderPartitions)=%v\n", partitionID, len(s.localLeaderPartitions))
-
-	return
 }
 
 func (s *DefaultRandomSelector) Count() int {

--- a/sdk/data/wrapper/default_random_selector.go
+++ b/sdk/data/wrapper/default_random_selector.go
@@ -70,11 +70,13 @@ func (s *DefaultRandomSelector) Refresh(partitions []*DataPartition) (err error)
 func (s *DefaultRandomSelector) Select(exclude map[string]struct{}) (dp *DataPartition, err error) {
 	dp = s.getLocalLeaderDataPartition(exclude)
 	if dp != nil {
+		log.LogDebugf("Select: select dp[%v] address[%p] from LocalLeaderDataPartition", dp, dp)
 		return dp, nil
 	}
 
 	s.RLock()
 	partitions := s.partitions
+	log.LogDebugf("Select: len(s.partitions)=%v\n", len(s.partitions))
 	s.RUnlock()
 
 	dp = s.getRandomDataPartition(partitions, exclude)
@@ -94,17 +96,21 @@ func (s *DefaultRandomSelector) RemoveDP(partitionID uint64) {
 	s.RLock()
 	rwPartitionGroups := s.partitions
 	localLeaderPartitions := s.localLeaderPartitions
+	log.LogDebugf("RemoveDP: partitionID[%v], len(s.partitions)=%v len(s.localLeaderPartitions)=%v\n", partitionID, len(s.partitions), len(s.localLeaderPartitions))
 	s.RUnlock()
 
 	var i int
 	for i = 0; i < len(rwPartitionGroups); i++ {
 		if rwPartitionGroups[i].PartitionID == partitionID {
+			log.LogDebugf("RemoveDP: found partitionID[%v] in rwPartitionGroups. dp[%v] address[%p]\n", partitionID, rwPartitionGroups[i], rwPartitionGroups[i])
 			break
 		}
 	}
 	if i >= len(rwPartitionGroups) {
+		log.LogDebugf("RemoveDP: not found partitionID[%v] in rwPartitionGroups", partitionID)
 		return
 	}
+
 	newRwPartition := make([]*DataPartition, 0)
 	newRwPartition = append(newRwPartition, rwPartitionGroups[:i]...)
 	newRwPartition = append(newRwPartition, rwPartitionGroups[i+1:]...)
@@ -112,15 +118,18 @@ func (s *DefaultRandomSelector) RemoveDP(partitionID uint64) {
 	defer func() {
 		s.Lock()
 		s.partitions = newRwPartition
+		log.LogDebugf("RemoveDP: finish, partitionID[%v], len(s.partitions)=%v\n", partitionID, len(s.partitions))
 		s.Unlock()
 	}()
 
 	for i = 0; i < len(localLeaderPartitions); i++ {
 		if localLeaderPartitions[i].PartitionID == partitionID {
+			log.LogDebugf("RemoveDP: found partitionID[%v] in localLeaderPartitions. dp[%v] address[%p]\n", partitionID, localLeaderPartitions[i], localLeaderPartitions[i])
 			break
 		}
 	}
 	if i >= len(localLeaderPartitions) {
+		log.LogDebugf("RemoveDP: not found partitionID[%v] in localLeaderPartitions", partitionID)
 		return
 	}
 	newLocalLeaderPartitions := make([]*DataPartition, 0)
@@ -130,6 +139,9 @@ func (s *DefaultRandomSelector) RemoveDP(partitionID uint64) {
 	s.Lock()
 	s.localLeaderPartitions = newLocalLeaderPartitions
 	s.Unlock()
+	log.LogDebugf("RemoveDP: finish, partitionID[%v], len(s.localLeaderPartitions)=%v\n", partitionID, len(s.localLeaderPartitions))
+
+	return
 }
 
 func (s *DefaultRandomSelector) Count() int {
@@ -141,6 +153,7 @@ func (s *DefaultRandomSelector) Count() int {
 func (s *DefaultRandomSelector) getLocalLeaderDataPartition(exclude map[string]struct{}) *DataPartition {
 	s.RLock()
 	localLeaderPartitions := s.localLeaderPartitions
+	log.LogDebugf("getLocalLeaderDataPartition: len(s.localLeaderPartitions)=%v\n", len(s.localLeaderPartitions))
 	s.RUnlock()
 	return s.getRandomDataPartition(localLeaderPartitions, exclude)
 }

--- a/sdk/data/wrapper/k_faster_random_selector.go
+++ b/sdk/data/wrapper/k_faster_random_selector.go
@@ -55,6 +55,7 @@ type KFasterRandomSelector struct {
 	kValueHundred int
 	kValue        int
 	partitions    []*DataPartition
+	removeDpMutex sync.Mutex
 }
 
 func (s *KFasterRandomSelector) Name() string {
@@ -124,6 +125,9 @@ func (s *KFasterRandomSelector) Select(exclude map[string]struct{}) (dp *DataPar
 }
 
 func (s *KFasterRandomSelector) RemoveDP(partitionID uint64) {
+	s.removeDpMutex.Lock()
+	defer s.removeDpMutex.Unlock()
+
 	s.RLock()
 	partitions := s.partitions
 	s.RUnlock()

--- a/sdk/data/wrapper/wrapper.go
+++ b/sdk/data/wrapper/wrapper.go
@@ -384,8 +384,8 @@ func (w *Wrapper) updateDataPartitionByRsp(forceUpdate bool, refreshPolicy Refre
 
 	// if not forceUpdate, at least keep 1 rw dp in the selector to avoid can't do write
 	if forceUpdate || len(rwPartitionGroups) >= 1 {
-		log.LogInfof("updateDataPartition: refresh dpSelector of volume(%v) with %v rw partitions(%v all), forceUpdate(%v)",
-			w.volName, len(rwPartitionGroups), len(DataPartitions), forceUpdate)
+		log.LogInfof("updateDataPartition: refresh dpSelector of volume(%v) with %v rw partitions(%v all), forceUpdate(%v) policy(%v)",
+			w.volName, len(rwPartitionGroups), len(DataPartitions), forceUpdate, refreshPolicy)
 		w.refreshDpSelector(refreshPolicy, rwPartitionGroups)
 	} else {
 		err = errors.New("updateDataPartition: no writable data partition")

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -290,6 +290,7 @@ func (api *AdminAPI) UpdateVolume(
 	request.addParam("replicaNum", strconv.FormatUint(uint64(vv.DpReplicaNum), 10))
 	request.addParam("enableQuota", strconv.FormatBool(vv.EnableQuota))
 	request.addParam("deleteLockTime", strconv.FormatInt(vv.DeleteLockTime, 10))
+	request.addParam("autoDpMetaRepair", strconv.FormatBool(vv.EnableAutoDpMetaRepair))
 	request.addParam("clientIDKey", clientIDKey)
 	if txMask != "" {
 		request.addParam("enableTxMask", txMask)

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -515,7 +515,7 @@ func (api *AdminAPI) SetMasterVolDeletionDelayTime(volDeletionDelayTimeHour int)
 
 func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate, loadFactor, maxDpCntLimit, maxMpCntLimit, clientIDKey string,
 	dataNodesetSelector, metaNodesetSelector, dataNodeSelector, metaNodeSelector string, markDiskBrokenThreshold string,
-	dpRepairTimeout string,
+	enableAutoDpMetaRepair string, dpRepairTimeout string,
 ) (err error) {
 	request := newRequest(get, proto.AdminSetNodeInfo).Header(api.h)
 	request.addParam("batchCount", batchCount)
@@ -533,6 +533,9 @@ func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSle
 	request.addParam("metaNodeSelector", metaNodeSelector)
 	if markDiskBrokenThreshold != "" {
 		request.addParam("markDiskBrokenThreshold", markDiskBrokenThreshold)
+	}
+	if enableAutoDpMetaRepair != "" {
+		request.addParam("autoDpMetaRepair", enableAutoDpMetaRepair)
 	}
 	if dpRepairTimeout != "" {
 		request.addParam("dpRepairTimeOut", dpRepairTimeout)

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -516,7 +516,7 @@ func (api *AdminAPI) SetMasterVolDeletionDelayTime(volDeletionDelayTimeHour int)
 
 func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate, loadFactor, maxDpCntLimit, maxMpCntLimit, clientIDKey string,
 	dataNodesetSelector, metaNodesetSelector, dataNodeSelector, metaNodeSelector string, markDiskBrokenThreshold string,
-	enableAutoDpMetaRepair string, dpRepairTimeout string,
+	enableAutoDpMetaRepair string, dpRepairTimeout string, dpTimeout string,
 ) (err error) {
 	request := newRequest(get, proto.AdminSetNodeInfo).Header(api.h)
 	request.addParam("batchCount", batchCount)
@@ -540,6 +540,9 @@ func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSle
 	}
 	if dpRepairTimeout != "" {
 		request.addParam("dpRepairTimeOut", dpRepairTimeout)
+	}
+	if dpTimeout != "" {
+		request.addParam("dpTimeout", dpTimeout)
 	}
 	_, err = api.mc.serveRequest(request)
 	return

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -170,12 +170,13 @@ func (api *AdminAPI) CreateDataPartition(volName string, count int, clientIDKey 
 	))
 }
 
-func (api *AdminAPI) DecommissionDataPartition(dataPartitionID uint64, nodeAddr string, raftForce bool, clientIDKey string) (err error) {
+func (api *AdminAPI) DecommissionDataPartition(dataPartitionID uint64, nodeAddr string, raftForce bool, clientIDKey, decommissionType string) (err error) {
 	request := newRequest(get, proto.AdminDecommissionDataPartition).Header(api.h)
 	request.addParam("id", strconv.FormatUint(dataPartitionID, 10))
 	request.addParam("addr", nodeAddr)
 	request.addParam("raftForceDel", strconv.FormatBool(raftForce))
 	request.addParam("clientIDKey", clientIDKey)
+	request.addParam("decommissionType", decommissionType)
 	_, err = api.mc.serveRequest(request)
 	return
 }

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -515,6 +515,7 @@ func (api *AdminAPI) SetMasterVolDeletionDelayTime(volDeletionDelayTimeHour int)
 
 func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSleepMs, autoRepairRate, loadFactor, maxDpCntLimit, maxMpCntLimit, clientIDKey string,
 	dataNodesetSelector, metaNodesetSelector, dataNodeSelector, metaNodeSelector string, markDiskBrokenThreshold string,
+	dpRepairTimeout string,
 ) (err error) {
 	request := newRequest(get, proto.AdminSetNodeInfo).Header(api.h)
 	request.addParam("batchCount", batchCount)
@@ -532,6 +533,9 @@ func (api *AdminAPI) SetClusterParas(batchCount, markDeleteRate, deleteWorkerSle
 	request.addParam("metaNodeSelector", metaNodeSelector)
 	if markDiskBrokenThreshold != "" {
 		request.addParam("markDiskBrokenThreshold", markDiskBrokenThreshold)
+	}
+	if dpRepairTimeout != "" {
+		request.addParam("dpRepairTimeOut", dpRepairTimeout)
 	}
 	_, err = api.mc.serveRequest(request)
 	return

--- a/storage/error.go
+++ b/storage/error.go
@@ -40,6 +40,7 @@ var (
 	VerNotConsistentError            = errors.New("ver not consistent")
 	SnapshotNeedNewExtentError       = errors.New("snapshot need new extent error")
 	NoDiskReadRepairExtentTokenError = errors.New("no disk read repair extent token")
+	ReachMaxExtentsCountError        = errors.New("reached max extents count")
 )
 
 func newParameterError(format string, a ...interface{}) error {

--- a/storage/extent.go
+++ b/storage/extent.go
@@ -72,6 +72,7 @@ type ExtentInfo struct {
 	SnapshotDataOff     uint64 `json:"snapSize"`
 	SnapPreAllocDataOff uint64 `json:"snapPreAllocSize"`
 	ApplyID             uint64 `json:"applyID"`
+	ApplySize           int64  `json:"ApplySize"`
 }
 
 func (ei *ExtentInfo) TotalSize() uint64 {
@@ -577,12 +578,8 @@ func (e *Extent) GetCrc(blockNo int64) uint32 {
 	return binary.BigEndian.Uint32(e.header[blockNo*util.PerBlockCrcSize : (blockNo+1)*util.PerBlockCrcSize])
 }
 
-func (e *Extent) autoComputeExtentCrc(crcFunc UpdateCrcFunc) (crc uint32, err error) {
+func (e *Extent) autoComputeExtentCrc(extSize int64, crcFunc UpdateCrcFunc) (crc uint32, err error) {
 	var blockCnt int
-	extSize := e.Size()
-	if e.snapshotDataOff > util.ExtentSize {
-		extSize = int64(e.snapshotDataOff)
-	}
 	blockCnt = int(extSize / util.BlockSize)
 	if extSize%util.BlockSize != 0 {
 		blockCnt += 1

--- a/storage/extent_store.go
+++ b/storage/extent_store.go
@@ -277,10 +277,6 @@ func (ei *ExtentInfo) UpdateExtentInfo(extent *Extent, crc uint32) {
 // When the master sends the loadDataPartition request, the snapshot is used to compare the replicas.
 func (s *ExtentStore) SnapShot() (files []*proto.File, err error) {
 	var normalExtentSnapshot, tinyExtentSnapshot []*ExtentInfo
-
-	// compute crc again to guarantee crc and applyID is the newest
-	s.autoComputeExtentCrc()
-
 	if normalExtentSnapshot, _, err = s.GetAllWatermarks(NormalExtentFilter()); err != nil {
 		log.LogErrorf("SnapShot GetAllWatermarks err %v", err)
 		return

--- a/storage/extent_store_test.go
+++ b/storage/extent_store_test.go
@@ -40,13 +40,27 @@ func extentStoreNormalRwTest(t *testing.T, s *storage.ExtentStore, id uint64) {
 	data := []byte(dataStr)
 	crc := crc32.ChecksumIEEE(data)
 	// append write
-	_, err := s.Write(id, 0, int64(len(data)), data, crc, storage.AppendWriteType, true, false, false, false)
+	param := &storage.WriteParam{
+		ExtentID:      id,
+		Offset:        0,
+		Size:          int64(len(data)),
+		Data:          data,
+		Crc:           crc,
+		WriteType:     storage.AppendWriteType,
+		IsSync:        true,
+		IsHole:        false,
+		IsRepair:      false,
+		IsBackupWrite: false,
+	}
+
+	_, err := s.Write(param)
 	require.NoError(t, err)
 	actualCrc, err := s.Read(id, 0, int64(len(data)), data, false, false)
 	require.NoError(t, err)
 	require.EqualValues(t, crc, actualCrc)
 	// random write
-	_, err = s.Write(id, 0, int64(len(data)), data, crc, storage.RandomWriteType, true, false, false, false)
+	param.WriteType = storage.RandomWriteType
+	_, err = s.Write(param)
 	require.NoError(t, err)
 	actualCrc, err = s.Read(id, 0, int64(len(data)), data, false, false)
 	require.NoError(t, err)
@@ -93,7 +107,19 @@ func extentMarkDeleteTinyTest(t *testing.T, s *storage.ExtentStore, id uint64) {
 	require.NotEqualValues(t, size, 0)
 	// write second file to extent
 	crc := crc32.ChecksumIEEE(data)
-	_, err = s.Write(id, size, int64(len(data)), data, crc, storage.AppendWriteType, true, false, false, false)
+	param := &storage.WriteParam{
+		ExtentID:      id,
+		Offset:        size,
+		Size:          int64(len(data)),
+		Data:          data,
+		Crc:           crc,
+		WriteType:     storage.AppendWriteType,
+		IsSync:        true,
+		IsHole:        false,
+		IsRepair:      false,
+		IsBackupWrite: false,
+	}
+	_, err = s.Write(param)
 	require.NoError(t, err)
 	// mark delete first file
 	extentStoreMarkDeleteTiny(t, s, id, 0, size)
@@ -155,7 +181,19 @@ func reopenExtentStoreTest(t *testing.T, dpType int) {
 	data := []byte(dataStr)
 	crc := crc32.ChecksumIEEE(data)
 	// write some data
-	_, err = s.Write(id, 0, int64(len(data)), data, crc, storage.AppendWriteType, true, false, false, false)
+	param := &storage.WriteParam{
+		ExtentID:      id,
+		Offset:        0,
+		Size:          int64(len(data)),
+		Data:          data,
+		Crc:           crc,
+		WriteType:     storage.AppendWriteType,
+		IsSync:        true,
+		IsHole:        false,
+		IsRepair:      false,
+		IsBackupWrite: false,
+	}
+	_, err = s.Write(param)
 	require.NoError(t, err)
 	firstSnap, err := s.SnapShot()
 	require.NoError(t, err)

--- a/util/atomicutil/bool.go
+++ b/util/atomicutil/bool.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package atomicutil
+
+import "sync/atomic"
+
+type Bool struct {
+	val uint32
+}
+
+func (b *Bool) Load() (v bool) {
+	v = atomic.LoadUint32(&b.val) == 1
+	return
+}
+
+func (b *Bool) Store(v bool) {
+	val := uint32(0)
+	if v {
+		val = 1
+	}
+	atomic.StoreUint32(&b.val, val)
+	return
+}
+
+func (b *Bool) CompareAndSwap(old bool, newVal bool) (swaped bool) {
+	oldVal := uint32(0)
+	if old {
+		oldVal = 1
+	}
+	val := uint32(0)
+	if newVal {
+		val = 1
+	}
+	swaped = atomic.CompareAndSwapUint32(&b.val, oldVal, val)
+	return
+}

--- a/util/atomicutil/bool.go
+++ b/util/atomicutil/bool.go
@@ -31,7 +31,6 @@ func (b *Bool) Store(v bool) {
 		val = 1
 	}
 	atomic.StoreUint32(&b.val, val)
-	return
 }
 
 func (b *Bool) CompareAndSwap(old bool, newVal bool) (swaped bool) {

--- a/util/atomicutil/bool_test.go
+++ b/util/atomicutil/bool_test.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package atomicutil_test
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/util/atomicutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicBool(t *testing.T) {
+	b := atomicutil.Bool{}
+	b.Store(true)
+	require.True(t, b.Load())
+	require.True(t, b.CompareAndSwap(true, false))
+	require.False(t, b.Load())
+}

--- a/util/atomicutil/flag.go
+++ b/util/atomicutil/flag.go
@@ -1,0 +1,28 @@
+// Copyright 2024 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package atomicutil
+
+type Flag struct {
+	v Bool
+}
+
+func (f *Flag) TestAndSet() (ok bool) {
+	ok = f.v.CompareAndSwap(false, true)
+	return
+}
+
+func (f *Flag) Release() {
+	f.v.Store(false)
+}

--- a/util/atomicutil/flag_test.go
+++ b/util/atomicutil/flag_test.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package atomicutil_test
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/util/atomicutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlag(t *testing.T) {
+	f := atomicutil.Flag{}
+	require.True(t, f.TestAndSet())
+	require.False(t, f.TestAndSet())
+	f.Release()
+	require.True(t, f.TestAndSet())
+}

--- a/util/conn_pool.go
+++ b/util/conn_pool.go
@@ -19,8 +19,6 @@ import (
 	"net"
 	"sync"
 	"time"
-
-	"github.com/cubefs/cubefs/util/log"
 )
 
 type Object struct {
@@ -169,11 +167,9 @@ func (cp *ConnectPool) autoRelease() {
 			pools = append(pools, pool)
 		}
 		cp.RUnlock()
-		begin := time.Now()
 		for _, pool := range pools {
 			pool.autoRelease()
 		}
-		log.LogInfof("[autoRelease] release conn pool cnt(%v) using time(%v)", len(pools), time.Since(begin))
 		timer.Reset(time.Second)
 	}
 }

--- a/util/exporter/exporter.go
+++ b/util/exporter/exporter.go
@@ -46,12 +46,13 @@ const (
 	ChSize                  = 1024 * 10        // collect chan size
 
 	// monitor label name
-	Vol    = "vol"
-	Disk   = "disk"
-	PartId = "partid"
-	Op     = "op"
-	Type   = "type"
-	Err    = "err"
+	Vol     = "vol"
+	Disk    = "disk"
+	PartId  = "partid"
+	Op      = "op"
+	Type    = "type"
+	Err     = "err"
+	Version = "version"
 )
 
 var (

--- a/util/exporter/version.go
+++ b/util/exporter/version.go
@@ -1,0 +1,57 @@
+package exporter
+
+import (
+	"time"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/cubefs/cubefs/util/log"
+)
+
+const StatPeriod = time.Minute * time.Duration(1)
+
+type VersionMetrics struct {
+	stopC      chan struct{}
+	Metric     *Counter
+	moduleName string
+	statPeriod time.Duration
+}
+
+func NewVersionMetrics(module string) *VersionMetrics {
+	return &VersionMetrics{
+		moduleName: module,
+		Metric:     NewCounter(Version),
+		stopC:      make(chan struct{}),
+		statPeriod: StatPeriod,
+	}
+}
+
+func (m *VersionMetrics) SetStatPeriod(period time.Duration) {
+	m.statPeriod = period
+}
+
+func (m *VersionMetrics) Start() {
+	ticker := time.NewTicker(m.statPeriod)
+	for {
+		select {
+		case <-m.stopC:
+			ticker.Stop()
+			log.LogInfof("stop version metrics ticker")
+			return
+		case <-ticker.C:
+			m.doStat()
+		}
+	}
+}
+
+func (m *VersionMetrics) Stop() {
+	close(m.stopC)
+	log.LogInfof("stop version metrics")
+}
+
+func (m *VersionMetrics) doStat() {
+	m.setVersionMetrics()
+}
+
+func (m *VersionMetrics) setVersionMetrics() {
+	m.Metric.AddWithLabels(1, proto.GetVersion(m.moduleName).ToMap())
+}

--- a/util/fileutil/stat.go
+++ b/util/fileutil/stat.go
@@ -15,15 +15,32 @@
 package fileutil
 
 import (
+	"io/fs"
 	"os"
 	"syscall"
 )
+
+const StatBlockSize = 512
 
 func Stat(name string) (stat *syscall.Stat_t, err error) {
 	info, err := os.Stat(name)
 	if err != nil {
 		return
 	}
+	stat = ConvertStat(info)
+	return
+}
+
+func ConvertStat(info fs.FileInfo) (stat *syscall.Stat_t) {
 	stat = info.Sys().(*syscall.Stat_t)
+	return
+}
+
+func GetFilePhysicalSize(name string) (size int64, err error) {
+	stat, err := Stat(name)
+	if err != nil {
+		return
+	}
+	size = stat.Blocks * StatBlockSize
 	return
 }

--- a/util/fileutil/stat_test.go
+++ b/util/fileutil/stat_test.go
@@ -16,6 +16,7 @@ package fileutil_test
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/cubefs/cubefs/util/fileutil"
@@ -29,4 +30,18 @@ func TestStat(t *testing.T) {
 	ino, err := fileutil.Stat(dir)
 	require.NoError(t, err)
 	require.NotEqual(t, 0, ino)
+}
+
+const blkSize = 4096
+
+func TestGetFilePhyscialSize(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	tmpFile := path.Join(dir, "tmp")
+	err = os.WriteFile(tmpFile, []byte("Hello World"), 0o755)
+	require.NoError(t, err)
+	size, err := fileutil.GetFilePhysicalSize(tmpFile)
+	require.NoError(t, err)
+	require.EqualValues(t, blkSize, size)
 }

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -125,8 +125,10 @@ func (writer *asyncWriter) flushScheduler() {
 			if !open {
 				ticker.Stop()
 
-				// TODO Unhandled errors
-				writer.file.Close()
+				if writer.fileName != "" {
+					// TODO Unhandled errors
+					writer.file.Close()
+				}
 				return
 			}
 		}
@@ -160,7 +162,9 @@ func (writer *asyncWriter) Close() (err error) {
 func (writer *asyncWriter) Flush() {
 	writer.flushToFile()
 	// TODO Unhandled errors
-	writer.file.Sync()
+	if writer.fileName != "" {
+		writer.file.Sync()
+	}
 }
 
 func (writer *asyncWriter) flushToFile() {
@@ -175,31 +179,39 @@ func (writer *asyncWriter) flushToFile() {
 	}
 	flushLength := writer.flushTmp.Len()
 
-	if (writer.logSize+int64(flushLength)) >= writer.
-		rotateSize || isRotateDay {
-		oldFile := writer.fileName + "." + time.Now().Format(
-			FileNameDateFormat) + RotatedExtension
-		if _, err := os.Lstat(oldFile); err != nil {
-			if err := writer.rename(oldFile); err == nil {
-				if fp, err := os.OpenFile(writer.fileName, FileOpt, 0o666); err == nil {
-					writer.file.Close()
-					writer.file = fp
-					writer.logSize = 0
-					_ = os.Chmod(writer.fileName, 0o666)
+	if writer.fileName == "" {
+		if _, err := writer.flushTmp.WriteTo(os.Stdout); err != nil {
+			syslog.Printf("log write to stdout error: %v", err)
+		}
+	} else {
+		if (writer.logSize+int64(flushLength)) >= writer.
+			rotateSize || isRotateDay {
+			oldFile := writer.fileName + "." + time.Now().Format(
+				FileNameDateFormat) + RotatedExtension
+			if _, err := os.Lstat(oldFile); err != nil {
+				if err := writer.rename(oldFile); err == nil {
+					if fp, err := os.OpenFile(writer.fileName, FileOpt, 0o666); err == nil {
+						writer.file.Close()
+						writer.file = fp
+						writer.logSize = 0
+						_ = os.Chmod(writer.fileName, 0o666)
+					} else {
+						syslog.Printf("log rotate: openFile %v error: %v", writer.fileName, err)
+					}
 				} else {
-					syslog.Printf("log rotate: openFile %v error: %v", writer.fileName, err)
+					syslog.Printf("log rotate: rename %v error: %v ", oldFile, err)
 				}
 			} else {
-				syslog.Printf("log rotate: rename %v error: %v ", oldFile, err)
+				syslog.Printf("log rotate: lstat error: %v already exists", oldFile)
 			}
-		} else {
-			syslog.Printf("log rotate: lstat error: %v already exists", oldFile)
+		}
+		writer.logSize += int64(flushLength)
+		// TODO Unhandled errors
+		if _, err := writer.file.Write(writer.flushTmp.Bytes()); err != nil {
+			syslog.Printf("log write to %v error: %v", writer.fileName, err)
 		}
 	}
 
-	writer.logSize += int64(flushLength)
-	// TODO Unhandled errors
-	writer.file.Write(writer.flushTmp.Bytes())
 	writer.flushTmp.Reset()
 	writer.mu.Unlock()
 }
@@ -212,20 +224,28 @@ func (writer *asyncWriter) rename(newName string) error {
 }
 
 func newAsyncWriter(fileName string, rotateSize int64) (*asyncWriter, error) {
-	fp, err := os.OpenFile(fileName, FileOpt, 0o666)
-	if err != nil {
-		return nil, err
+	var fp *os.File
+	var fInfo os.FileInfo
+	var logSize int64
+	var err error
+	if fileName != "" {
+		fp, err = os.OpenFile(fileName, FileOpt, 0o666)
+		if err != nil {
+			return nil, err
+		}
+		fInfo, err = fp.Stat()
+		if err != nil {
+			return nil, err
+		}
+		_ = os.Chmod(fileName, 0o666)
+		logSize = fInfo.Size()
 	}
-	fInfo, err := fp.Stat()
-	if err != nil {
-		return nil, err
-	}
-	_ = os.Chmod(fileName, 0o666)
+
 	w := &asyncWriter{
 		file:       fp,
 		fileName:   fileName,
 		rotateSize: rotateSize,
-		logSize:    fInfo.Size(),
+		logSize:    logSize,
 		buffer:     bytes.NewBuffer(make([]byte, 0, WriterBufferInitSize)),
 		flushTmp:   bytes.NewBuffer(make([]byte, 0, WriterBufferInitSize)),
 		flushC:     make(chan bool, 1000),
@@ -305,49 +325,59 @@ func (l *Log) outputStderr(calldepth int, s string) {
 func InitLog(dir, module string, level Level, rotate *LogRotate, logLeftSpaceLimitRatio float64) (*Log, error) {
 	l := new(Log)
 	l.printStderr = 1
-	dir = path.Join(dir, module)
-	l.dir = dir
-	LogDir = dir
-	fi, err := os.Stat(dir)
-	if err != nil {
-		os.MkdirAll(dir, 0o755)
+	if dir != "" {
+		dir = path.Join(dir, module)
+		l.dir = dir
+		LogDir = dir
+		fi, err := os.Stat(dir)
+		if err != nil {
+			os.MkdirAll(dir, 0o755)
+		} else {
+			if !fi.IsDir() {
+				return nil, errors.New(dir + " is not a directory")
+			}
+		}
+		_ = os.Chmod(dir, 0o755)
+
+		fs := syscall.Statfs_t{}
+		if err := syscall.Statfs(dir, &fs); err != nil {
+			return nil, fmt.Errorf("[InitLog] stats disk space: %s", err.Error())
+		}
+
+		if rotate == nil {
+			rotate = NewLogRotate()
+		}
+
+		if rotate.headRoom == 0 {
+			var minLogLeftSpaceLimit float64
+
+			minLogLeftSpaceLimit = float64(fs.Blocks*uint64(fs.Bsize)) * logLeftSpaceLimitRatio / 1024 / 1024
+
+			rotate.SetHeadRoomMb(int64(math.Min(minLogLeftSpaceLimit, DefaultHeadRoom)))
+		}
+
+		if rotate.rotateSize == 0 {
+			minRotateSize := int64(fs.Bavail * uint64(fs.Bsize) / uint64(len(levelPrefixes)))
+			if minRotateSize < DefaultMinRotateSize {
+				minRotateSize = DefaultMinRotateSize
+			}
+			rotate.SetRotateSizeMb(int64(math.Min(float64(minRotateSize), float64(DefaultRotateSize))))
+		}
 	} else {
-		if !fi.IsDir() {
-			return nil, errors.New(dir + " is not a directory")
+		if rotate == nil {
+			rotate = NewLogRotate()
 		}
-	}
-	_ = os.Chmod(dir, 0o755)
-
-	fs := syscall.Statfs_t{}
-	if err := syscall.Statfs(dir, &fs); err != nil {
-		return nil, fmt.Errorf("[InitLog] stats disk space: %s", err.Error())
-	}
-
-	if rotate == nil {
-		rotate = NewLogRotate()
-	}
-
-	if rotate.headRoom == 0 {
-		minLogLeftSpaceLimit := float64(fs.Blocks*uint64(fs.Bsize)) * logLeftSpaceLimitRatio / 1024 / 1024
-
-		rotate.SetHeadRoomMb(int64(math.Min(minLogLeftSpaceLimit, DefaultHeadRoom)))
-	}
-
-	if rotate.rotateSize == 0 {
-		minRotateSize := int64(fs.Bavail * uint64(fs.Bsize) / uint64(len(levelPrefixes)))
-		if minRotateSize < DefaultMinRotateSize {
-			minRotateSize = DefaultMinRotateSize
-		}
-		rotate.SetRotateSizeMb(int64(math.Min(float64(minRotateSize), float64(DefaultRotateSize))))
 	}
 
 	l.rotate = rotate
-	err = l.initLog(dir, module, level)
+	err := l.initLog(dir, module, level)
 	if err != nil {
 		return nil, err
 	}
 	l.lastRolledTime = time.Now()
-	go l.checkLogRotation(dir, module)
+	if dir != "" {
+		go l.checkLogRotation(dir, module)
+	}
 
 	gLog = l
 	setBlobLogLevel(level)
@@ -387,7 +417,12 @@ func (l *Log) initLog(logDir, module string, level Level) error {
 	logOpt := log.LstdFlags | log.Lmicroseconds
 
 	newLog := func(logFileName string) (newLogger *LogObject, err error) {
-		logName := path.Join(logDir, module+logFileName)
+		var logName string
+		if logDir == "" {
+			logName = ""
+		} else {
+			logName = path.Join(logDir, module+logFileName)
+		}
 		w, err := newAsyncWriter(logName, l.rotate.rotateSize)
 		if err != nil {
 			return

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -349,9 +349,7 @@ func InitLog(dir, module string, level Level, rotate *LogRotate, logLeftSpaceLim
 		}
 
 		if rotate.headRoom == 0 {
-			var minLogLeftSpaceLimit float64
-
-			minLogLeftSpaceLimit = float64(fs.Blocks*uint64(fs.Bsize)) * logLeftSpaceLimitRatio / 1024 / 1024
+			minLogLeftSpaceLimit := float64(fs.Blocks*uint64(fs.Bsize)) * logLeftSpaceLimitRatio / 1024 / 1024
 
 			rotate.SetHeadRoomMb(int64(math.Min(minLogLeftSpaceLimit, DefaultHeadRoom)))
 		}

--- a/util/unit.go
+++ b/util/unit.go
@@ -147,7 +147,7 @@ func ParseIpAddrToDomainAddr(ipAddr string) (domainAddr string) {
 	}
 	domains, err := net.LookupAddr(ip)
 	if err != nil {
-		log.LogWarnf("action[ParseIpAddrToDomainAddr] failed, ipAddr[%v], ip[%v], err[%v]", ipAddr, ip, err)
+		log.LogInfof("action[ParseIpAddrToDomainAddr] failed, ipAddr[%v], ip[%v], err[%v]", ipAddr, ip, err)
 		return
 	}
 	for _, v := range domains {


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #xyz

<!-- or this PR is one task of an issue. -->

Main Issue: #xyz


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

1. repair some bugs
2.  batch delete extents in delete extent channel
3. support enable or disable auto dp meta repair
4. add some debug log
5. print goroutine info when cfs-client exiting normally.
6. support vol level dp meta repair
7. add cfs_IsDir,cfs_IsRegular for libsdk.
8. add gosdk

### Modifications
<!-- Describe the modifications you've done. -->

``` text
1. repair some bugs
2.  batch delete extents in delete extent channel
3. support enable or disable auto dp meta repair
4. add some debug log
5. print goroutine info when cfs-client exiting normally.
6. support vol level dp meta repair
7. add cfs_IsDir,cfs_IsRegular for libsdk.
8. add gosdk

```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [x] Master
- [ ] MetaNode
- [x] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [x] Client
- [ ] Cli
- [x] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
