### PR TITLE
fix(blobstore): adjust the log level for specific error types

### DIFF
--- a/blobstore/blobnode/base/util.go
+++ b/blobstore/blobnode/base/util.go
@@ -89,6 +89,34 @@ func IsEmptyDisk(filename string) (bool, error) {
 	return true, nil
 }
 
+func IsShardDeleted(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return os.IsNotExist(err) ||
+		err1.Is(err, errors.ErrNoSuchBid) ||
+		errors.DetectCode(err) == errors.CodeBidNotFound
+}
+
+func IsShardMarkDeleted(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return err1.Is(err, errors.ErrShardMarkDeleted) ||
+		errors.DetectCode(err) == errors.CodeShardMarkDeleted
+}
+
+func IsChunkCompacting(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return err1.Is(err, errors.ErrChunkInCompact) ||
+		errors.DetectCode(err) == errors.CodeChunkCompacting
+}
+
 // parse rangeStr to => [start, end]
 func ParseHttpRangeStr(rangeBytesStr string) (start int64, end int64, err error) {
 	pos := strings.Index(rangeBytesStr, "=")

--- a/blobstore/blobnode/core/chunk/chunk.go
+++ b/blobstore/blobnode/core/chunk/chunk.go
@@ -621,7 +621,11 @@ func (cs *chunk) MarkDelete(ctx context.Context, bid proto.BlobID) (err error) {
 
 	err = stg.MarkDelete(ctx, bid)
 	if err != nil {
-		span.Errorf("Failed mark delete: diskID:%d, vuid:%d, bid:%d, err:%v", cs.diskID, cs.vuid, bid, err)
+		if base.IsShardMarkDeleted(err) {
+			span.Warnf("Failed mark delete: diskID:%d, vuid:%d, bid:%d, err:%v", cs.diskID, cs.vuid, bid, err)
+		} else {
+			span.Errorf("Failed mark delete: diskID:%d, vuid:%d, bid:%d, err:%v", cs.diskID, cs.vuid, bid, err)
+		}
 		return err
 	}
 
@@ -649,7 +653,11 @@ func (cs *chunk) Delete(ctx context.Context, bid proto.BlobID) (err error) {
 
 	n, err := stg.Delete(ctx, bid)
 	if err != nil {
-		span.Errorf("Failed delete: diskID:%d, vuid:%d, bid:%d, err:%v", cs.diskID, cs.vuid, bid, err)
+		if base.IsShardDeleted(err) {
+			span.Warnf("Failed delete: diskID:%d, vuid:%d, bid:%d, err:%v", cs.diskID, cs.vuid, bid, err)
+		} else {
+			span.Errorf("Failed delete: diskID:%d, vuid:%d, bid:%d, err:%v", cs.diskID, cs.vuid, bid, err)
+		}
 		return err
 	}
 

--- a/blobstore/blobnode/core/storage/storage.go
+++ b/blobstore/blobnode/core/storage/storage.go
@@ -23,6 +23,7 @@ import (
 
 	bnapi "github.com/cubefs/cubefs/blobstore/api/blobnode"
 	"github.com/cubefs/cubefs/blobstore/api/clustermgr"
+	"github.com/cubefs/cubefs/blobstore/blobnode/base"
 	"github.com/cubefs/cubefs/blobstore/blobnode/core"
 	bloberr "github.com/cubefs/cubefs/blobstore/common/errors"
 	"github.com/cubefs/cubefs/blobstore/common/proto"
@@ -148,7 +149,11 @@ func (stg *storage) Delete(ctx context.Context, bid proto.BlobID) (n int64, err 
 
 	shardMeta, err := meta.Read(ctx, bid)
 	if err != nil {
-		span.Errorf("Failed: shard:%v read err:%v", bid, err)
+		if base.IsShardDeleted(err) {
+			span.Warnf("Failed: shard:%v read err:%v", bid, err)
+		} else {
+			span.Errorf("Failed: shard:%v read err:%v", bid, err)
+		}
 		return n, err
 	}
 

--- a/blobstore/blobnode/shard.go
+++ b/blobstore/blobnode/shard.go
@@ -455,7 +455,11 @@ func (s *Service) ShardMarkdelete(c *rpc.Context) {
 	err := cs.MarkDelete(ctx, args.Bid)
 	if err != nil {
 		err = handlerBidNotFoundErr(err)
-		span.Errorf("Failed to mark delete, args:%+v err:%v", args, err)
+		if base.IsShardMarkDeleted(err) || base.IsShardDeleted(err) || base.IsChunkCompacting(err) {
+			span.Warnf("Failed to mark delete, args:%+v err:%v", args, err)
+		} else {
+			span.Errorf("Failed to mark delete, args:%+v err:%v", args, err)
+		}
 		c.RespondError(err)
 		return
 	}
@@ -530,7 +534,11 @@ func (s *Service) ShardDelete(c *rpc.Context) {
 	err = cs.Delete(ctx, args.Bid)
 	if err != nil {
 		err = handlerBidNotFoundErr(err)
-		span.Errorf("Failed to delete, args:%+v, err:%v", args, err)
+		if base.IsShardDeleted(err) || base.IsChunkCompacting(err) {
+			span.Warnf("Failed to delete, args:%+v, err:%v", args, err)
+		} else {
+			span.Errorf("Failed to delete, args:%+v, err:%v", args, err)
+		}
 		c.RespondError(err)
 		return
 	}


### PR DESCRIPTION
adjust the log level to reduce unnecessary log output

<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #xyz

<!-- or this PR is one task of an issue. -->

Main Issue: #xyz


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

During our test, a large number of logs were printed as follows:

case1: delete a blob that no longer exists:

```text
grep blobstore/blobnode/shard.go:443 blobnode_8891.log | grep 'err:bid not found' | wc -l [error]
300295
grep blobstore/blobnode/core/chunk/chunk.go:595 blobnode_8891.log |grep 'err:file does not exist' | wc -l [error]
300295
grep blobstore/blobnode/core/storage/storage.go:146 blobnode_8891.log |grep 'err:file does not exist' | wc -l [error]
300295
```

case2: delete a compacting blob:

```text
grep 'blobstore/blobnode/shard.go:360' blobnode_8891.log | grep 'err:chunk is compacting' | wc -l [error]
760169
grep blobstore/blobnode/shard.go:443 blobnode_8891.log | grep 'err:chunk is compacting' | wc -l [error]
76627
```

case3: markdelete a already marked blob:

```text
grep 'blobstore/blobnode/shard.go:360' blobnode_8891.log | grep 'shard already mark delete' | wc -l [error]
1504040
grep blobstore/blobnode/core/chunk/chunk.go:567 blobnode_8891.log | grep 'shard already mark delete' | wc -l  [error]
1504040
```


We believe that these are not system errors, so we reduce the amount of printing by adjusting the log level.

### Modifications
<!-- Describe the modifications you've done. -->

``` text
blaaaaa
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Log Level

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
