### PR TITLE
fix(metanode): new gauge for each partid when updatePartitionMetrics to prevent two coroutines from concurrently reading and writing to the same gauge

### DIFF
--- a/metanode/metrics.go
+++ b/metanode/metrics.go
@@ -32,10 +32,8 @@ const (
 )
 
 type MetaNodeMetrics struct {
-	MetricConnectionCount          *exporter.Gauge
-	MetricMetaFailedPartition      *exporter.Gauge
-	MetricMetaPartitionInodeCount  *exporter.Gauge
-	MetricMetaPartitionDentryCount *exporter.Gauge
+	MetricConnectionCount     *exporter.Gauge
+	MetricMetaFailedPartition *exporter.Gauge
 
 	metricStopCh chan struct{}
 }
@@ -44,22 +42,20 @@ func (m *MetaNode) startStat() {
 	m.metrics = &MetaNodeMetrics{
 		metricStopCh: make(chan struct{}, 0),
 
-		MetricConnectionCount:          exporter.NewGauge(MetricConnectionCount),
-		MetricMetaFailedPartition:      exporter.NewGauge(MetricMetaFailedPartition),
-		MetricMetaPartitionInodeCount:  exporter.NewGauge(MetricMetaPartitionInodeCount),
-		MetricMetaPartitionDentryCount: exporter.NewGauge(MetricMetaPartitionDentryCount),
+		MetricConnectionCount:     exporter.NewGauge(MetricConnectionCount),
+		MetricMetaFailedPartition: exporter.NewGauge(MetricMetaFailedPartition),
 	}
 
 	go m.collectPartitionMetrics()
 }
 
-func (m *MetaNode) upatePartitionMetrics(mp *metaPartition) {
+func (m *MetaNode) updatePartitionMetrics(mp *metaPartition) {
 	labels := map[string]string{
 		"partid":     fmt.Sprintf("%d", mp.config.PartitionId),
 		exporter.Vol: mp.config.VolName,
 	}
-	m.metrics.MetricMetaPartitionInodeCount.SetWithLabels(float64(mp.GetInodeTreeLen()), labels)
-	m.metrics.MetricMetaPartitionDentryCount.SetWithLabels(float64(mp.GetDentryTreeLen()), labels)
+	exporter.NewGauge(MetricMetaPartitionInodeCount).SetWithLabels(float64(mp.GetInodeTreeLen()), labels)
+	exporter.NewGauge(MetricMetaPartitionDentryCount).SetWithLabels(float64(mp.GetDentryTreeLen()), labels)
 }
 
 func (m *MetaNode) collectPartitionMetrics() {
@@ -73,7 +69,7 @@ func (m *MetaNode) collectPartitionMetrics() {
 				manager.mu.RLock()
 				for _, p := range manager.partitions {
 					if mp, ok := p.(*metaPartition); ok {
-						m.upatePartitionMetrics(mp)
+						m.updatePartitionMetrics(mp)
 					}
 				}
 				manager.mu.RUnlock()

--- a/metanode/partition_fsmop_dentry.go
+++ b/metanode/partition_fsmop_dentry.go
@@ -134,7 +134,7 @@ func (mp *metaPartition) fsmCreateDentry(dentry *Dentry,
 			log.LogDebugf("action[fsmCreateDentry.ver] mp[%v] no need repeat create new one [%v]", mp.config.PartitionId, dentry)
 			return
 		}
-		log.LogErrorf("action[fsmCreateDentry.ver] mp[%v] dentry already exist [%v] and diff with the request [%v]", mp.config.PartitionId, d, dentry)
+		log.LogWarnf("action[fsmCreateDentry.ver] mp[%v] dentry already exist [%v] and diff with the request [%v]", mp.config.PartitionId, d, dentry)
 		status = proto.OpExistErr
 		return
 	}


### PR DESCRIPTION
fix(metanode): new gauge for each partid when updatePartitionMetrics to prevent two coroutines from concurrently reading and writing to the same gauge


### Motivation
1、new gauge for each partid when updatePartitionMetrics to prevent two coroutines from concurrently reading and writing to the same gauge
2、modify log level of "dentry already exist" when create dentry in metanode. Because when rename and overwrite the destination file(if the file already exist) in client, the client will try creating dentry before update dentry. This is allowed and printing warn log is better than error log.

### Modifications
1、new gauge for each partid when updatePartitionMetrics to prevent two coroutines from concurrently reading and writing to the same gauge
2、modify log level of "dentry already exist" when create dentry in metanode. Because when rename and overwrite the destination file(if the file already exist) in client, the client will try creating dentry before update dentry. This is allowed and printing warn log is better than error log.

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [x] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`
