### PR TITLE
fix(raft): fix readIndex not set index.

### DIFF
--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -648,6 +648,7 @@ func (s *raft) apply() {
 		}
 		apply := pool.getApply()
 		apply.readIndexes = readIndexes
+		apply.index = s.curApplied.Get()
 		select {
 		case <-s.stopc:
 			respondReadIndex(readIndexes, ErrStopped)


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: 

<!-- or this PR is one task of an issue. -->

Main Issue: 


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

When readIndex is supported, if committedEntries is equal to 0 and readIndexs is not 0, an apply will be obtained from the pool, but the index is not set, which may cause the index to be greater than curApplied, resulting in data loss.

### Modifications
<!-- Describe the modifications you've done. -->

``` text
Added readindex applied
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.


