### PR TITLE
fix(cli): migrate metanode cmd cannot work with default limit mp count

### DIFF
--- a/cli/cmd/metanode.go
+++ b/cli/cmd/metanode.go
@@ -26,7 +26,7 @@ import (
 const (
 	cmdMetaNodeUse   = "metanode [COMMAND]"
 	cmdMetaNodeShort = "Manage meta nodes"
-	mpMigrateMax     = 15
+	mpMigrateMax     = 3
 )
 
 func newMetaNodeCmd(client *master.MasterClient) *cobra.Command {
@@ -173,7 +173,7 @@ func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 			src = args[0]
 			dst = args[1]
 			if optCount > mpMigrateMax || optCount <= 0 {
-				stdout("Migrate mp count should between [1-15]\n")
+				stdout("Migrate mp count should between [1-3]\n")
 				return
 			}
 			if err = client.NodeAPI().MetaNodeMigrate(src, dst, optCount, clientIDKey); err != nil {

--- a/cli/cmd/metanode.go
+++ b/cli/cmd/metanode.go
@@ -20,13 +20,13 @@ import (
 
 	"github.com/cubefs/cubefs/proto"
 	"github.com/cubefs/cubefs/sdk/master"
+	"github.com/cubefs/cubefs/util"
 	"github.com/spf13/cobra"
 )
 
 const (
 	cmdMetaNodeUse   = "metanode [COMMAND]"
 	cmdMetaNodeShort = "Manage meta nodes"
-	mpMigrateMax     = 3
 )
 
 func newMetaNodeCmd(client *master.MasterClient) *cobra.Command {
@@ -172,8 +172,8 @@ func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 			}()
 			src = args[0]
 			dst = args[1]
-			if optCount > mpMigrateMax || optCount <= 0 {
-				stdout("Migrate mp count should between [1-3]\n")
+			if optCount > util.DefaultMigrateMpCnt || optCount <= 0 {
+				stdout("Migrate mp count should between [1-%d]\n", util.DefaultMigrateMpCnt)
 				return
 			}
 			if err = client.NodeAPI().MetaNodeMigrate(src, dst, optCount, clientIDKey); err != nil {
@@ -188,7 +188,7 @@ func newMetaNodeMigrateCmd(client *master.MasterClient) *cobra.Command {
 			return validMetaNodes(client, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
-	cmd.Flags().IntVar(&optCount, CliFlagCount, mpMigrateMax, "Migrate mp count")
+	cmd.Flags().IntVar(&optCount, CliFlagCount, util.DefaultMigrateMpCnt, "Migrate mp count")
 	cmd.Flags().StringVar(&clientIDKey, CliFlagClientIDKey, client.ClientIDKey(), CliUsageClientIDKey)
 	return cmd
 }

--- a/master/api_service.go
+++ b/master/api_service.go
@@ -5157,8 +5157,8 @@ func (m *Server) migrateMetaNodeHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if limit > defaultMigrateMpCnt {
-		err = fmt.Errorf("limit %d can't be bigger than %d", limit, defaultMigrateMpCnt)
+	if limit > util.DefaultMigrateMpCnt {
+		err = fmt.Errorf("limit %d can't be bigger than %d", limit, util.DefaultMigrateMpCnt)
 		sendErrReply(w, r, newErrHTTPReply(err))
 		return
 	}

--- a/master/cluster.go
+++ b/master/cluster.go
@@ -3540,7 +3540,7 @@ func (c *Cluster) migrateMetaNode(srcAddr, targetAddr string, limit int) (err er
 	}
 
 	if limit <= 0 {
-		limit = defaultMigrateMpCnt
+		limit = util.DefaultMigrateMpCnt
 	}
 
 	if limit > len(toBeOfflineMps) {

--- a/master/const.go
+++ b/master/const.go
@@ -215,7 +215,6 @@ const (
 	defaultRangeOfCountDifferencesAllowed         = 50
 	defaultMinusOfMaxInodeID                      = 1000
 	defaultNodeSetGrpBatchCnt                     = 3
-	defaultMigrateMpCnt                           = 3
 	defaultMaxReplicaCnt                          = 16
 	defaultIopsRLimit                      uint64 = 1 << 35
 	defaultIopsWLimit                      uint64 = 1 << 35

--- a/util/unit.go
+++ b/util/unit.go
@@ -80,6 +80,10 @@ const (
 	DefaultTinySizeLimit = 1 * MB // TODO explain tiny extent?
 )
 
+const (
+	DefaultMigrateMpCnt = 3
+)
+
 type MultiVersionSeq uint64
 
 func Min(a, b int) int {


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #xyz

<!-- or this PR is one task of an issue. -->

Main Issue: #xyz


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
migrate metanode with cli cmd can not work
<img width="806" alt="image" src="https://github.com/user-attachments/assets/3a1a785d-f3c4-44a4-bfda-0816fd1b2dc6" />

changed by this PR
[enhance(master): mp migrate need limit the parrallel count](https://github.com/cubefs/cubefs/pull/2752/commits/c137a273d9595ef200c65ef246860f33e25f24b6)

### Modifications
<!-- Describe the modifications you've done. -->

``` text
I think we can do the following modifications:
1、migrate metanode cli set default mp count with 0 but not maxMpCount
2、remove the check for limit value as it is specified by the user 
      and the cli command will detect that this value does not exceed 15

```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
