### PR TITLE
fix(blobstore): still sleeps and waits when configured to delete immediately

### DIFF
--- a/blobstore/scheduler/blob_deleter.go
+++ b/blobstore/scheduler/blob_deleter.go
@@ -509,7 +509,7 @@ func (mgr *BlobDeleteMgr) consume(item *delBlobRet, consumerPause base.ConsumerP
 		}
 	}
 	now := time.Now().UTC()
-	if now.Sub(time.Unix(item.delMsg.Time, 0)) < mgr.safeDelayTime {
+	if mgr.safeDelayTime > 0 && now.Sub(time.Unix(item.delMsg.Time, 0)) < mgr.safeDelayTime {
 		sleepDuration := mgr.delayDuration(item.delMsg.Time)
 		span.Debugf("blob is protected: until[%+v], sleep[%+v]", time.Unix(item.delMsg.Time, 0).Add(mgr.safeDelayTime), sleepDuration)
 		ok := sleep(sleepDuration, consumerPause)


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

In our tests, the scheduler's blob_deleter configuration was as follows, where safe_delay_time_h was set to -1, indicating an intention to delete immediately. 

```Json
"blob_delete": {
    "batch_interval_s": 5,
    "delete_log": {
        "dir": "/var/log/scheduler/delete_log"
    },
    "delete_rate_per_second": 1500,
    "fail_task_pool_size": 30,
    "max_batch_size": 50,
    "message_punish_threshold": 3,
    "message_punish_time_m": 10,
    "safe_delay_time_h": -1,
    "task_pool_size": 100
}
```

However, the following warning log was generated:

```Text
2025/10/08 00:10:20.974549 [WARN] blobstore/scheduler/blob_deleter.go:525 [73005b0295963200_1adb831ccd2822a7:6613b1afb9729240] blob is protected: until[2025-10-08 00:10:21 +0000 UTC], sleep[25.466776ms]
```

It means that it was not deleted immediately but waited, the corresponding code is as follows: 

```Go
if now.Sub(time.Unix(item.delMsg.Time, 0)) < mgr.safeDelayTime {
	sleepDuration := mgr.delayDuration(item.delMsg.Time)
	span.Debugf("blob is protected: until[%+v], sleep[%+v]", time.Unix(item.delMsg.Time, 0).Add(mgr.safeDelayTime), sleepDuration)
}
```

Since safeDelayTime equals 0, it means that item.delMsg.Time exceeds the current system time by 25.466776ms (this difference may still exist even if NTP is configured).

Therefore, the change is to first determine if delayed deletion is configured, and then determine if a delay is needed.

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
