### PR TITLE
feat(util): try to wait with context in retry

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -30,8 +30,10 @@ EOF
     exit 0
 }
 
-#compose="docker-compose --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose-hy.yml"
-compose="docker compose --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose.yml"
+cmdcompose="docker-compose"
+docker compose version > /dev/null 2>&1 && cmdcompose="docker compose"
+#compose="${cmdcompose} --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose-hy.yml"
+compose="${cmdcompose} --env-file ${RootPath}/docker/run_docker.env -f ${RootPath}/docker/docker-compose.yml"
 
 has_go() {
     if command -v go &> /dev/null


### PR DESCRIPTION
Fixes: #3758

### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

try to wait with context in retry

### Modifications
<!-- Describe the modifications you've done. -->

``` text
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkWait
BenchmarkWait/success
BenchmarkWait/success-4     432140625    2.793 ns/op    0 B/op  0 allocs/op
BenchmarkWait/retry-3
BenchmarkWait/retry-3-4      97395789   12.27 ns/op     0 B/op  0 allocs/op
BenchmarkContext
BenchmarkContext/success
BenchmarkContext/success-4  449174043    2.641 ns/op    0 B/op  0 allocs/op
BenchmarkContext/retry-3
BenchmarkContext/retry-3-4    3177039  380.2 ns/op    232 B/op  3 allocs/op
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [x] Make sure that the change passes the testing checks.

This change added tests and can be verified as follows:


### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [x] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`


