### PR TITLE
fix(client): only delete src dir directly if dstPath exists in trash and fix error log in renameToTrashTempFile

### DIFF
--- a/sdk/meta/trash.go
+++ b/sdk/meta/trash.go
@@ -228,7 +228,7 @@ func (trash *Trash) MoveToTrash(parentPathAbsolute string, parentIno uint64, fil
 				if err != nil {
 					return err
 				}
-				break
+				return nil
 			}
 		} else {
 			log.LogDebugf("action[MoveToTrash]break")
@@ -729,10 +729,14 @@ func (trash *Trash) createParentPathInTrash(parentPath, rootDir string) (err err
 	return
 }
 
-func (trash *Trash) renameToTrashTempFile(parentIno, currentIno uint64, oldPath, newPath string) error {
-	err := trash.mw.Rename_ll(parentIno, path.Base(oldPath), currentIno, path.Base(newPath), oldPath, newPath, true)
+func (trash *Trash) renameToTrashTempFile(parentIno, currentIno uint64, oldPath, newPath string) (err error) {
+	defer func() {
+		if err != nil {
+			log.LogErrorf("action[renameToTrashTempFile] rename src %v err %v", oldPath, err)
+		}
+	}()
+	err = trash.mw.Rename_ll(parentIno, path.Base(oldPath), currentIno, path.Base(newPath), oldPath, newPath, true)
 	if err == syscall.ENOENT {
-		log.LogErrorf("action[renameToTrashTempFile] rename src %v err ENOENT", oldPath)
 		srcParentMP := trash.mw.getPartitionByInode(parentIno)
 		if srcParentMP == nil {
 			return syscall.ENOENT


### PR DESCRIPTION
fix(client): only delete src dir directly if dstPath exists in trash and fix error log in renameToTrashTempFile


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
When the trash policy is enabled and I delete the same directory twice, there are some error logs which is 'no such file or directory'. Because the same directory is in trash after the first deletion, so it will be deleted directly for the second time. However, after this direct deletion, it will be renamed to trash again which is unreasonable and causes 'no such file or directory' during rename.

### Modifications
<!-- Describe the modifications you've done. -->


When the same directory is in trash after the first deletion, just only delete the directory directly, don't need to rename to trash again.


### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [x] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`
