### PR TITLE
fix(master): expand quota id range to support more quota settings

### DIFF
--- a/master/id_allocator.go
+++ b/master/id_allocator.go
@@ -129,10 +129,10 @@ func (alloc *IDAllocator) restoreMaxQuotaID() {
 		panic(fmt.Sprintf("Failed to restore maxQuotaID,err:%v ", err.Error()))
 	}
 
-	if maxQuotaID > 0 && maxQuotaID <= math.MaxInt32 {
+	if maxQuotaID > 0 && maxQuotaID <= math.MaxUint32 {
 		alloc.quotaID = uint32(maxQuotaID)
 	} else {
-		alloc.quotaID = math.MaxInt32
+		alloc.quotaID = math.MaxUint32
 	}
 
 	log.LogInfof("action[restoreMaxCommonID] maxQuotaID[%v]", alloc.quotaID)


### PR DESCRIPTION
Fixes: quotaID is typed as uint32, yet its range is capped at MaxInt32, cutting the usable quota count in half.

### Modifications
<!-- Describe the modifications you've done. -->
The maximum value has been changed from MaxInt32 to MaxUint32.

### Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->
- [x] Master

### Documentation
<!-- Is there a chinese and english document modification? -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->
- [x] `in-two-days`