### PR TITLE
fix(client_kernel) When the client is compatible with parsing the server message, the time zone is set to UTC.

### DIFF
--- a/client_kernel/cfs_packet.c
+++ b/client_kernel/cfs_packet.c
@@ -159,7 +159,7 @@ static int cfs_packet_inode_from_json(cfs_json_t *json,
 	ret = cfs_json_get_string_ptr(json, "mt", &val, &len);
 	CHECK_GOTO(ret, "not found mt");
 	ret = cfs_parse_time(val, len, &info->modify_time);
-	CHECK_GOTO(ret, "failed to parse mt");
+    	CHECK_GOTO(ret, "failed to parse mt, raw value: [%.*s]", (int)len, val);
 
 	ret = cfs_json_get_string_ptr(json, "ct", &val, &len);
 	CHECK_GOTO(ret, "not found ct");

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -24,7 +24,9 @@ EOF
     exit 0
 }
 
-compose="docker compose --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose.yml"
+cmdcompose="docker-compose"
+docker compose version > /dev/null 2>&1 && cmdcompose="docker compose"
+compose="${cmdcompose} --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose.yml"
 
 
 clean() {

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -24,7 +24,7 @@ EOF
     exit 0
 }
 
-compose="docker-compose --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose.yml"
+compose="docker compose --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose.yml"
 
 
 clean() {


### PR DESCRIPTION
1. The log clearly analyzes the failed value of mt.
2. When the client is compatible with parsing the server message, the time zone is set to UTC.
