### PR TITLE
feat(blobnode): add enable_put_shard_verify in blobnode

### DIFF
--- a/blobstore/access/server.go
+++ b/blobstore/access/server.go
@@ -234,7 +234,7 @@ func (s *Service) Put(c *rpc.Context) {
 	}
 
 	rc := s.limiter.Reader(ctx, c.Request.Body)
-	loc, err := s.streamHandler.Put(ctx, rc, args.Size, hasherMap)
+	loc, err := s.streamHandler.Put(ctx, rc, args.Size, hasherMap, args.AssignClusterID, args.CodeMode)
 	if err != nil {
 		span.Error("stream put failed", errors.Detail(err))
 		c.RespondError(httpError(err))

--- a/blobstore/access/stream/codemode.go
+++ b/blobstore/access/stream/codemode.go
@@ -43,3 +43,22 @@ func (c CodeModePairs) SelectCodeMode(size int64) codemode.CodeMode {
 
 	panic(fmt.Sprintf("no codemode policy to be selected by size %d, %+v", size, c))
 }
+
+// Verify select codemode
+func (c CodeModePairs) VerifySelectCodeMode(selectCodeMode codemode.CodeMode) bool {
+	if !selectCodeMode.IsValid() {
+		return false
+	}
+
+	for codeMode, pair := range c {
+		policy := pair.Policy
+		if !policy.Enable {
+			continue
+		}
+		if selectCodeMode == codeMode {
+			return true
+		}
+	}
+
+	return false
+}

--- a/blobstore/access/stream/stream.go
+++ b/blobstore/access/stream/stream.go
@@ -74,7 +74,9 @@ type StreamHandler interface {
 	// Put put one object
 	//     required: size, file size
 	//     optional: hasher map to calculate hash.Hash
-	Put(ctx context.Context, rc io.Reader, size int64, hasherMap access.HasherMap) (*proto.Location, error)
+	//     optional: code to specify codemode and not choose codemode by size
+	Put(ctx context.Context, rc io.Reader, size int64, hasherMap access.HasherMap,
+		assignClusterID proto.ClusterID, codeMode codemode.CodeMode) (*proto.Location, error)
 
 	// Get read file
 	//     required: location, readSize

--- a/blobstore/access/stream/stream_alloc.go
+++ b/blobstore/access/stream/stream_alloc.go
@@ -57,7 +57,7 @@ func (h *Handler) Alloc(ctx context.Context, size uint64, blobSize uint32,
 		span.Debugf("fill blobsize:%d", blobSize)
 	}
 
-	if codeMode == 0 {
+	if codeMode == codemode.CodeModeNone {
 		codeMode = h.allCodeModes.SelectCodeMode(int64(size))
 		span.Debugf("select codemode:%d", codeMode)
 	}

--- a/blobstore/access/stream/stream_get_test.go
+++ b/blobstore/access/stream/stream_get_test.go
@@ -34,7 +34,7 @@ func TestAccessStreamGetBase(t *testing.T) {
 	{
 		dataShards.clean()
 		data := []byte("x")
-		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(len(data)), nil)
+		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(len(data)), nil, proto.ClusterID(0), codemode.CodeModeNone)
 		require.NoError(t, err)
 
 		buff := bytes.NewBuffer(nil)
@@ -47,7 +47,7 @@ func TestAccessStreamGetBase(t *testing.T) {
 	{
 		dataShards.clean()
 		data := []byte("x")
-		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(len(data)), nil)
+		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(len(data)), nil, proto.ClusterID(0), codemode.CodeModeNone)
 		require.NoError(t, err)
 
 		buff := bytes.NewBuffer(nil)
@@ -83,7 +83,7 @@ func TestAccessStreamGetBase(t *testing.T) {
 		size := cs.size
 		data := make([]byte, size)
 		rand.Read(data)
-		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(size), nil)
+		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 		require.NoError(t, err)
 
 		buff := bytes.NewBuffer(nil)
@@ -117,7 +117,7 @@ func TestAccessStreamGetBroken(t *testing.T) {
 	rand.Read(data)
 	// time wait the punished services
 	time.Sleep(time.Second * time.Duration(punishServiceS))
-	loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(size), nil)
+	loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -183,7 +183,7 @@ func TestAccessStreamGetOffset(t *testing.T) {
 		size := cs.size
 		data := make([]byte, size)
 		rand.Read(data)
-		loc, err := streamer.Put(ctx(), bytes.NewReader(data), size, nil)
+		loc, err := streamer.Put(ctx(), bytes.NewReader(data), size, nil, proto.ClusterID(0), codemode.CodeModeNone)
 		require.NoError(t, err)
 
 		buff := bytes.NewBuffer(nil)
@@ -210,7 +210,7 @@ func TestAccessStreamGetShardTimeout(t *testing.T) {
 	size := 1 << 22
 	buff := make([]byte, size)
 	rand.Read(buff)
-	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil)
+	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	// no delay when blocking one shard, cos MinReadShardsX = 1
@@ -259,7 +259,7 @@ func TestAccessStreamGetShardSlow(t *testing.T) {
 	size := 1 << 20
 	buff := make([]byte, size)
 	rand.Read(buff)
-	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil)
+	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	vuidController.SetSlowdown(1001, 500*time.Millisecond)
@@ -287,7 +287,7 @@ func TestAccessStreamGetShardCrcMismatch(t *testing.T) {
 		dataShards.clean()
 		buff := make([]byte, size)
 		rand.Read(buff)
-		loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil)
+		loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 		require.NoError(t, err)
 
 		transfer, err := streamer.Get(ctx(), bytes.NewBuffer(nil), *loc, uint64(size), 0)
@@ -311,7 +311,7 @@ func TestAccessStreamGetShardBroken(t *testing.T) {
 	size := 1 << 22
 	buff := make([]byte, size)
 	rand.Read(buff)
-	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil)
+	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	// no delay when blocking one shard, cos MinReadShardsX = 1
@@ -352,7 +352,7 @@ func TestAccessStreamGetShardOnlyTimeout(t *testing.T) {
 	size := 1
 	buff := make([]byte, size)
 	rand.Read(buff)
-	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil)
+	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	// blocking the data shard, force to waiting ReadDataOnlyTimeoutMS
@@ -384,7 +384,7 @@ func TestAccessStreamGetLocalIDC(t *testing.T) {
 	size := 1 << 22
 	buff := make([]byte, size)
 	rand.Read(buff)
-	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil)
+	loc, err := streamer.Put(ctx(), bytes.NewReader(buff), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	// no delay when blocking other idc all shards
@@ -495,7 +495,7 @@ func TestAccessStreamGetAligned(t *testing.T) {
 
 		data := make([]byte, cs.size)
 		rand.Read(data)
-		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(cs.size), nil)
+		loc, err := streamer.Put(ctx(), bytes.NewReader(data), int64(cs.size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 		require.NoError(t, err)
 
 		// cos put shards asynchronously, should wait all shard written
@@ -675,7 +675,7 @@ func BenchmarkAccessStreamGet(b *testing.B) {
 	for _, cs := range cases {
 		b.ResetTimer()
 		b.Run(cs.name, func(b *testing.B) {
-			loc, err := streamer.Put(ctx, newReader(cs.size), int64(cs.size), nil)
+			loc, err := streamer.Put(ctx, newReader(cs.size), int64(cs.size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 			require.NoError(b, err)
 
 			b.ResetTimer()

--- a/blobstore/access/stream/stream_mock_test.go
+++ b/blobstore/access/stream/stream_mock_test.go
@@ -424,7 +424,13 @@ func initMockData() {
 	c := NewMockClusterController(ctr)
 	c.EXPECT().Region().AnyTimes().Return("test-region")
 	c.EXPECT().ChooseOne().AnyTimes().Return(clusterInfo, nil)
-	c.EXPECT().GetServiceController(gomock.Any()).AnyTimes().Return(serviceController, nil)
+	c.EXPECT().GetServiceController(gomock.Any()).AnyTimes().DoAndReturn(
+		func(needClusterID proto.ClusterID) (controller.ServiceController, error) {
+			if needClusterID != clusterID {
+				return nil, fmt.Errorf("no service controller of %d", needClusterID)
+			}
+			return serviceController, nil
+		})
 	c.EXPECT().GetVolumeGetter(gomock.Any()).AnyTimes().Return(volumeGetter, nil)
 	c.EXPECT().ChangeChooseAlg(gomock.Any()).AnyTimes().DoAndReturn(
 		func(alg controller.AlgChoose) error {

--- a/blobstore/access/stream/stream_test.go
+++ b/blobstore/access/stream/stream_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cubefs/cubefs/blobstore/access/controller"
 	"github.com/cubefs/cubefs/blobstore/common/codemode"
+	"github.com/cubefs/cubefs/blobstore/common/proto"
 )
 
 func newReader(size int) io.Reader {
@@ -79,7 +80,7 @@ func TestAccessStreamNew(t *testing.T) {
 func TestAccessStreamDelete(t *testing.T) {
 	ctx := ctxWithName("TestAccessStreamDelete")
 	size := 1 << 18
-	loc, err := streamer.Put(ctx(), newReader(size), int64(size), nil)
+	loc, err := streamer.Put(ctx(), newReader(size), int64(size), nil, proto.ClusterID(0), codemode.CodeModeNone)
 	require.NoError(t, err)
 
 	err = streamer.Delete(ctx(), loc)

--- a/blobstore/api/access/client.go
+++ b/blobstore/api/access/client.go
@@ -424,7 +424,9 @@ func (c *client) Put(ctx context.Context, args *PutArgs) (location proto.Locatio
 func (c *client) putObject(ctx context.Context, args *PutArgs) (location proto.Location, hashSumMap HashSumMap, err error) {
 	rpcClient := c.rpcClient.Load().(rpc.Client)
 
-	urlStr := fmt.Sprintf("/put?size=%d&hashes=%d", args.Size, args.Hashes)
+	urlStr := fmt.Sprintf("/put?size=%d&hashes=%d&assign_cluster_id=%d&code_mode=%d",
+		args.Size, args.Hashes, args.AssignClusterID, args.CodeMode)
+
 	req, err := http.NewRequest(http.MethodPut, urlStr, args.Body)
 	if err != nil {
 		return
@@ -570,7 +572,12 @@ func (c *client) putParts(ctx context.Context, args *PutArgs) (proto.Location, H
 
 	// alloc
 	allocResp := &AllocResp{}
-	if err := rpcClient.PostWith(ctx, "/alloc", allocResp, AllocArgs{Size: uint64(args.Size)}); err != nil {
+	allocArgs := &AllocArgs{
+		Size:            uint64(args.Size),
+		AssignClusterID: args.AssignClusterID,
+		CodeMode:        args.CodeMode,
+	}
+	if err := rpcClient.PostWith(ctx, "/alloc", allocResp, allocArgs); err != nil {
 		return allocResp.Location, nil, err
 	}
 	loc = allocResp.Location

--- a/blobstore/api/access/proto.go
+++ b/blobstore/api/access/proto.go
@@ -196,10 +196,17 @@ func (h HashSumMap) All() map[string]interface{} {
 // PutArgs for service /put
 // Hashes means how to calculate check sum,
 // HashAlgCRC32 | HashAlgMD5 equal 2 + 4 = 6
+// AssignClusterID > 0 means that cluster_id is assigned by the API caller
+// AssignClusterID = 0 means that cluster_id is assigned by access cluster controller
+// CodeMode > 0 means that codemode is assigned by the API caller
+// CodeMode = 0 means that codemode is assigned by code_mode_policies
 type PutArgs struct {
 	Size   int64         `json:"size"`
 	Hashes HashAlgorithm `json:"hashes,omitempty"`
 	Body   io.Reader     `json:"-"`
+
+	AssignClusterID proto.ClusterID   `json:"assign_cluster_id,omitempty"`
+	CodeMode        codemode.CodeMode `json:"code_mode,omitempty"`
 
 	// GetBody defines an optional func to return a new copy of Body.
 	// It is used for client requests when a redirect requires reading

--- a/blobstore/blobnode/core/config.go
+++ b/blobstore/blobnode/core/config.go
@@ -88,6 +88,7 @@ type RuntimeConfig struct {
 	IOStatFileDryRun             bool    `json:"iostat_file_dryrun"`
 	SetDefaultSwitch             bool    `json:"set_default_switch"`
 	EnableDeleteShardVerify      bool    `json:"enable_delete_shard_verify"`
+	EnablePutShardVerify         bool    `json:"enable_put_shard_verify"`
 	CompactBatchSize             int     `json:"compact_batch_size"`
 	WaitPendingReqIntervalSec    int64   `json:"wait_pending_req_interval_sec"`
 	MetricReportIntervalS        int64   `json:"metric_report_interval_S"`

--- a/blobstore/blobnode/core/config.go
+++ b/blobstore/blobnode/core/config.go
@@ -84,6 +84,7 @@ type RuntimeConfig struct {
 	AllowCleanTrash              bool    `json:"allow_clean_trash"`
 	DisableModifyInCompacting    bool    `json:"disable_modify_in_compacting"`
 	MustMountPoint               bool    `json:"must_mount_point"`
+	MustMountPointMeta           bool    `json:"must_mount_point_meta"`
 	IOStatFileDryRun             bool    `json:"iostat_file_dryrun"`
 	SetDefaultSwitch             bool    `json:"set_default_switch"`
 	EnableDeleteShardVerify      bool    `json:"enable_delete_shard_verify"`

--- a/blobstore/blobnode/core/disk/disk.go
+++ b/blobstore/blobnode/core/disk/disk.go
@@ -949,13 +949,26 @@ func newDiskStorage(ctx context.Context, conf core.Config) (ds *DiskStorage, err
 
 	if conf.MustMountPoint {
 		if !myos.IsMountPoint(conf.Path) {
-			span.Errorf("%s must mount point.", conf.Path)
-			return nil, errors.New("must mount point")
+			span.Errorf("%s must be a mount point.", conf.Path)
+			return nil, errors.New("must be a mount point")
+		}
+	}
+
+	// If metaRoot is not configured, the meta directory will be
+	// created under conf.Path, no need to check.
+	if metaRoot != "" {
+		// First check whether the metadata space is mounted separately for each disk,
+		// and then check whether the metadata space is mounted together for all disks.
+		checkPath := ""
+		if conf.MustMountPointMeta {
+			checkPath = filepath.Join(metaRoot, path)
+		} else if conf.MustMountPoint {
+			checkPath = metaRoot
 		}
 
-		if metaRoot != "" && !myos.IsMountPoint(metaRoot) {
-			span.Errorf("%s must mount point.", metaRoot)
-			return nil, errors.New("must mount point")
+		if checkPath != "" && !myos.IsMountPoint(checkPath) {
+			span.Errorf("%s must be a mount point.", checkPath)
+			return nil, errors.New("must be a mount point")
 		}
 	}
 

--- a/blobstore/blobnode/core/proto.go
+++ b/blobstore/blobnode/core/proto.go
@@ -94,6 +94,7 @@ type DataHandler interface {
 	Flush() (err error)
 	Delete(ctx context.Context, shard *Shard) (err error)
 	Destroy(ctx context.Context) (err error)
+	GetConfig() (config *Config)
 	Close()
 }
 

--- a/blobstore/blobnode/core/storage/datafile.go
+++ b/blobstore/blobnode/core/storage/datafile.go
@@ -512,6 +512,10 @@ func (cd *datafile) Destroy(ctx context.Context) (err error) {
 	return os.Remove(cd.File)
 }
 
+func (cd *datafile) GetConfig() (config *core.Config) {
+	return cd.conf
+}
+
 func (cd *datafile) String() string {
 	return fmt.Sprintf(`
 -----------------------------

--- a/blobstore/blobnode/core/storage/storage_cp_test.go
+++ b/blobstore/blobnode/core/storage/storage_cp_test.go
@@ -115,6 +115,10 @@ func (mm *mockBrokenData) Destroy(ctx context.Context) (err error) {
 	return
 }
 
+func (mm *mockBrokenData) GetConfig() (config *core.Config) {
+	return nil
+}
+
 func (mm *mockBrokenData) Close() {
 	// do nothing
 }

--- a/blobstore/blobnode/core/storage/storage_test.go
+++ b/blobstore/blobnode/core/storage/storage_test.go
@@ -151,6 +151,10 @@ func (mm *mockdata) Destroy(ctx context.Context) (err error) {
 	return
 }
 
+func (mm *mockdata) GetConfig() (config *core.Config) {
+	return nil
+}
+
 func (mm *mockdata) Close() {
 	// do nothing
 }

--- a/blobstore/cli/access/access.go
+++ b/blobstore/cli/access/access.go
@@ -185,6 +185,8 @@ func Register(app *grumble.App) {
 			f.String("f", "filepath", "", "put file path")
 			f.Int64("", "size", 0, "put file size, 0 means file size")
 			f.Uint("", "hashes", 0, "put file hashes")
+			f.Uint("", "codemode", 0, "put file codemode")
+			f.Uint("", "clusterid", 0, "put file cluster id")
 		},
 	})
 	accessCommand.AddCommand(&grumble.Command{

--- a/blobstore/cli/access/put.go
+++ b/blobstore/cli/access/put.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cubefs/cubefs/blobstore/cli/common/flags"
 	"github.com/cubefs/cubefs/blobstore/cli/common/fmt"
 	"github.com/cubefs/cubefs/blobstore/cli/config"
+	"github.com/cubefs/cubefs/blobstore/common/codemode"
+	"github.com/cubefs/cubefs/blobstore/common/proto"
 )
 
 func putFile(c *grumble.Context) error {
@@ -69,11 +71,15 @@ func putFile(c *grumble.Context) error {
 
 	putHashes := access.HashAlgorithm(c.Flags.Uint("hashes"))
 	fmt.Printf("to upload size:%d hash:b(%b)\n", size, putHashes)
+	codeMode := c.Flags.Uint("codemode")
+	clusterID := c.Flags.Uint("clusterid")
 
 	location, hashes, err := client.Put(common.CmdContext(), &access.PutArgs{
-		Size:   size,
-		Hashes: putHashes,
-		Body:   reader,
+		Size:            size,
+		Hashes:          putHashes,
+		Body:            reader,
+		AssignClusterID: proto.ClusterID(clusterID),
+		CodeMode:        codemode.CodeMode(codeMode),
 	})
 	if err != nil {
 		return err

--- a/blobstore/common/codemode/codemode.go
+++ b/blobstore/common/codemode/codemode.go
@@ -26,6 +26,7 @@ type (
 
 // pre-defined mode
 const (
+	CodeModeNone  CodeMode = 0
 	EC15P12       CodeMode = 1
 	EC6P6         CodeMode = 2
 	EC16P20L2     CodeMode = 3

--- a/blobstore/sdk/sdk_client.go
+++ b/blobstore/sdk/sdk_client.go
@@ -587,7 +587,7 @@ func (s *sdkHandler) doPutObject(ctx context.Context, args *acapi.PutArgs) (prot
 	}
 
 	rc := s.limiter.Reader(ctx, args.Body)
-	loc, err := s.handler.Put(ctx, rc, args.Size, hasherMap)
+	loc, err := s.handler.Put(ctx, rc, args.Size, hasherMap, args.AssignClusterID, args.CodeMode)
 	if err != nil {
 		span.Error("stream put failed", errors.Detail(err))
 		err = httpError(err)
@@ -779,7 +779,12 @@ func (s *sdkHandler) putParts(ctx context.Context, args *acapi.PutArgs) (proto.L
 	}()
 
 	// alloc
-	allocResp, err := s.alloc(ctx, &acapi.AllocArgs{Size: uint64(args.Size)})
+	allocArgs := &acapi.AllocArgs{
+		Size:            uint64(args.Size),
+		AssignClusterID: args.AssignClusterID,
+		CodeMode:        args.CodeMode,
+	}
+	allocResp, err := s.alloc(ctx, allocArgs)
 	if err != nil {
 		return proto.Location{}, nil, err
 	}

--- a/blobstore/testing/mocks/access_stream.go
+++ b/blobstore/testing/mocks/access_stream.go
@@ -172,18 +172,18 @@ func (mr *MockStreamHandlerMockRecorder) ListBlob(arg0, arg1 interface{}) *gomoc
 }
 
 // Put mocks base method.
-func (m *MockStreamHandler) Put(arg0 context.Context, arg1 io.Reader, arg2 int64, arg3 access.HasherMap) (*proto.Location, error) {
+func (m *MockStreamHandler) Put(arg0 context.Context, arg1 io.Reader, arg2 int64, arg3 access.HasherMap, arg4 proto.ClusterID, arg5 codemode.CodeMode) (*proto.Location, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*proto.Location)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockStreamHandlerMockRecorder) Put(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockStreamHandlerMockRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStreamHandler)(nil).Put), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStreamHandler)(nil).Put), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // PutAt mocks base method.

--- a/docs-zh/source/ops/configs/blobstore/blobnode.md
+++ b/docs-zh/source/ops/configs/blobstore/blobnode.md
@@ -68,6 +68,7 @@ BlobNode的配置是基于[公有配置](./base.md)，以下配置说明主要�
 		"set_default_switch": "是否默认设置开关.建议该项填true,会设置need_compact_check,allow_force_compact,allow_clean_trash",
 		"must_mount_point": "数据存放目录是否强制是挂载点",
 		"must_mount_point_meta": "如果配置了 meta_root_prefix，开启 must_mount_point_meta 后会检查每个磁盘的元数据目录是否为挂载点，默认值 false",
+		"enable_put_shard_verify": "开启 true 表示在写入 bid/shard 前先检查 shard meta 是否存在，若存在直接返回 shard.crc，避免重复上传同一个 bid/shard 多次，关闭 false 表示允许对同一个 bid/shard 上传多次，依赖 chunk compacting 进行垃圾回收，默认值 false",
 		"write_thread_cnt": "限制写线程个数, 默认值4",
 		"read_thread_cnt": "限制读线程个数, 默认值4",
 		"delete_thread_cnt": "限制删线程个数, 默认值1",

--- a/docs-zh/source/ops/configs/blobstore/blobnode.md
+++ b/docs-zh/source/ops/configs/blobstore/blobnode.md
@@ -67,6 +67,7 @@ BlobNode的配置是基于[公有配置](./base.md)，以下配置说明主要�
 		"metric_report_interval_S": "metric上报的定时任务周期",
 		"set_default_switch": "是否默认设置开关.建议该项填true,会设置need_compact_check,allow_force_compact,allow_clean_trash",
 		"must_mount_point": "数据存放目录是否强制是挂载点",
+		"must_mount_point_meta": "如果配置了 meta_root_prefix，开启 must_mount_point_meta 后会检查每个磁盘的元数据目录是否为挂载点，默认值 false",
 		"write_thread_cnt": "限制写线程个数, 默认值4",
 		"read_thread_cnt": "限制读线程个数, 默认值4",
 		"delete_thread_cnt": "限制删线程个数, 默认值1",

--- a/docs/source/ops/configs/blobstore/blobnode.md
+++ b/docs/source/ops/configs/blobstore/blobnode.md
@@ -68,9 +68,10 @@ BlobNode configuration is based on the [public configuration](./base.md), and th
     "metric_report_interval_S": "interval for metric reporting",
     "set_default_switch": "whether to set switch.suggest you set it to true,will set: need_compact_check,allow_force_compact,allow_clean_trash",
     "must_mount_point": "whether the data storage directory must be a mount point",
-    "write_thread_cnt": "limit the number of write threads，default 4",
-    "read_thread_cnt": "limit the number of read threads，default 4",
-    "delete_thread_cnt": "limit the number of delete threads，default 1",
+    "must_mount_point_meta": "if meta_root_prefix is ​​configured, turning on must_mount_point_meta will check if the metadata directory of each disk is a mount point, default false",
+    "write_thread_cnt": "limit the number of write threads, default 4",
+    "read_thread_cnt": "limit the number of read threads, default 4",
+    "delete_thread_cnt": "limit the number of delete threads, default 1",
     "data_qos": {
       "read_mbps": "per disk normal read IO bandwidth",
       "write_mbps": "per disk normal write IO bandwidth",

--- a/docs/source/ops/configs/blobstore/blobnode.md
+++ b/docs/source/ops/configs/blobstore/blobnode.md
@@ -69,6 +69,7 @@ BlobNode configuration is based on the [public configuration](./base.md), and th
     "set_default_switch": "whether to set switch.suggest you set it to true,will set: need_compact_check,allow_force_compact,allow_clean_trash",
     "must_mount_point": "whether the data storage directory must be a mount point",
     "must_mount_point_meta": "if meta_root_prefix is ​​configured, turning on must_mount_point_meta will check if the metadata directory of each disk is a mount point, default false",
+    "enable_put_shard_verify": "enable true to check if the shard meta exists before writing to the bid/shard. if it exists, return shard.crc directly to avoid uploading the same bid/shard multiple times. disable false to allow multiple uploads of the same bid/shard, relying on chunk compacting for garbage collection. default false",
     "write_thread_cnt": "limit the number of write threads, default 4",
     "read_thread_cnt": "limit the number of read threads, default 4",
     "delete_thread_cnt": "limit the number of delete threads, default 1",


### PR DESCRIPTION
```
    feat(blobstore): add enable_put_shard_verify in blobnode

    problem: multiple retry uploads of the same bid/shard in blobnode ShardPut
    can lead to in wasted disk space.
    solution: read bid shard meta before write to disk, if bid shard meta is exists,
    return crc directly.
    fixes: github.com/cubefs/cubefs/issues/3969
```

<!-- Thanks for sending the pull request! -->
<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #3969 

<!-- or this PR is one task of an issue. -->

Main Issue: #3969 


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

```
problem: multiple retry uploads of the same bid/shard in blobnode ShardPut can lead to in wasted disk space.
```

### Modifications
<!-- Describe the modifications you've done. -->

``` text
solution: read bid shard meta before write to disk, if bid shard meta is exists, return crc directly.
```

### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [x] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
