### PR TITLE
fix(objectnode): clamp oversized list max-keys values

### DIFF
--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -40,6 +40,21 @@ var (
 	MaxKeyLength = 750
 )
 
+func parseMaxKeys(maxKeys string) (uint64, error) {
+	if maxKeys == "" {
+		return MaxKeys, nil
+	}
+
+	maxKeysInt, err := strconv.ParseUint(maxKeys, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if maxKeysInt > MaxKeys {
+		maxKeysInt = MaxKeys
+	}
+	return maxKeysInt, nil
+}
+
 // Get object
 // API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
 func (o *ObjectNode) getObjectHandler(w http.ResponseWriter, r *http.Request) {
@@ -973,15 +988,12 @@ func (o *ObjectNode) getBucketV1Handler(w http.ResponseWriter, r *http.Request) 
 
 	var maxKeysInt uint64
 	if maxKeys != "" {
-		maxKeysInt, err = strconv.ParseUint(maxKeys, 10, 16)
+		maxKeysInt, err = parseMaxKeys(maxKeys)
 		if err != nil {
 			log.LogErrorf("getBucketV1Handler: parse max key fail: requestID(%v) volume(%v) maxKeys(%v) err(%v)",
 				GetRequestID(r), vol.Name(), maxKeys, err)
 			errorCode = InvalidArgument
 			return
-		}
-		if maxKeysInt > MaxKeys {
-			maxKeysInt = MaxKeys
 		}
 	} else {
 		maxKeysInt = uint64(MaxKeys)
@@ -1114,15 +1126,12 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 
 	var maxKeysInt uint64
 	if maxKeys != "" {
-		maxKeysInt, err = strconv.ParseUint(maxKeys, 10, 16)
+		maxKeysInt, err = parseMaxKeys(maxKeys)
 		if err != nil {
 			log.LogErrorf("getBucketV2Handler: parse max keys fail: requestID(%v) volume(%v) maxKeys(%v) err(%v)",
 				GetRequestID(r), vol.Name(), maxKeys, err)
 			errorCode = InvalidArgument
 			return
-		}
-		if maxKeysInt > MaxKeys {
-			maxKeysInt = MaxKeys
 		}
 	} else {
 		maxKeysInt = MaxKeys

--- a/objectnode/api_handler_object_test.go
+++ b/objectnode/api_handler_object_test.go
@@ -1,0 +1,37 @@
+package objectnode
+
+import "testing"
+
+func TestParseMaxKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "empty uses default", input: "", want: MaxKeys},
+		{name: "small value", input: "100", want: 100},
+		{name: "clamp over limit", input: "1001", want: MaxKeys},
+		{name: "clamp huge value", input: "2147483647", want: MaxKeys},
+		{name: "invalid string", input: "abc", wantErr: true},
+		{name: "negative string", input: "-1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMaxKeys(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected max keys: got %d want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- parse S3 list `max-keys` through a shared helper
- clamp oversized values to `MaxKeys` instead of returning `InvalidArgument`
- add unit coverage for empty, normal, oversized, and invalid inputs

## Motivation
ObjectNode currently rejects very large `max-keys` values because it parses them with a 16-bit width. For S3-compatible list APIs, oversized values should be accepted and capped by the server-side maximum instead.

## Testing
- `go test ./objectnode -run TestParseMaxKeys -count=1`

Closes #4042