### PR TITLE
feat(objectnode): enrich audit webhook payload

### DIFF
--- a/objectnode/api_context.go
+++ b/objectnode/api_context.go
@@ -15,6 +15,7 @@
 package objectnode
 
 import (
+	"encoding/json"
 	"html"
 	"net/http"
 	"strconv"
@@ -35,6 +36,7 @@ const (
 	ContextKeyAccessKey     = "access_key"
 	ContextKeyRequester     = "requester"
 	ContextKeyOwner         = "owner"
+	ContextKeyAuditFields   = "audit_fields"
 )
 
 func SetRequestID(r *http.Request, requestID string) {
@@ -71,4 +73,28 @@ func SetResponseErrorMessage(r *http.Request, message string) {
 
 func getResponseErrorMessage(r *http.Request) string {
 	return mux.Vars(r)[ContextKeyErrorMessage]
+}
+
+type AuditFields struct {
+	Size    int64    `json:"Size,omitempty"`
+	ETag    string   `json:"ETag,omitempty"`
+	Objects []string `json:"Objects,omitempty"`
+}
+
+func SetAuditFields(r *http.Request, fields AuditFields) {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return
+	}
+	mux.Vars(r)[ContextKeyAuditFields] = string(data)
+}
+
+func GetAuditFields(r *http.Request) AuditFields {
+	var fields AuditFields
+	raw := mux.Vars(r)[ContextKeyAuditFields]
+	if raw == "" {
+		return fields
+	}
+	_ = json.Unmarshal([]byte(raw), &fields)
+	return fields
 }

--- a/objectnode/api_handler_multipart.go
+++ b/objectnode/api_handler_multipart.go
@@ -775,6 +775,8 @@ func (o *ObjectNode) completeMultipartUploadHandler(w http.ResponseWriter, r *ht
 		return
 	}
 
+	SetAuditFields(r, AuditFields{Size: fsFileInfo.Size, ETag: fsFileInfo.ETag})
+
 	completeResult := CompleteMultipartResult{
 		Bucket: param.Bucket(),
 		Key:    param.Object(),

--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -676,6 +676,12 @@ func (o *ObjectNode) deleteObjectsHandler(w http.ResponseWriter, r *http.Request
 	}
 	span.AppendTrackLog("files.d", start, err)
 
+	auditObjects := make([]string, 0, len(deletedObjects))
+	for _, deleted := range deletedObjects {
+		auditObjects = append(auditObjects, deleted.Key)
+	}
+	SetAuditFields(r, AuditFields{Objects: auditObjects})
+
 	deleteResult := DeleteResult{
 		Deleted: deletedObjects,
 		Error:   deletedErrors,
@@ -1403,6 +1409,8 @@ func (o *ObjectNode) putObjectHandler(w http.ResponseWriter, r *http.Request) {
 		errorCode = BadDigest
 		return
 	}
+
+	SetAuditFields(r, AuditFields{Size: fsFileInfo.Size, ETag: fsFileInfo.ETag})
 
 	// set response header
 	w.Header()[ETag] = []string{wrapUnescapedQuot(fsFileInfo.ETag)}

--- a/objectnode/audit.go
+++ b/objectnode/audit.go
@@ -64,10 +64,13 @@ type AuditEntry struct {
 		Error      string            `json:"Error,omitempty"`
 	} `json:"Response"`
 
-	BytesRequest  int64  `json:"BytesRequest,omitempty"`
-	BytesResponse int64  `json:"BytesResponse,omitempty"`
-	Duration      string `json:"Duration,omitempty"`
-	DurationNS    string `json:"DurationNS,omitempty"`
+	BytesRequest  int64    `json:"BytesRequest,omitempty"`
+	BytesResponse int64    `json:"BytesResponse,omitempty"`
+	Duration      string   `json:"Duration,omitempty"`
+	DurationNS    string   `json:"DurationNS,omitempty"`
+	Size          int64    `json:"Size,omitempty"`
+	ETag          string   `json:"ETag,omitempty"`
+	Objects       []string `json:"Objects,omitempty"`
 }
 
 type AuditLogConfig struct {
@@ -176,6 +179,10 @@ func (a *ExternalAudit) Logger(w http.ResponseWriter, r *http.Request) {
 	entry.Response.StatusCode = statusCode
 	entry.Response.Status = http.StatusText(statusCode)
 	entry.Response.Error = getResponseErrorMessage(r)
+	fields := GetAuditFields(r)
+	entry.Size = fields.Size
+	entry.ETag = fields.ETag
+	entry.Objects = fields.Objects
 
 	data, err := json.Marshal(entry)
 	if err != nil {

--- a/objectnode/audit_fields_test.go
+++ b/objectnode/audit_fields_test.go
@@ -1,0 +1,94 @@
+package objectnode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+type captureAuditLogger struct {
+	ch chan []byte
+}
+
+func (l *captureAuditLogger) Name() string {
+	return "capture"
+}
+
+func (l *captureAuditLogger) Send(data []byte) error {
+	buf := make([]byte, len(data))
+	copy(buf, data)
+	l.ch <- buf
+	return nil
+}
+
+func (l *captureAuditLogger) Close() error {
+	return nil
+}
+
+func TestAuditFieldsRoundTrip(t *testing.T) {
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodPut, "/bucket/object", nil), map[string]string{})
+	want := AuditFields{
+		Size:    123,
+		ETag:    "etag-value",
+		Objects: []string{"a.txt", "b.txt"},
+	}
+
+	SetAuditFields(req, want)
+
+	require.Equal(t, want, GetAuditFields(req))
+}
+
+func TestExternalAuditLoggerIncludesAuditFields(t *testing.T) {
+	logger := &captureAuditLogger{ch: make(chan []byte, 1)}
+	audit := NewExternalAudit()
+	audit.AddLoggers(logger)
+
+	req := httptest.NewRequest(http.MethodPut, "http://example.com/test-bucket/test-object?uploadId=1", strings.NewReader("payload"))
+	req.RemoteAddr = "127.0.0.1:12345"
+	req = mux.SetURLVars(req, map[string]string{
+		ContextKeyRequestID: "req-123",
+		ContextKeyRequester: "requester-1",
+		ContextKeyAccessKey: "ak-test",
+		ContextKeyOwner:     "owner-1",
+		ContextKeyBucket:    "test-bucket",
+		ContextKeyObject:    "test-object",
+	})
+	SetRequestAction(req, proto.OSSPutObjectAction)
+	SetAuditFields(req, AuditFields{
+		Size:    456,
+		ETag:    "etag-456",
+		Objects: []string{"deleted-a", "deleted-b"},
+	})
+
+	recorder := NewResponseStater(httptest.NewRecorder())
+	recorder.StartTime = time.Now().UTC().Add(-2 * time.Millisecond)
+	recorder.Header().Set(ETag, wrapUnescapedQuot("etag-456"))
+	recorder.WriteHeader(http.StatusCreated)
+	_, err := recorder.Write([]byte("ok"))
+	require.NoError(t, err)
+
+	audit.Logger(recorder, req)
+
+	select {
+	case data := <-logger.ch:
+		var entry AuditEntry
+		require.NoError(t, json.Unmarshal(data, &entry))
+		require.Equal(t, "req-123", entry.RequestID)
+		require.Equal(t, "PutObject", entry.Request.API)
+		require.Equal(t, "test-bucket", entry.Request.Bucket)
+		require.Equal(t, "test-object", entry.Request.Object)
+		require.Equal(t, http.StatusCreated, entry.Response.StatusCode)
+		require.Equal(t, int64(456), entry.Size)
+		require.Equal(t, "etag-456", entry.ETag)
+		require.Equal(t, []string{"deleted-a", "deleted-b"}, entry.Objects)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for audit payload")
+	}
+}


### PR DESCRIPTION
## Summary

This PR enriches objectnode external audit webhook payloads with more event metadata:

- include `Size` and `ETag` for successful upload flows
- include deleted object keys for `DeleteObjects`
- add focused tests for the new audit fields

## Details

The change stores audit-specific fields in the request context and emits them from `ExternalAudit.Logger`.

It populates these fields for:

- `PutObject`
- `CompleteMultipartUpload`
- `DeleteObjects`

## Testing

```bash
cd /mnt/c/tmp/cubefs-pr-audit-webhook-fields && go test ./objectnode -run 'TestAuditFieldsRoundTrip|TestExternalAuditLoggerIncludesAuditFields' -count=1
```

Closes #4044