### PR TITLE
perf(util): scale the capacity of buffer in o1

### DIFF
--- a/blobstore/util/bytespool/pool_test.go
+++ b/blobstore/util/bytespool/pool_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bytespool_test
+
+import (
+	"testing"
+
+	"github.com/cubefs/cubefs/blobstore/util/bytespool"
+)
+
+func TestUtilBytespool(t *testing.T) {
+	run := func(size int) {
+		buff := bytespool.Alloc(size)
+		if len(buff) != size {
+			t.Fatal(size)
+		}
+		bytespool.Zero(buff)
+		bytespool.Free(buff)
+		if size == 0 {
+			return
+		}
+		size--
+		buff = bytespool.Alloc(size)
+		if len(buff) != size {
+			t.Fatal(size)
+		}
+		bytespool.Zero(buff)
+		bytespool.Free(buff)
+	}
+	run(0)
+	for bits := range [27]struct{}{} {
+		run(1 << bits)
+	}
+}
+
+func BenchmarkBytespool(b *testing.B) {
+	var buff []byte
+	for ii := 0; ii < b.N; ii++ {
+		buff = bytespool.Alloc(1 << (ii % 20))
+		bytespool.Free(buff)
+	}
+}


### PR DESCRIPTION

### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

scale the capacity of buffer in o1

### Modifications
<!-- Describe the modifications you've done. -->

``` text
BenchmarkBytespool
BenchmarkBytespool-4  21887019  67.65 ns/op  28 B/op  1 allocs/op
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [x] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [x] Make sure that the change passes the testing checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [x] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [ ] `weekly`
- [x] `free-time`
- [ ] `whenever`

