### PR TITLE
fix(scheduler): check chunk compacting for blob_deleter

### DIFF
--- a/blobstore/api/clustermgr/volume.go
+++ b/blobstore/api/clustermgr/volume.go
@@ -43,6 +43,8 @@ type Unit struct {
 type VolumeInfo struct {
 	Units []Unit `json:"units"`
 	VolumeInfoBase
+	// for scheduler
+	HasChunkCompacting bool `json:"has_chunk_compacting"`
 }
 
 func (v *VolumeInfo) Equal(expected *VolumeInfo) bool {

--- a/blobstore/clustermgr/volumemgr/proto.go
+++ b/blobstore/clustermgr/volumemgr/proto.go
@@ -73,16 +73,21 @@ func (vol *volume) ToRecord() *volumedb.VolumeRecord {
 
 func (vol *volume) ToVolumeInfo() cm.VolumeInfo {
 	units := make([]cm.Unit, len(vol.vUnits))
+	hasChunkCompacting := false
 	for i, vUnit := range vol.vUnits {
 		units[i] = cm.Unit{
 			Vuid:   vUnit.vuInfo.Vuid,
 			DiskID: vUnit.vuInfo.DiskID,
 			Host:   vUnit.vuInfo.Host,
 		}
+		if !hasChunkCompacting && vUnit.vuInfo.Compacting {
+			hasChunkCompacting = true
+		}
 	}
 	return cm.VolumeInfo{
-		VolumeInfoBase: vol.volInfoBase,
-		Units:          units,
+		VolumeInfoBase:     vol.volInfoBase,
+		HasChunkCompacting: hasChunkCompacting,
+		Units:              units,
 	}
 }
 

--- a/blobstore/common/proto/proxy.go
+++ b/blobstore/common/proto/proxy.go
@@ -61,6 +61,7 @@ type DeleteMsg struct {
 	Time          int64           `json:"time"`
 	ReqId         string          `json:"req_id"`
 	BlobDelStages BlobDeleteStage `json:"blob_del_stages"`
+	Errno         int             `json:"errno"`
 }
 
 func (msg *DeleteMsg) IsValid() bool {

--- a/blobstore/scheduler/client/clustermgr.go
+++ b/blobstore/scheduler/client/clustermgr.go
@@ -194,6 +194,8 @@ type VolumeInfoSimple struct {
 	CodeMode       codemode.CodeMode     `json:"code_mode"`
 	Status         proto.VolumeStatus    `json:"status"`
 	VunitLocations []proto.VunitLocation `json:"vunit_locations"`
+	// Among N+M+L chunks, as long as there is one compacting=true
+	HasChunkCompacting bool `json:"has_chunk_compacting"`
 }
 
 // EqualWith returns whether equal with another.
@@ -228,6 +230,7 @@ func (vol *VolumeInfoSimple) set(info *cmapi.VolumeInfo) {
 	vol.Vid = info.Vid
 	vol.CodeMode = info.CodeMode
 	vol.Status = info.Status
+	vol.HasChunkCompacting = info.HasChunkCompacting
 	vol.VunitLocations = make([]proto.VunitLocation, len(info.Units))
 
 	// check volume info


### PR DESCRIPTION
```
1.during period blobnode chunk compact, delete ops are not allowed, so scheduler blob_deleter will receive a large number of chunk is compacting error when MarkDelete/Delete.
2.when delMsg.Retry more than MessagePunishThreshold, will sleep(MessagePunishTimeM) unconditionally.
3.when there are all chunk is compacting's delMsg in blob_delete_fail topic, the speed of blob_deleter consuming delMsg will be very very slow. 
fixes: https://github.com/cubefs/cubefs/issues/3772
```

<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #3772

<!-- or this PR is one task of an issue. -->

Main Issue: #3772


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

```
1.during period blobnode chunk compact, delete ops are not allowed, so scheduler blob_deleter will receive a large number of chunk is compacting error when MarkDelete/Delete.
2.when delMsg.Retry more than MessagePunishThreshold, will sleep(MessagePunishTimeM) unconditionally.
3.when there are all chunk is compacting's delMsg in blob_delete_fail topic, the speed of blob_deleter consuming delMsg will be very very slow. 
```

### Modifications
<!-- Describe the modifications you've done. -->

Add Get VolumeInfo HasChunkCompacting
``` text
1. Add HasChunkCompacting bool for `type VolumeInfo struct`
2. Add HasChunkCompacting bool for `type VolumeInfoSimple struct`
3. Modify VolumeInfoSimple set => vol.HasChunkCompacting = info.HasChunkCompacting
```

Add Errno in `type DeleteMsg struct`
```text
1. Add Errno int in type DeleteMsg struct
```


Check hasChunkCompacting(vid) when `delMsg.errno == errcode.CodeChunkCompacting` before sleep
```text
1. Add BlobDeleteMgr hasChunkCompacting(vid) for blob_deleter to check HasChunkCompacting false/true
3. Call hasChunkCompacting(vid)  in BlobDeleteMgr Consume
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
