### PR TITLE
feat(blobstore): supports mounting meta directories separately for each disk

### DIFF
--- a/blobstore/blobnode/core/disk/disk.go
+++ b/blobstore/blobnode/core/disk/disk.go
@@ -953,9 +953,15 @@ func newDiskStorage(ctx context.Context, conf core.Config) (ds *DiskStorage, err
 			return nil, errors.New("must mount point")
 		}
 
-		if metaRoot != "" && !myos.IsMountPoint(metaRoot) {
-			span.Errorf("%s must mount point.", metaRoot)
-			return nil, errors.New("must mount point")
+		if metaRoot != "" {
+			checkPath := metaRoot
+			if conf.MetaPreDisk {
+				checkPath = filepath.Join(metaRoot, path)
+			}
+			if !myos.IsMountPoint(checkPath) {
+				span.Errorf("%s must mount point.", checkPath)
+				return nil, errors.New("must mount point")
+			}
 		}
 	}
 

--- a/blobstore/blobnode/db/config.go
+++ b/blobstore/blobnode/db/config.go
@@ -20,6 +20,7 @@ const (
 
 type MetaConfig struct {
 	MetaRootPrefix     string `json:"meta_root_prefix"`
+	MetaPreDisk        bool   `json:"meta_pre_disk"`
 	SupportInline      bool   `json:"support_inline"`
 	TinyFileThresholdB int    `json:"tinyfile_threshold_B"`
 	Sync               bool   `json:"sync"`


### PR DESCRIPTION
supports mounting meta directories separately for each disk

<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #xyz

<!-- or this PR is one task of an issue. -->

Main Issue: #xyz


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Currently, the meta_root_prefix setting is used to specify a unified metadata directory prefix. All disks then create their own metadata directories under this prefix. If the disk mounted to the meta_root_prefix fails (you can use multiple disks in a RAID configuration, but this introduces additional complexity), the metadata for all disks will become unavailable. Therefore, we implement a unique metadata mount directory for each disk using the following steps:

1. Create a directory named meta_root_prefix+disk_path in the system and mount it to the corresponding SSD (or SSD partition).
2. Set meta_root_prefix.
3. Set must_mount_point to false.

The actual deployment is as follows (the metadata directory is quite long):

```Shell
[root@localhost ~]# df -h | grep blobnode
/dev/sdy                 7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk1
/dev/sde1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk1
/dev/sdz                 7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk2
/dev/sde2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk2
/dev/sdaa                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk3
/dev/sde3                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk3
/dev/sdab                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk4
/dev/sdf1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk4
/dev/sdac                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk5
/dev/sdf2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk5
/dev/sdad                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk6
/dev/sdf3                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk6
/dev/sdae                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk7
/dev/sdg1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk7
/dev/sdaf                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk8
/dev/sdg2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk8
/dev/sdag                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk9
/dev/sdg3                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk9
/dev/sdah                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk10
/dev/sdh1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk10
/dev/sdai                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk11
/dev/sdh2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk11
[root@localhost ~]#
```

Since meta_root_prefix is not a mount point, setting must_mount_point to false is the only way to ensure service startup. This can cause other issues in a production environment and is undesirable.

Therefore, the meta_pre_disk option is added to indicate whether to mount a metadata directory for each disk separately. If not configured in the configuration file, the default value is false to maintain forward compatibility. If set to true, the check for mount points will be changed to meta_root_prefix+disk_path.

### Modifications
<!-- Describe the modifications you've done. -->

``` text
blaaaaa
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
