### PR TITLE
fix(blobstore): ensure Delete returns correct failed locations on error

### DIFF
--- a/blobstore/api/access/client.go
+++ b/blobstore/api/access/client.go
@@ -216,7 +216,11 @@ type API interface {
 	// Get object, range is supported.
 	Get(ctx context.Context, args *GetArgs) (body io.ReadCloser, err error)
 	// Delete all blobs in these locations.
-	// return failed locations which have yet been deleted if error is not nil.
+	//
+	// Returns:
+	// - (nil, nil): all blobs deleted successfully.
+	// - (nil, ErrIllegalArguments): when args is invalid.
+	// - (failedLocations, err): returns the list of locations that have not yet been deleted.
 	Delete(ctx context.Context, args *DeleteArgs) (failedLocations []Location, err error)
 }
 

--- a/blobstore/sdk/sdk_client.go
+++ b/blobstore/sdk/sdk_client.go
@@ -149,7 +149,7 @@ func (s *sdkHandler) Delete(ctx context.Context, args *acapi.DeleteArgs) (failed
 	if err := s.limiter.Acquire(name); err != nil {
 		span := trace.SpanFromContextSafe(ctx)
 		span.Debugf("access concurrent limited %s, err:%+v", name, err)
-		return nil, errcode.ErrAccessLimited
+		return locations, errcode.ErrAccessLimited
 	}
 	defer s.limiter.Release(name)
 


### PR DESCRIPTION
Previously, the Delete method did not fully comply with its interface contract, which states that it should return the list of locations that have not yet been deleted when an error occurs.

This change ensures:
- When args are invalid (e.g., illegal Locations), returns (nil, ErrIllegalArguments), as no deletion was attempted.
- For other errors, returns the list of failed or pending locations to allow proper handling by the caller.

This improves consistency and helps callers handle partial failures correctly.

close #3851

