### PR TITLE
feat(bssdk): support log file configuration for sdk client

### DIFF
--- a/blobstore/cmd/cmd.go
+++ b/blobstore/cmd/cmd.go
@@ -86,7 +86,7 @@ func RegisterGracefulModule(m *Module) {
 	mod.graceful = true
 }
 
-func newLogWriter(cfg *LogConfig) io.Writer {
+func NewLogWriter(cfg *LogConfig) io.Writer {
 	maxsize := cfg.MaxSize
 	if maxsize == 0 {
 		maxsize = 1024
@@ -119,7 +119,7 @@ func Main(args []string) {
 	log.SetOutputLevel(cfg.LogConf.Level)
 	registerLogLevel()
 	if cfg.LogConf.Filename != "" {
-		log.SetOutput(newLogWriter(&cfg.LogConf))
+		log.SetOutput(NewLogWriter(&cfg.LogConf))
 	}
 	if cfg.ShutdownTimeoutS <= 0 {
 		cfg.ShutdownTimeoutS = defaultShutdownTimeoutS

--- a/blobstore/sdk/sdk_client.go
+++ b/blobstore/sdk/sdk_client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cubefs/cubefs/blobstore/access/stream"
 	acapi "github.com/cubefs/cubefs/blobstore/api/access"
 	"github.com/cubefs/cubefs/blobstore/api/shardnode"
+	"github.com/cubefs/cubefs/blobstore/cmd"
 	errcode "github.com/cubefs/cubefs/blobstore/common/errors"
 	"github.com/cubefs/cubefs/blobstore/common/proto"
 	"github.com/cubefs/cubefs/blobstore/common/resourcepool"
@@ -85,8 +86,8 @@ type Config struct {
 	RetryDelayMs    uint32             `json:"retry_delay_ms"`
 	PartConcurrence int                `json:"part_concurrence"`
 
-	LogLevel log.Level `json:"log_level"`
-	Logger   io.Writer `json:"-"`
+	LogConf cmd.LogConfig `json:"log"`
+	Logger  io.Writer     `json:"-"`
 }
 
 type sdkHandler struct {
@@ -1202,9 +1203,13 @@ func fixConfig(cfg *Config) {
 	defaulter.LessOrEqual(&cfg.MaxRetry, defaultMaxRetry)
 	defaulter.LessOrEqual(&cfg.RetryDelayMs, defaultRetryDelayMs)
 	defaulter.LessOrEqual(&cfg.PartConcurrence, defaultPartConcurrence)
-	log.SetOutputLevel(cfg.LogLevel)
+	log.SetOutputLevel(cfg.LogConf.Level)
 	if cfg.Logger != nil {
 		log.SetOutput(cfg.Logger)
+	} else {
+		if cfg.LogConf.Filename != "" {
+			log.SetOutput(cmd.NewLogWriter(&cfg.LogConf))
+		}
 	}
 }
 

--- a/blobstore/sdk/sdk_client_test.go
+++ b/blobstore/sdk/sdk_client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cubefs/cubefs/blobstore/access/stream"
 	acapi "github.com/cubefs/cubefs/blobstore/api/access"
 	"github.com/cubefs/cubefs/blobstore/api/shardnode"
+	"github.com/cubefs/cubefs/blobstore/cmd"
 	"github.com/cubefs/cubefs/blobstore/common/codemode"
 	errcode "github.com/cubefs/cubefs/blobstore/common/errors"
 	"github.com/cubefs/cubefs/blobstore/common/proto"
@@ -36,7 +37,7 @@ func newSdkHandler(t *testing.T) *sdkHandler {
 		NameRps: map[string]int{"alloc": 2},
 	})
 
-	conf := Config{LogLevel: log.Lpanic}
+	conf := Config{LogConf: cmd.LogConfig{Level: log.Lpanic}}
 	fixConfig(&conf)
 	return &sdkHandler{
 		handler: h,


### PR DESCRIPTION
This commit adds support for logging to a file in the blobstore sdk client,
allowing configuration of log file path, level, and size.
    
close: #3862
    
Signed-off-by: yanghonggang <yanghonggang_yewu@cmss.chinamobile.com>
Signed-off-by: zhangjianwei2 <zhangjianwei2_yewu@cmss.chinamobile.com>

