### PR TITLE
fix(raft): fix apply not return pool.

### DIFF
--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -227,13 +227,13 @@ func (s *raft) runApply() {
 			return
 
 		case apply := <-s.applyc:
-
 			s.applyLk.Lock()
 			if apply.index <= s.curApplied.Get() {
 				logger.Debug("rarft(%d) index %d is less than applied %d", s.raftFsm.id, apply.index, s.curApplied.Get())
 				if len(apply.readIndexes) > 0 {
 					respondReadIndex(apply.readIndexes, nil)
 				}
+				pool.returnApply(apply)
 				s.applyLk.Unlock()
 				continue
 			}


### PR DESCRIPTION
Fixes: raft

### Motivation
when using readIndex, it was found that 'apply' is not return poll and unexpected situations may occur in concurrent situations