### PR TITLE
feat(volume): implement UUID-based idempotency for volume creation

### DIFF
--- a/master/api_args_parse.go
+++ b/master/api_args_parse.go
@@ -771,6 +771,8 @@ type createVolReq struct {
 	flashNodeTimeoutCount        int64
 	remoteCacheSameZoneTimeout   int64
 	remoteCacheSameRegionTimeout int64
+	// idempotency check
+	createUUID string
 }
 
 func parseColdArgs(r *http.Request) (args coldVolArgs, err error) {
@@ -1023,6 +1025,9 @@ func parseRequestToCreateVol(r *http.Request, req *createVolReq) (err error) {
 	if req.remoteCacheSameRegionTimeout, err = extractInt64WithDefault(r, remoteCacheSameRegionTimeout, proto.DefaultRemoteCacheSameRegionTimeout); err != nil {
 		return
 	}
+
+	// parse idempotency check
+	req.createUUID = extractStrWithDefault(r, "createUUID", "")
 	return
 }
 

--- a/master/gapi_volume.go
+++ b/master/gapi_volume.go
@@ -173,7 +173,7 @@ func (s *VolumeService) volPermission(ctx context.Context, args struct {
 }
 
 func (s *VolumeService) createVolume(ctx context.Context, args struct {
-	Name, Owner, ZoneName, Description                          string
+	Name, Owner, ZoneName, Description, CreateUUID              string
 	Capacity, DataPartitionSize, MpCount, DpCount, DpReplicaNum uint64
 	FollowerRead, Authenticate, CrossZone, DefaultPriority      bool
 	iopsRLimit, iopsWLimit, flowRlimit, flowWlimit              uint64
@@ -214,6 +214,7 @@ func (s *VolumeService) createVolume(ctx context.Context, args struct {
 		normalZonesFirst: args.DefaultPriority,
 		zoneName:         args.ZoneName,
 		description:      args.Description,
+		createUUID:       args.CreateUUID,
 	}
 	vol, err := s.cluster.createVol(req)
 	if err != nil {

--- a/master/metadata_fsm_op.go
+++ b/master/metadata_fsm_op.go
@@ -396,6 +396,7 @@ type volValue struct {
 	FlashNodeTimeoutCount        int64
 	RemoteCacheSameZoneTimeout   int64
 	RemoteCacheSameRegionTimeout int64
+	CreateUUID                   string // idempotency check
 }
 
 func (v *volValue) Bytes() (raw []byte, err error) {
@@ -484,6 +485,7 @@ func newVolValue(vol *Vol) (vv *volValue) {
 		FlashNodeTimeoutCount:        vol.flashNodeTimeoutCount,
 		RemoteCacheSameZoneTimeout:   vol.remoteCacheSameZoneTimeout,
 		RemoteCacheSameRegionTimeout: vol.remoteCacheSameRegionTimeout,
+		CreateUUID:                   vol.CreateUUID,
 	}
 	vv.AllowedStorageClass = make([]uint32, len(vol.allowedStorageClass))
 	copy(vv.AllowedStorageClass, vol.allowedStorageClass)

--- a/master/vol.go
+++ b/master/vol.go
@@ -150,6 +150,7 @@ type Vol struct {
 	createTime    int64
 	description   string
 	TrashInterval int64
+	CreateUUID    string // idempotency check
 
 	dpReplicaNum      uint8
 	mpReplicaNum      uint8
@@ -252,6 +253,7 @@ func newVol(vv volValue) (vol *Vol) {
 	vol.flashNodeTimeoutCount = vv.FlashNodeTimeoutCount
 	vol.remoteCacheSameZoneTimeout = vv.RemoteCacheSameZoneTimeout
 	vol.remoteCacheSameRegionTimeout = vv.RemoteCacheSameRegionTimeout
+	vol.CreateUUID = vv.CreateUUID
 
 	limitQosVal := &qosArgs{
 		qosEnable:     vv.VolQosEnable,

--- a/sdk/graphql/client/volume/client.go
+++ b/sdk/graphql/client/volume/client.go
@@ -76,9 +76,9 @@ type SimpleVolView struct {
 }
 
 // function begin .....
-func (c *VolumeClient) CreateVolume(ctx context.Context, authenticate bool, capacity uint64, crossZone bool, dataPartitionSize uint64, description string, dpReplicaNum uint64, enableToken bool, followerRead bool, mpCount uint64, dpCount uint64, name string, owner string, zoneName string) (*Vol, error) {
-	req := client.NewRequest(ctx, `mutation($authenticate: bool, $capacity: uint64, $crossZone: bool, $dataPartitionSize: uint64, $description: string, $dpReplicaNum: uint64, $enableToken: bool, $followerRead: bool, $mpCount: uint64, $dpCount: uint64, $name: string, $owner: string, $zoneName: string){
-			createVolume(authenticate: $authenticate, capacity: $capacity, crossZone: $crossZone, dataPartitionSize: $dataPartitionSize, description: $description, dpReplicaNum: $dpReplicaNum, enableToken: $enableToken, followerRead: $followerRead, mpCount: $mpCount, dpCount: $dpCount, name: $name, owner: $owner, zoneName: $zoneName){
+func (c *VolumeClient) CreateVolume(ctx context.Context, authenticate bool, capacity uint64, crossZone bool, dataPartitionSize uint64, description string, dpReplicaNum uint64, enableToken bool, followerRead bool, mpCount uint64, dpCount uint64, name string, owner string, zoneName string, createUUID string) (*Vol, error) {
+	req := client.NewRequest(ctx, `mutation($authenticate: bool, $capacity: uint64, $crossZone: bool, $dataPartitionSize: uint64, $description: string, $dpReplicaNum: uint64, $enableToken: bool, $followerRead: bool, $mpCount: uint64, $dpCount: uint64, $name: string, $owner: string, $zoneName: string, $createUUID: string){
+			createVolume(authenticate: $authenticate, capacity: $capacity, crossZone: $crossZone, dataPartitionSize: $dataPartitionSize, description: $description, dpReplicaNum: $dpReplicaNum, enableToken: $enableToken, followerRead: $followerRead, mpCount: $mpCount, dpCount: $dpCount, name: $name, owner: $owner, zoneName: $zoneName, createUUID: $createUUID){
 				capacity
 				createTime
 				dpReplicaNum
@@ -135,6 +135,7 @@ func (c *VolumeClient) CreateVolume(ctx context.Context, authenticate bool, capa
 	req.Var("name", name)
 	req.Var("owner", owner)
 	req.Var("zoneName", zoneName)
+	req.Var("createUUID", createUUID)
 
 	rep, err := c.Query(ctx, "/api/volume", req)
 	if err != nil {

--- a/sdk/master/api_admin.go
+++ b/sdk/master/api_admin.go
@@ -413,7 +413,7 @@ func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, delet
 	clientIDKey string, volStorageClass uint32, allowedStorageClass string, optMetaFollowerRead string, optMaximallyRead string,
 	remoteCacheEnable string, remoteCacheAutoPrepare string, remoteCachePath string, remoteCacheTTL int64, remoteCacheReadTimeout int64,
 	remoteCacheMaxFileSizeGB int64, remoteCacheOnlyForNotSSD string, remoteCacheMultiRead string, flashNodeTimeoutCount int64,
-	remoteCacheSameZoneTimeout int64, remoteCacheSameRegionTimeout int64,
+	remoteCacheSameZoneTimeout int64, remoteCacheSameRegionTimeout int64, createUUID string,
 ) (err error) {
 	request := newRequest(get, proto.AdminCreateVol).Header(api.h)
 	request.addParam("name", volName)
@@ -448,6 +448,7 @@ func (api *AdminAPI) CreateVolName(volName, owner string, capacity uint64, delet
 	request.addParamAny("flashNodeTimeoutCount", flashNodeTimeoutCount)
 	request.addParamAny("remoteCacheSameZoneTimeout", remoteCacheSameZoneTimeout)
 	request.addParamAny("remoteCacheSameRegionTimeout", remoteCacheSameRegionTimeout)
+	request.addParam("createUUID", createUUID)
 
 	if txMask != "" {
 		request.addParam("enableTxMask", txMask)


### PR DESCRIPTION
- Add getVolByUUID function to find volumes by UUID
- Implement idempotency check in createVol with volume name and owner validation
- Add createUUID parameter support in volume creation APIs
- Add comprehensive test cases for idempotency functionality
- Update CLI, GraphQL client, and admin API to support createUUID parameter

This ensures that volume creation requests with the same UUID return the existing volume only when all key parameters (name, owner) match, preventing security issues and naming conflicts.

close: #3877

<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #3877 

<!-- or this PR is one task of an issue. -->

Main Issue: #3877 


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Ensures that volume creation requests with the same UUID return the existing volume only when all key parameters (name, owner) match, preventing security issues and naming conflicts.

### Modifications
<!-- Describe the modifications you've done. -->

``` text
- Add getVolByUUID function to find volumes by UUID
- Implement idempotency check in createVol with volume name and owner validation
- Add createUUID parameter support in volume creation APIs
- Add comprehensive test cases for idempotency functionality
- Update CLI, GraphQL client, and admin API to support createUUID parameter
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [x] Make sure that the change passes the testing checks.

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [x] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [x] Client
- [x] Cli
- [x] SDK
- [ ] Other Tools
- [ ] Common Packages
- [x] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: https://github.com/cubefs/cubefs/pull/3924

<!-- Thanks for contributing, best days! -->
