### PR TITLE
perf(util): store pointer of bytes in bytespool

### DIFF
--- a/blobstore/util/bytespool/pool_test.go
+++ b/blobstore/util/bytespool/pool_test.go
@@ -28,9 +28,15 @@ func TestUtilBytespool(t *testing.T) {
 		}
 		bytespool.Zero(buff)
 		bytespool.Free(buff)
+		bp := bytespool.AllocPointer(size)
+		if len(*bp) != size {
+			t.Fatal(size)
+		}
+		bytespool.FreePointer(bp)
 		if size == 0 {
 			return
 		}
+
 		size--
 		buff = bytespool.Alloc(size)
 		if len(buff) != size {
@@ -38,17 +44,31 @@ func TestUtilBytespool(t *testing.T) {
 		}
 		bytespool.Zero(buff)
 		bytespool.Free(buff)
+		bp = bytespool.AllocPointer(size)
+		if len(*bp) != size {
+			t.Fatal(size)
+		}
+		bytespool.FreePointer(bp)
 	}
 	run(0)
 	for bits := range [27]struct{}{} {
 		run(1 << bits)
 	}
+	bytespool.FreePointer(nil)
 }
 
-func BenchmarkBytespool(b *testing.B) {
+func BenchmarkBytespoolSlice(b *testing.B) {
 	var buff []byte
 	for ii := 0; ii < b.N; ii++ {
 		buff = bytespool.Alloc(1 << (ii % 20))
 		bytespool.Free(buff)
+	}
+}
+
+func BenchmarkBytespoolPointer(b *testing.B) {
+	var bp *[]byte
+	for ii := 0; ii < b.N; ii++ {
+		bp = bytespool.AllocPointer(1 << (ii % 20))
+		bytespool.FreePointer(bp)
 	}
 }


### PR DESCRIPTION
Fixes: #3786

### Modifications
<!-- Describe the modifications you've done. -->

``` text
pkg: github.com/cubefs/cubefs/blobstore/util/bytespool cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkBytespoolSlice
BenchmarkBytespoolSlice-4        23023845    50.60 ns/op   29 B/op    1 allocs/op
BenchmarkBytespoolPointer
BenchmarkBytespoolPointer-4    60203656    18.60 ns/op    0 B/op    0 allocs/op
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [x] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [x] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [ ] `weekly`
- [x] `free-time`
- [ ] `whenever`
