### PR TITLE
fix(common): optimize span track log format and unit of time

### DIFF
--- a/blobstore/blobnode/core/chunk/chunk.go
+++ b/blobstore/blobnode/core/chunk/chunk.go
@@ -540,8 +540,8 @@ func (cs *chunk) rangeRead(ctx context.Context, stg core.Storage, s *core.Shard,
 	default:
 	}
 	n, err = io.CopyN(tw, tr, int64(to-from))
-	span.AppendTrackLogWithDuration("net.w", tw.Duration(), err)
-	span.AppendTrackLogWithDuration("dat.r", tr.Duration(), err)
+	span.AppendTrackLogWithDuration("net.w", tw.Duration(), err, trace.OptSpanDurationUs())
+	span.AppendTrackLogWithDuration("dat.r", tr.Duration(), err, trace.OptSpanDurationUs())
 	if err != nil {
 		return n, err
 	}

--- a/blobstore/blobnode/core/storage/datafile.go
+++ b/blobstore/blobnode/core/storage/datafile.go
@@ -347,9 +347,9 @@ func (cd *datafile) Write(ctx context.Context, shard *core.Shard) (err error) {
 	encoder := crc32block.NewSizedBlockEncoder(io.NopCloser(body), int64(shard.Size), core.CrcBlockUnitSize)
 	defer func() {
 		encoder.Close()
-		span.AppendTrackLogWithDuration("net.r", tr.Duration(), err)
-		span.AppendTrackLogWithDuration("dat.w", twRaw.Duration(), err)
-		span.AppendTrackLogWithDuration("dat.wai", tw.Duration()-twRaw.Duration(), err)
+		span.AppendTrackLogWithDuration("net.r", tr.Duration(), err, trace.OptSpanDurationUs())
+		span.AppendTrackLogWithDuration("dat.w", twRaw.Duration(), err, trace.OptSpanDurationUs())
+		span.AppendTrackLogWithDuration("dat.wai", tw.Duration()-twRaw.Duration(), err, trace.OptSpanDurationUs())
 	}()
 
 	// fill header
@@ -459,7 +459,7 @@ func (cd *datafile) Delete(ctx context.Context, shard *core.Shard) (err error) {
 		defer bytespool.Free(buf) // nolint: staticcheck
 
 		_, err = cd.ef.ReadAt(buf, shard.Offset)
-		span.AppendTrackLog("hdr.r", start, err) // cost time: read header
+		span.AppendTrackLog("hdr.r", start, err, trace.OptSpanDurationUs()) // cost time: read header
 
 		if err != nil {
 			return err
@@ -485,7 +485,7 @@ func (cd *datafile) Delete(ctx context.Context, shard *core.Shard) (err error) {
 	discardSize = core.Alignphysize(int64(shard.Size))
 	discardSize = core.AlignSize(discardSize, _pageSize)
 	err = cd.ef.Discard(shard.Offset, discardSize)
-	span.AppendTrackLog("dat.d", start, err) // cost time: Discard(PunchHole)
+	span.AppendTrackLog("dat.d", start, err, trace.OptSpanDurationUs()) // cost time: Discard(PunchHole)
 
 	return err
 }

--- a/blobstore/blobnode/core/storage/metadb.go
+++ b/blobstore/blobnode/core/storage/metadb.go
@@ -119,7 +119,7 @@ func (cm *metafile) writeData(ctx context.Context, Key []byte, Value []byte) err
 	start := time.Now()
 
 	err := cm.db.Put(ctx, kv)
-	span.AppendTrackLog("md.w", start, err)
+	span.AppendTrackLog("md.w", start, err, trace.OptSpanDurationUs())
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (cm *metafile) readData(ctx context.Context, Key []byte) (data []byte, err 
 	start := time.Now()
 
 	data, err = cm.db.Get(ctx, Key)
-	span.AppendTrackLog("md.r", start, err)
+	span.AppendTrackLog("md.r", start, err, trace.OptSpanDurationUs())
 	if err != nil {
 		return
 	}
@@ -146,7 +146,7 @@ func (cm *metafile) deleteKey(ctx context.Context, Key []byte) (err error) {
 	start := time.Now()
 
 	err = cm.db.Delete(ctx, Key)
-	span.AppendTrackLog("md.d", start, err)
+	span.AppendTrackLog("md.d", start, err, trace.OptSpanDurationUs())
 	if err != nil {
 		return
 	}

--- a/blobstore/blobnode/core/storage/storage_cp.go
+++ b/blobstore/blobnode/core/storage/storage_cp.go
@@ -203,7 +203,7 @@ func (stg *replicateStorage) SyncData(ctx context.Context) (err error) {
 	go func() {
 		span := trace.SpanFromContextSafe(ctx)
 		innerErr := stg.slaveStg.SyncData(ctx)
-		span.AppendTrackLog("sync.2", start, innerErr)
+		span.AppendTrackLog("sync.2", start, innerErr, trace.OptSpanDurationUs())
 		fwdCh <- innerErr
 	}()
 
@@ -222,7 +222,7 @@ func (stg *replicateStorage) SyncData(ctx context.Context) (err error) {
 	}()
 
 	err = stg.masterStg.SyncData(ctx)
-	span.AppendTrackLog("sync.1", start, err)
+	span.AppendTrackLog("sync.1", start, err, trace.OptSpanDurationUs())
 
 	return err
 }

--- a/blobstore/blobnode/shard.go
+++ b/blobstore/blobnode/shard.go
@@ -522,7 +522,7 @@ func (s *Service) ShardPut(c *rpc.Context) {
 
 	start := time.Now()
 	err = cs.Write(ctx, shard)
-	span.AppendTrackLog("disk.put", start, err)
+	span.AppendTrackLog("disk.put", start, err, trace.OptSpanDurationUs())
 	if err != nil {
 		span.Errorf("Failed to put shard, args: %+v, err: %v", args, err)
 		c.RespondError(err)
@@ -533,7 +533,7 @@ func (s *Service) ShardPut(c *rpc.Context) {
 	if !shard.Inline {
 		start = time.Now()
 		err = cs.SyncData(ctx)
-		span.AppendTrackLog("sync", start, err)
+		span.AppendTrackLog("sync", start, err, trace.OptSpanDurationUs())
 		if err != nil {
 			span.Errorf("Failed to sync shard, args: %+v, err: %v", args, err)
 			c.RespondError(err)

--- a/blobstore/common/trace/span.go
+++ b/blobstore/common/trace/span.go
@@ -273,7 +273,7 @@ func (s *spanImpl) AppendTrackLogWithDuration(module string, duration time.Durat
 
 	if spanOpt.duration == durationAny {
 		module += ":" + duration.String()
-	} else if dur := spanOpt.duration.Value(duration); dur > 0 {
+	} else if dur := spanOpt.duration.Value(duration); dur >= 0 {
 		module += ":" + strconv.FormatInt(dur, 10)
 		if spanOpt.durationUnit {
 			module += spanOpt.duration.Unit(duration)

--- a/blobstore/common/trace/span_test.go
+++ b/blobstore/common/trace/span_test.go
@@ -176,29 +176,29 @@ func TestSpan_TrackLog(t *testing.T) {
 	span, ctx := StartSpanFromContext(context.Background(), "test trackLog")
 	defer span.Finish()
 
-	span.AppendTrackLog("sleep", time.Now(), nil)
-	require.Equal(t, []string{"sleep"}, span.TrackLog())
+	span.AppendTrackLog("sleep", time.Now(), nil, OptSpanDurationSecond())
+	require.Equal(t, []string{"sleep:0"}, span.TrackLog())
 
 	spanChild, _ := StartSpanFromContext(ctx, "child of span")
-	require.Equal(t, []string{"sleep"}, spanChild.TrackLog())
+	require.Equal(t, []string{"sleep:0"}, spanChild.TrackLog())
 
-	spanChild.AppendTrackLog("sleep2", time.Now(), errors.New("sleep2 err"))
-	require.Equal(t, []string{"sleep", "sleep2/sleep2 err"}, spanChild.TrackLog())
-	require.Equal(t, []string{"sleep", "sleep2/sleep2 err"}, span.TrackLog())
+	spanChild.AppendTrackLog("sleep2", time.Now(), errors.New("sleep2 err"), OptSpanDurationSecond())
+	require.Equal(t, []string{"sleep:0", "sleep2:0/sleep2 err"}, spanChild.TrackLog())
+	require.Equal(t, []string{"sleep:0", "sleep2:0/sleep2 err"}, span.TrackLog())
 
 	spanChild.AppendRPCTrackLog([]string{"blobnode:4", "scheduler:5"})
-	require.Equal(t, []string{"sleep", "sleep2/sleep2 err", "blobnode:4", "scheduler:5"}, spanChild.TrackLog())
-	require.Equal(t, []string{"sleep", "sleep2/sleep2 err", "blobnode:4", "scheduler:5"}, span.TrackLog())
+	require.Equal(t, []string{"sleep:0", "sleep2:0/sleep2 err", "blobnode:4", "scheduler:5"}, spanChild.TrackLog())
+	require.Equal(t, []string{"sleep:0", "sleep2:0/sleep2 err", "blobnode:4", "scheduler:5"}, span.TrackLog())
 
-	spanChild.AppendTrackLog("sleep3", time.Now(), nil)
-	require.Equal(t, []string{"sleep", "sleep2/sleep2 err", "blobnode:4", "scheduler:5", "sleep3"}, span.TrackLog())
+	spanChild.AppendTrackLog("sleep3", time.Now(), nil, OptSpanDurationSecond())
+	require.Equal(t, []string{"sleep:0", "sleep2:0/sleep2 err", "blobnode:4", "scheduler:5", "sleep3:0"}, span.TrackLog())
 
 	msg := make([]byte, maxErrorLen+10)
 	for idx := range msg {
 		msg[idx] = 97
 	}
-	spanChild.AppendTrackLog("longError", time.Now(), errors.New(string(msg)))
-	except := "longError/" + string(msg[:maxErrorLen])
+	spanChild.AppendTrackLog("longError", time.Now(), errors.New(string(msg)), OptSpanDurationSecond())
+	except := "longError:0/" + string(msg[:maxErrorLen])
 	require.Equal(t, except, span.TrackLog()[len(span.TrackLog())-1])
 }
 


### PR DESCRIPTION
close #3922

fix(common): optimize span track log format and unit of time




<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #3922

<!-- or this PR is one task of an issue. -->

Main Issue: #3922


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

blaaaaa

### Modifications
<!-- Describe the modifications you've done. -->

# 2025-09-17 blobnode 分阶段延迟内容优化

## 问题

* 问题1：Trace-Log 中没有 net.r  dat.w dat.put 等阶段性延迟没有数值
* 问题2：Trace-Log 中各阶段的延迟的单位为毫秒，但是 duration 为微妙，时间单位没有对齐

## 优化前
```
{
  "req_type": "REQ",
  "module": "BLOBNODE",
  "start_time": 17581147227754708,
  "method": "POST",
  "path": "/shard/put/diskid/4/vuid/700163555329/bid/610079/size/307200",
  "req_header": {
    "Accept-Encoding": "gzip",
    "BodySize": 307200,
    "Content-Length": "307220",
    "Host": "127.0.0.2:8889",
    "IP": "127.0.0.1",
    "RawQuery": "iotype=0",
    "User-Agent": "bench/wip_zjw_stage_latency_cmain/7e119b9f9fece040659fc95a8b4ebb8d33a44b3d (linux/amd64; go1.21.13) zjw-redundancer-dev/223550",
    "X-Crc-Encoded": "1"
  },
  "req_params": "",
  "status_code": 200,
  "resp_header": {
    "Blobstore-Tracer-Traceid": "bench-p-37471e7b-685e-473c-b024-d4a0207103a1",
    "Content-Length": "18",
    "Content-Type": "application/json",
    "Trace-Log": [
      "net.r",  //没有数值
      "dat.w",  //没有数值
      "dat.wai",  //没有数值
      "md.w",  //没有数值
      "disk.put",  //没有数值
      "sync",  //没有数值
      "BLOBNODE:1" // 单位为毫秒
    ],
    "Trace-Tags": [
      "span.kind:server"
    ],
    "X-Ack-Crc-Encoded": "1"
  },
  "resp_body": "{\"crc\":2410861340}",
  "resp_length": 18,
  "duration": 1056  //单位为微妙
}
```

## 优化后

```
{
  "req_type": "REQ",
  "module": "BLOBNODE",
  "start_time": 17581147227754708,
  "method": "POST",
  "path": "/shard/put/diskid/4/vuid/700163555329/bid/610079/size/307200",
  "req_header": {
    "Accept-Encoding": "gzip",
    "BodySize": 307200,
    "Content-Length": "307220",
    "Host": "127.0.0.2:8889",
    "IP": "127.0.0.1",
    "RawQuery": "iotype=0",
    "User-Agent": "bench/wip_zjw_stage_latency_cmain/7e119b9f9fece040659fc95a8b4ebb8d33a44b3d (linux/amd64; go1.21.13) zjw-redundancer-dev/223550",
    "X-Crc-Encoded": "1"
  },
  "req_params": "",
  "status_code": 200,
  "resp_header": {
    "Blobstore-Tracer-Traceid": "bench-p-37471e7b-685e-473c-b024-d4a0207103a1",
    "Content-Length": "18",
    "Content-Type": "application/json",
    "Trace-Log": [
      "net.r:0",
      "dat.w:477",
      "dat.wai:8",
      "md.w:86",
      "disk.put:947",
      "sync:1",
      "BLOBNODE:1011"
    ],
    "Trace-Tags": [
      "span.kind:server"
    ],
    "X-Ack-Crc-Encoded": "1"
  },
  "resp_body": "{\"crc\":2410861340}",
  "resp_length": 18,
  "duration": 1056
}
```


### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [x] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
