### PR TITLE
feat(blobstore): supports mounting meta directories separately for each disk

### DIFF
--- a/blobstore/blobnode/core/config.go
+++ b/blobstore/blobnode/core/config.go
@@ -84,6 +84,7 @@ type RuntimeConfig struct {
 	AllowCleanTrash              bool    `json:"allow_clean_trash"`
 	DisableModifyInCompacting    bool    `json:"disable_modify_in_compacting"`
 	MustMountPoint               bool    `json:"must_mount_point"`
+	MustMountPointMeta           bool    `json:"must_mount_point_meta"`
 	IOStatFileDryRun             bool    `json:"iostat_file_dryrun"`
 	SetDefaultSwitch             bool    `json:"set_default_switch"`
 	EnableDeleteShardVerify      bool    `json:"enable_delete_shard_verify"`

--- a/blobstore/blobnode/core/disk/disk.go
+++ b/blobstore/blobnode/core/disk/disk.go
@@ -949,13 +949,26 @@ func newDiskStorage(ctx context.Context, conf core.Config) (ds *DiskStorage, err
 
 	if conf.MustMountPoint {
 		if !myos.IsMountPoint(conf.Path) {
-			span.Errorf("%s must mount point.", conf.Path)
-			return nil, errors.New("must mount point")
+			span.Errorf("%s must be a mount point.", conf.Path)
+			return nil, errors.New("must be a mount point")
+		}
+	}
+
+	// If metaRoot is not configured, the meta directory will be
+	// created under conf.Path, no need to check.
+	if metaRoot != "" {
+		// First check whether the metadata space is mounted separately for each disk,
+		// and then check whether the metadata space is mounted together for all disks.
+		checkPath := ""
+		if conf.MustMountPointMeta {
+			checkPath = filepath.Join(metaRoot, path)
+		} else if conf.MustMountPoint {
+			checkPath = metaRoot
 		}
 
-		if metaRoot != "" && !myos.IsMountPoint(metaRoot) {
-			span.Errorf("%s must mount point.", metaRoot)
-			return nil, errors.New("must mount point")
+		if checkPath != "" && !myos.IsMountPoint(checkPath) {
+			span.Errorf("%s must be a mount point.", checkPath)
+			return nil, errors.New("must be a mount point")
 		}
 	}
 

--- a/docs-zh/source/ops/configs/blobstore/blobnode.md
+++ b/docs-zh/source/ops/configs/blobstore/blobnode.md
@@ -67,6 +67,7 @@ BlobNode的配置是基于[公有配置](./base.md)，以下配置说明主要�
 		"metric_report_interval_S": "metric上报的定时任务周期",
 		"set_default_switch": "是否默认设置开关.建议该项填true,会设置need_compact_check,allow_force_compact,allow_clean_trash",
 		"must_mount_point": "数据存放目录是否强制是挂载点",
+		"must_mount_point_meta": "如果配置了 meta_root_prefix，开启 must_mount_point_meta 后会检查每个磁盘的元数据目录是否为挂载点，默认值 false",
 		"write_thread_cnt": "限制写线程个数, 默认值4",
 		"read_thread_cnt": "限制读线程个数, 默认值4",
 		"delete_thread_cnt": "限制删线程个数, 默认值1",

--- a/docs/source/ops/configs/blobstore/blobnode.md
+++ b/docs/source/ops/configs/blobstore/blobnode.md
@@ -68,9 +68,10 @@ BlobNode configuration is based on the [public configuration](./base.md), and th
     "metric_report_interval_S": "interval for metric reporting",
     "set_default_switch": "whether to set switch.suggest you set it to true,will set: need_compact_check,allow_force_compact,allow_clean_trash",
     "must_mount_point": "whether the data storage directory must be a mount point",
-    "write_thread_cnt": "limit the number of write threads，default 4",
-    "read_thread_cnt": "limit the number of read threads，default 4",
-    "delete_thread_cnt": "limit the number of delete threads，default 1",
+    "must_mount_point_meta": "if meta_root_prefix is ​​configured, turning on must_mount_point_meta will check if the metadata directory of each disk is a mount point, default false",
+    "write_thread_cnt": "limit the number of write threads, default 4",
+    "read_thread_cnt": "limit the number of read threads, default 4",
+    "delete_thread_cnt": "limit the number of delete threads, default 1",
     "data_qos": {
       "read_mbps": "per disk normal read IO bandwidth",
       "write_mbps": "per disk normal write IO bandwidth",


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->


<!-- or this PR is one task of an issue. -->


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

Currently, the meta_root_prefix setting is used to specify a unified metadata directory prefix. All disks then create their own metadata directories under this prefix. If the disk mounted to the meta_root_prefix fails (you can use multiple disks in a RAID configuration, but this introduces additional complexity), the metadata for all disks will become unavailable. Therefore, we implement a unique metadata mount directory for each disk using the following steps:

1. Create a directory named meta_root_prefix+disk_path in the system and mount it to the corresponding SSD (or SSD partition).
2. Set meta_root_prefix.
3. Set must_mount_point to false.

The actual deployment is as follows (the metadata directory is quite long):

```Shell
[root@localhost ~]# df -h | grep blobnode
/dev/sdy                 7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk1
/dev/sde1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk1
/dev/sdz                 7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk2
/dev/sde2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk2
/dev/sdaa                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk3
/dev/sde3                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk3
/dev/sdab                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk4
/dev/sdf1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk4
/dev/sdac                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk5
/dev/sdf2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk5
/dev/sdad                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk6
/dev/sdf3                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk6
/dev/sdae                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk7
/dev/sdg1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk7
/dev/sdaf                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk8
/dev/sdg2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk8
/dev/sdag                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk9
/dev/sdg3                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk9
/dev/sdah                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk10
/dev/sdh1                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk10
/dev/sdai                7.3T   44K  6.9T   1% /var/lib/redundancer/blobnode/data/disk11
/dev/sdh2                293G  4.4M  278G   1% /var/lib/redundancer/blobnode/meta/var/lib/redundancer/blobnode/data/disk11
[root@localhost ~]#
```

Since meta_root_prefix is not a mount point, setting must_mount_point to false is the only way to ensure service startup. This can cause other issues in a production environment and is undesirable.

Therefore, the must_mount_point_meta option is added to indicate whether to mount a metadata directory for each disk separately. If not configured in the configuration file, the default value is false to maintain forward compatibility. If set to true, the check for mount points will be changed to meta_root_prefix+disk_path.


如果配置了 meta_root_prefix，那么 meta 的实际路径是 meta_root_prefix+data_path，但是 must_mount_point 检查挂载点是检查的 meta_root_prefix，所以如果一个大的 ssd 空间保存所有 disk 的 meta 是没问题的。但如果为每个磁盘单独挂载 meta 目录就会有挂载点检查的问题，因为这种情况下，实际的挂载点是 meta_root_prefix+data_path。


### Modifications
<!-- Describe the modifications you've done. -->

The must_mount_point_meta option is added to indicate whether to mount a metadata directory for each disk separately. If not configured in the configuration file, the default value is false to maintain forward compatibility. If set to true, the check for mount points will be changed to meta_root_prefix+disk_path.

增加 must_mount_point_meta 选项用于区分是否为每个磁盘的元数据目录配置挂载点。如果未设置该选项或设置为 false，那么所有逻辑不变，保持向前兼容；如果设置为 true，在配置了 meta_root_prefix 的情况下，会检查 meta_root_prefix+data_path 是不是挂载点（不配置 meta_root_prefix 的话所有元数据在 disk_path 下创建，无需单独检查）

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [x] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
