### PR TITLE
fix(objectnode): When S3 deletes an object, the empty folder is not recursively deleted

### DIFF
--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -943,6 +943,7 @@ func (v *Volume) DeletePath(path string) (err error) {
 		log.LogWarnf("DeletePath Evict: path(%v) inode(%v)", path, ino)
 	}
 
+	err = nil
 	// Recursive deletion of empty directory
 	if os_path.Dir(path) == "." {
 		return
@@ -955,9 +956,6 @@ func (v *Volume) DeletePath(path string) (err error) {
 		}
 		return
 	}
-
-	err = nil
-	return
 }
 
 func (v *Volume) InitMultipart(path string, opt *PutFileOption) (multipartID string, err error) {

--- a/objectnode/fs_volume.go
+++ b/objectnode/fs_volume.go
@@ -24,6 +24,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	os_path "path"
 	"reflect"
 	"sort"
 	"strconv"
@@ -941,6 +942,20 @@ func (v *Volume) DeletePath(path string) (err error) {
 	if err = v.mw.Evict(ino, path); err != nil {
 		log.LogWarnf("DeletePath Evict: path(%v) inode(%v)", path, ino)
 	}
+
+	// Recursive deletion of empty directory
+	if os_path.Dir(path) == "." {
+		return
+	} else {
+		log.LogInfof("os_path.Dir(path): (%v)", os_path.Dir(path))
+
+		if err = v.DeletePath(fmt.Sprintf("%s/", os_path.Dir(path))); err != nil {
+			log.LogErrorf("Recursive DeletePath: delete path fail: path(%v) err(%v)", path, err)
+			return
+		}
+		return
+	}
+
 	err = nil
 	return
 }


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #fix(objectnode): When S3 deletes an object, the empty folder is not recursively deleted

<!-- or this PR is one task of an issue. -->

Main Issue: #


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Cubefs uses the S3 semantics implemented by the file system, so when deleting objects, empty directories are not deleted. In the scenario of creating a large number of deleted objects in S3, only files are deleted without deleting the directory part, resulting in a large number of empty files occupying the storage space of the meta system.

### Modifications
<!-- Describe the modifications you've done. -->

When using S3 semantics to delete an object, recursively determine whether the directory component of the object key is an empty directory.  If it is empty, delete it; otherwise, exit. This will not affect the semantics of file operations.

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [x] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [ ] `weekly`
- [x] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
