### PR TITLE
fix(othertools): java libcubefs compilation failure caused by path errors

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -399,12 +399,12 @@ build_libsdk() {
     CGO_ENABLED=1 go build $MODFLAGS -gcflags=all=-trimpath=${SrcPath} -asmflags=all=-trimpath=${SrcPath} -ldflags="${LDFlags}" -buildmode c-shared -o ${TargetFile} ${SrcPath}/client/libsdk/*.go && echo "success" || echo "failed"
     popd >/dev/null
 
-    pushd $SrcPath/client/java >/dev/null
+    pushd $SrcPath/java >/dev/null
     echo -n "build java libcubefs        "
-    mkdir -p $SrcPath/client/java/src/main/resources/
-    \cp  -rf ${TargetFile}  $SrcPath/client/java/src/main/resources/
+    mkdir -p $SrcPath/java/src/main/resources/
+    \cp  -rf ${TargetFile}  $SrcPath/java/src/main/resources/
     mvn clean package
-    \cp -rf $SrcPath/client/java/target/*.jar ${BuildBinPath}  && echo "build java libcubefs success" || echo "build java libcubefs failed"
+    \cp -rf $SrcPath/java/target/*.jar ${BuildBinPath}  && echo "build java libcubefs success" || echo "build java libcubefs failed"
     popd >/dev/null
 }
 


### PR DESCRIPTION
fix(othertools): java libcubefs compilation failure caused by path errors

<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #Fix the issue of Java libcubefs compilation failure caused by path errors

<!-- or this PR is one task of an issue. -->

Main Issue: # java libcubefs，build failure
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.089 s
[INFO] Finished at: 2025-01-03T10:22:28+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] The goal you specified requires a project to execute but there is no POM in this directory (/root/GoProject/src/cubefs_metaapp/client/java). Please verify you invoked Maven from the correct directory. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
cp: cannot stat ‘/root/tmp/cfs/go/src/github.com/cubefs/cubefs/client/java/target/*.jar’: No such file or directory

```



### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->



### Modifications
<!-- Describe the modifications you've done. -->


The Java project path configuration in the build.sh script is incorrect, which prevents successful compilation. Changing 'client/java' to '/java' will result in successful compilation


### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment



### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`

<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
