### PR TITLE
feat(bssdk): sdk auditlog support resp_body and resp_length

### DIFF
--- a/blobstore/common/rpc/client.go
+++ b/blobstore/common/rpc/client.go
@@ -339,7 +339,7 @@ func ParseData(resp *http.Response, data interface{}) (err error) {
 func ParseResponseErr(resp *http.Response) (err error) {
 	// wrap the error with HttpError for StatusCode is not 2XX
 	if resp.StatusCode > 299 && resp.ContentLength != 0 {
-		errR := &errorResponse{}
+		errR := &ErrorResponse{}
 		if err := json.NewDecoder(resp.Body).Decode(errR); err != nil {
 			return NewError(decodeStatus, "JSONDecode",
 				fmt.Errorf("%d response decode %s", resp.StatusCode, err.Error()))

--- a/blobstore/common/rpc/context.go
+++ b/blobstore/common/rpc/context.go
@@ -152,7 +152,7 @@ func (c *Context) RespondError(err error) {
 		c.Respond()
 		return
 	}
-	c.RespondStatusData(httpErr.StatusCode(), errorResponse{
+	c.RespondStatusData(httpErr.StatusCode(), ErrorResponse{
 		Error: httpErr.Error(),
 		Code:  httpErr.ErrorCode(),
 	})

--- a/blobstore/common/rpc/error.go
+++ b/blobstore/common/rpc/error.go
@@ -31,9 +31,9 @@ type (
 		Err    error  // error
 	}
 
-	// errorResponse response error with json
+	// ErrorResponse response error with json
 	// internal type between server and client
-	errorResponse struct {
+	ErrorResponse struct {
 		Error string `json:"error"`
 		Code  string `json:"code,omitempty"`
 	}

--- a/blobstore/common/rpc/server_test.go
+++ b/blobstore/common/rpc/server_test.go
@@ -422,7 +422,7 @@ func TestServerResponseWith(t *testing.T) {
 		w := resp(router)
 		require.Equal(t, 400, w.status)
 
-		ret := new(errorResponse)
+		ret := new(ErrorResponse)
 		err := json.Unmarshal(w.body, ret)
 		require.NoError(t, err)
 		require.Equal(t, "", ret.Code)
@@ -461,7 +461,7 @@ func TestServerResponseWith(t *testing.T) {
 		w := resp(router)
 		require.Equal(t, 400, w.status)
 
-		ret := new(errorResponse)
+		ret := new(ErrorResponse)
 		err := json.Unmarshal(w.body, ret)
 		require.NoError(t, err)
 		require.Equal(t, "", ret.Code)

--- a/blobstore/sdk/sdk_client.go
+++ b/blobstore/sdk/sdk_client.go
@@ -147,7 +147,7 @@ func (s *sdkHandler) Get(ctx context.Context, args *acapi.GetArgs) (body io.Read
 	ctx = acapi.ClientWithReqidContext(ctx)
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "Get"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		body, err = s._get(ctx, args)
 		return err
@@ -186,7 +186,7 @@ func (s *sdkHandler) Delete(ctx context.Context, args *acapi.DeleteArgs) (failed
 	ctx = acapi.ClientWithReqidContext(ctx)
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "Delete"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		failedLocations, err = s._delete(ctx, args)
 		return err
@@ -238,9 +238,21 @@ func (s *sdkHandler) Put(ctx context.Context, args *acapi.PutArgs) (lc proto.Loc
 	ctx = acapi.ClientWithReqidContext(ctx)
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "Put"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		lc, hm, err = s._put(ctx, args)
+
+		if err == nil {
+			auditline.RespBody = jsonString(acapi.PutResp{
+				Location:   lc,
+				HashSumMap: hm,
+			})
+		} else {
+			auditline.RespBody = jsonString(rpc.ErrorResponse{
+				Error: err.Error(),
+			})
+		}
+		auditline.RespLength = int64(len(auditline.RespBody))
 		return err
 	})
 	return
@@ -295,7 +307,7 @@ func (s *sdkHandler) ListBlob(ctx context.Context, args *acapi.ListBlobArgs) (re
 
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "ListBlob"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		if !args.IsValid() {
 			err = errcode.ErrIllegalArguments
@@ -319,7 +331,7 @@ func (s *sdkHandler) DeleteBlob(ctx context.Context, args *acapi.DelBlobArgs) (e
 
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "DeleteBlob"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		if !args.IsValid() {
 			err = errcode.ErrIllegalArguments
@@ -340,7 +352,7 @@ func (s *sdkHandler) GetBlob(ctx context.Context, args *acapi.GetBlobArgs) (body
 
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "GetBlob"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		if !args.IsValid() {
 			err = errcode.ErrIllegalArguments
@@ -374,7 +386,7 @@ func (s *sdkHandler) PutBlob(ctx context.Context, args *acapi.PutBlobArgs) (cid 
 	ctx = acapi.ClientWithReqidContext(ctx)
 	s.auditor.Audit(ctx, func(ctx context.Context, auditline *auditlog.AuditLog) error {
 		auditline.Method = "PutBlob"
-		auditline.ReqParams = requestParams(args)
+		auditline.ReqParams = jsonString(args)
 
 		cid, hashes, err = s._putBlob(ctx, args)
 		return err
@@ -1336,7 +1348,7 @@ func fixLocationSize(loc proto.Location, size uint64) (proto.Location, error) {
 	return loc, nil
 }
 
-func requestParams(args any) string {
+func jsonString(args any) string {
 	data, err := json.Marshal(args)
 	if err != nil {
 		return fmt.Sprintf(`{"error":"marshal args: %v"}`, err)


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #4013

<!-- or this PR is one task of an issue. -->

Main Issue: #4013


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

```
tail -n 1 0-0_access_2.log  | jq .
{
  "req_type": "REQ",
  "module": "ACCESS@127.0.0.2:9500",
  "start_time": 1773121722827233,
  "method": "PUT",
  "path": "/put",
  "req_header": {
    "BodySize": 26878,
    "Host": "127.0.0.2:9500",
    "IP": "127.0.0.1",
    "RawQuery": "size=26878&hashes=0&assign_cluster_id=0&code_mode=0",
    "User-Agent": "blobstore-cli/feature_sdk_putauditlog/b71e75f3ed09972f217f548c5fe6104d599ff0d4 (linux/amd64; go1.21.13) zjw-redundancer-dev/208181",
    "X-Crc-Encoded": "1"
  },
  "req_params": "",
  "status_code": 200,
  "resp_header": {
    "Blobstore-Tracer-Traceid": "7816368796e16ec9-cmd",
    "Content-Length": "154",
    "Content-Type": "application/json",
    "Trace-Log": [
      "PROXY@127.0.0.1:9600",
      "CLUSTERMGR@127.0.0.1:9998:1;PROXY@127.0.0.1:9600:2",
      "a_0_r_0_w_11",
      "ACCESS@127.0.0.2:9500:17"
    ],
    "Trace-Tags": [
      "span.kind:client",
      "http.method:GET"
    ],
    "X-Ack-Crc-Encoded": "1"
  },
  "resp_body": "{\"location\":{\"cluster_id\":1,\"code_mode\":11,\"size\":26878,\"blob_size\":16777216,\"crc\":3305032162,\"blobs\":[{\"min_bid\":1765,\"vid\":62,\"count\":1}]},\"hashsum\":{}}",
  "resp_length": 154,
  "duration": 17787
}
```

``` text
# tail -n 1 2-18y6d_sdk_0.log | jq .
{
  "req_type": "REQ",
  "module": "sdk@0",
  "start_time": 1773122658894688,
  "method": "Put",
  "path": "",
  "req_header": null,
  "req_params": "{\"size\":921600,\"hashes\":1}",
  "status_code": 200,
  "resp_header": {
    "Blobstore-Tracer-Traceid": "bench-p-e28c80ef-dd7e-4f24-82a8-19c0a0439841",
    "Trace-Log": [
      "PROXY@127.0.0.2:9600",
      "PROXY@127.0.0.1:9600",
      "PROXY@127.0.0.3:9600",
      "PROXY@127.0.0.2:9600",
      "CLUSTERMGR@127.0.0.3:9998:1;PROXY@127.0.0.1:9600:2",
      "a_4_r_0_w_10"
    ],
    "Trace-Tags": [
      "http.method:GET",
      "span.kind:client"
    ]
  },
  "resp_body":"",
  "resp_length": 0,
  "duration": 327272
}
```

### Modifications
<!-- Describe the modifications you've done. -->


CORRECT PAHT:
```
tail -n 1 2-18y6d_sdk_0.log | jq .
{
  "req_type": "REQ",
  "module": "sdk@0",
  "start_time": 1773122658894688,
  "method": "Put",
  "path": "",
  "req_header": null,
  "req_params": "{\"size\":921600,\"hashes\":1}",
  "status_code": 200,
  "resp_header": {
    "Blobstore-Tracer-Traceid": "bench-p-e28c80ef-dd7e-4f24-82a8-19c0a0439841",
    "Trace-Log": [
      "PROXY@127.0.0.2:9600",
      "PROXY@127.0.0.1:9600",
      "PROXY@127.0.0.3:9600",
      "PROXY@127.0.0.2:9600",
      "CLUSTERMGR@127.0.0.3:9998:1;PROXY@127.0.0.1:9600:2",
      "a_4_r_0_w_10"
    ],
    "Trace-Tags": [
      "http.method:GET",
      "span.kind:client"
    ]
  },
  "resp_body": "{\"location\":{\"cluster_id\":1,\"code_mode\":11,\"size\":921600,\"blob_size\":16777216,\"crc\":3259429572,\"blobs\":[{\"min_bid\":201740,\"vid\":33,\"count\":1}]},\"hashsum\":{\"1\":\"\"}}",
  "resp_length": 163,
  "duration": 327272
}
```

ERROR PATH
```
tail -n 1 2-18y6d_sdk_0.log | jq .
{
  "req_type": "REQ",
  "module": "sdk@0",
  "start_time": 1773128346375640,
  "method": "Put",
  "path": "",
  "req_header": null,
  "req_params": "{\"size\":921600,\"hashes\":1}",
  "status_code": 500,
  "resp_header": {
    "Blobstore-Tracer-Traceid": "bench-p-d173e4f8-0d3f-4e4a-b045-13856cdb04e3",
    "Trace-Log": [
      "PROXY@127.0.0.3:9600",
      "PROXY@127.0.0.1:9600",
      "a_1_r_0_w_9",
      "PROXY@127.0.0.1:9600:113"
    ],
    "Trace-Tags": [
      "span.kind:client",
      "http.method:POST"
    ]
  },
  "resp_body": "{\"error\":\"quorum write failed (0 \\u003c 5) of blob(cid:1 vid:62 bid:101701)\"}",
  "resp_length": 77,
  "duration": 130799
}
```


### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change
<!-- Please pick either of the following options. -->

- [ ] Make sure that the change passes the testing checks.

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *This can be verified in development debugging*
  - *This can be realized in a mocked environment, like a test cluster consisting in docker*

*(or)*

This change `MUST` reappear in online clusters, or occur in that specific scenarios.

### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [x] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->
