### PR TITLE
fix(scheduler): adjust log levels to reduce unnecessary log output for blob_deleter

### DIFF
--- a/blobstore/scheduler/blob_deleter.go
+++ b/blobstore/scheduler/blob_deleter.go
@@ -615,8 +615,13 @@ func (mgr *BlobDeleteMgr) deleteShards(
 				continue
 			}
 
-			span.Errorf("delete shard failed: bid[%d], vuid[%d], markDelete[%+v], code[%d], err[%+v]",
-				bid, ret.vuid, markDelete, errCode, ret.err)
+			if errCode == errcode.CodeChunkCompacting || errCode == errcode.CodeVUIDReadonly {
+				span.Warnf("delete shard failed: bid[%d], vuid[%d], markDelete[%+v], code[%d], err[%+v]",
+					bid, ret.vuid, markDelete, errCode, ret.err)
+			} else {
+				span.Errorf("delete shard failed: bid[%d], vuid[%d], markDelete[%+v], code[%d], err[%+v]",
+					bid, ret.vuid, markDelete, errCode, ret.err)
+			}
 			return volInfo, ret.err
 		}
 	}


### PR DESCRIPTION
during period blobnode chunk compact, delete ops are not allowed, so scheduler bloc_deleter will receive a large number of `chunk is compacting` error logs when MarkDelete/Delete. to reduce log pressure, this entry is adjusted to Warn

<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

```
# grep 'chunk is compacting' service/scheduler/scheduler-start.log | grep -w ERROR | wc -l
279993
```

```
2025/04/23 08:41:22.542143 [ERROR] blobstore/scheduler/blob_deleter.go:591 [1e69fa05b5d395f5_e04746940db4553d:30d2094277d60c7f] delete shard failed: bid[180098383], vuid[14894946582529], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:22.838751 [ERROR] blobstore/scheduler/blob_deleter.go:591 [5405a4333d51fb12_310ee8c5723b95d2:434dbed670e6c4fe] delete shard failed: bid[180605782], vuid[14890685169665], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:22.958848 [ERROR] blobstore/scheduler/blob_deleter.go:591 [edd2877944650085_f13359d537674a62:2955f55b33106131] delete shard failed: bid[180588513], vuid[14594298871809], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:23.044628 [ERROR] blobstore/scheduler/blob_deleter.go:591 [7d220ec43ddba427_daf7fc8962e68f17:8f401a0b6b4051bc] delete shard failed: bid[180589913], vuid[14594298871809], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:23.829100 [ERROR] blobstore/scheduler/blob_deleter.go:591 [b1880578cff6d10e_f0dc42667c7a5970:14086ebc18b3ade4] delete shard failed: bid[180395528], vuid[11828457373697], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:23.855298 [ERROR] blobstore/scheduler/blob_deleter.go:591 [9f8bce553edbf9fd_9dce5d81c4f29782:f8525992663fe4fa] delete shard failed: bid[180603419], vuid[13310170759169], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:23.961037 [ERROR] blobstore/scheduler/blob_deleter.go:591 [1d7d0c36a908eab9_18df1f4f66a9d333:226bf5590c02412c] delete shard failed: bid[180575276], vuid[12051728564225], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:23.962941 [ERROR] blobstore/scheduler/blob_deleter.go:591 [61ac2e0a4bb9173b_f5804bbd0511bbe7:4861b5c699ebd749] delete shard failed: bid[180097482], vuid[14890685169665], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:24.026266 [ERROR] blobstore/scheduler/blob_deleter.go:591 [5fb64335942ea018_3e216087c93d70ba:2a43c29f7e2b0226] delete shard failed: bid[180595622], vuid[15212925157377], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:24.444436 [ERROR] blobstore/scheduler/blob_deleter.go:591 [097a84e1ea83c43f_566dede7693713e0:42a4f2ddbc0a0c98] delete shard failed: bid[180606483], vuid[14894946582529], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:24.756696 [ERROR] blobstore/scheduler/blob_deleter.go:591 [72a6f8804123d2a3_6aaf55cd0c1b50b6:f8916c288aba05b2] delete shard failed: bid[180903930], vuid[11965829218305], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:25.077754 [ERROR] blobstore/scheduler/blob_deleter.go:591 [f8e247395354aceb_c0ad9c3da36647d5:53b34c216c8b4658] delete shard failed: bid[180596822], vuid[15212925157377], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:25.097918 [ERROR] blobstore/scheduler/blob_deleter.go:591 [0e0160b72499487a_2dbe028cf2608be0:53420fc732d3e361] delete shard failed: bid[180098800], vuid[15303002030081], markDelete[true], code[628], err[chunk is compacting]
2025/04/23 08:41:25.109181 [ERROR] blobstore/scheduler/blob_deleter.go:591 [0e0160b72499487a_7fc5f79b811fea05:f82ad67398aa9048] delete shard failed: bid[180494587], vuid[14813358981121], markDelete[true], code[628], err[chunk is compacting]
```


### Modifications
<!-- Describe the modifications you've done. -->

``` text
during period blobnode chunk compact, delete ops are not allowed,
so scheduler bloc_deleter will receive a large number of
`chunk is compacting` error logs when MarkDelete/Delete.
to reduce log pressure, this entry is adjusted to Warn
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Log Level

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
