### PR TITLE
fix(strutil): reject size parsing overflow

### DIFF
--- a/util/strutil/fmt.go
+++ b/util/strutil/fmt.go
@@ -31,6 +31,7 @@ var suffixs = map[string]uint64{
 }
 
 func ParseSize(sizeStr string) (size uint64, err error) {
+	original := sizeStr
 	sizeStr = strings.ToLower(sizeStr)
 	base := uint64(1)
 	for suffix, v := range suffixs {
@@ -42,6 +43,10 @@ func ParseSize(sizeStr string) (size uint64, err error) {
 	}
 	size, err = strconv.ParseUint(sizeStr, 10, 64)
 	if err != nil {
+		return
+	}
+	if size > ^uint64(0)/base {
+		err = fmt.Errorf("size %q overflows uint64", original)
 		return
 	}
 	size *= base

--- a/util/strutil/fmt_test.go
+++ b/util/strutil/fmt_test.go
@@ -27,6 +27,7 @@ func TestParseSize(t *testing.T) {
 	str2 := "1024kb"
 	str3 := "1024KB"
 	str4 := "0PB"
+	str5 := "18014398509482112KB"
 
 	size1, err := strutil.ParseSize(str1)
 	require.NoError(t, err)
@@ -43,6 +44,9 @@ func TestParseSize(t *testing.T) {
 	size4, err := strutil.ParseSize(str4)
 	require.NoError(t, err)
 	require.EqualValues(t, 0, size4)
+
+	_, err = strutil.ParseSize(str5)
+	require.Error(t, err)
 }
 
 func TestFormatSize(t *testing.T) {


### PR DESCRIPTION
Fixes a tiny ParseSize overflow footgun.

Repro:
- old code: ParseSize("18014398509482112KB") returns 128KB because uint64 multiply wraps
- cfs-cli volume set-repair-size <vol> 18014398509482112KB can hit this path, and 128KB is inside the master range check, so yep this is triggerable
- now oversized suffixed values return an error before multiplying

Tests:
- go test ./util/strutil ./cli/cmd