### PR TITLE
objectnode: fix UTF-8 key encoding in S3 list responses

### DIFF
--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -1054,6 +1054,7 @@ func (o *ObjectNode) getBucketV1Handler(w http.ResponseWriter, r *http.Request) 
 		Bucket:         param.Bucket(),
 		Prefix:         prefix,
 		Marker:         marker,
+		EncodingType:   encodingType,
 		MaxKeys:        int(maxKeysInt),
 		Delimiter:      delimiter,
 		IsTruncated:    result.Truncated,
@@ -1220,6 +1221,7 @@ func (o *ObjectNode) getBucketV2Handler(w http.ResponseWriter, r *http.Request) 
 	listBucketResult := ListBucketResultV2{
 		Name:           param.Bucket(),
 		Prefix:         prefix,
+		EncodingType:   encodingType,
 		Token:          contToken,
 		NextToken:      result.NextToken,
 		KeyCount:       result.KeyCount,

--- a/objectnode/result.go
+++ b/objectnode/result.go
@@ -182,6 +182,7 @@ type ListBucketResult struct {
 	Bucket         string          `xml:"Name"`
 	Prefix         string          `xml:"Prefix"`
 	Marker         string          `xml:"Marker"`
+	EncodingType   string          `xml:"EncodingType,omitempty"`
 	MaxKeys        int             `xml:"MaxKeys"`
 	Delimiter      string          `xml:"Delimiter"`
 	IsTruncated    bool            `xml:"IsTruncated"`
@@ -257,6 +258,7 @@ type ListBucketResultV2 struct {
 	XMLName        xml.Name        `xml:"ListBucketResult"`
 	Name           string          `xml:"Name"`
 	Prefix         string          `xml:"Prefix,omitempty"`
+	EncodingType   string          `xml:"EncodingType,omitempty"`
 	Token          string          `xml:"ContinuationToken,omitempty"`
 	NextToken      string          `xml:"NextContinuationToken,omitempty"`
 	KeyCount       uint64          `xml:"KeyCount"`

--- a/objectnode/util.go
+++ b/objectnode/util.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -230,24 +229,40 @@ func wrapUnescapedQuot(src string) string {
 	return "\"" + src + "\""
 }
 
-func encodeKey(key, encodingType string) string {
-	isKeyEscapedSkipByte := func(b byte) bool {
-		for _, skipByte := range keyEscapedSkipBytes {
-			if b == skipByte {
-				return true
-			}
-		}
+func shouldEscapeKeyByte(b byte) bool {
+	switch {
+	case '0' <= b && b <= '9':
+		return false
+	case 'A' <= b && b <= 'Z':
+		return false
+	case 'a' <= b && b <= 'z':
+		return false
+	case b == '~':
 		return false
 	}
+
+	for _, skipByte := range keyEscapedSkipBytes {
+		if b == skipByte {
+			return false
+		}
+	}
+	return true
+}
+
+func encodeKey(key, encodingType string) string {
 	if strings.ToLower(encodingType) == "url" {
+		const upperhex = "0123456789ABCDEF"
 		encodedKeyBuilder := strings.Builder{}
+		encodedKeyBuilder.Grow(len(key) * 3)
 		for i := 0; i < len(key); i++ {
-			b := byte(key[i])
-			if isKeyEscapedSkipByte(b) {
-				encodedKeyBuilder.Write([]byte{b})
-			} else {
-				encodedKeyBuilder.Write([]byte(url.QueryEscape(string(b))))
+			b := key[i]
+			if !shouldEscapeKeyByte(b) {
+				encodedKeyBuilder.WriteByte(b)
+				continue
 			}
+			encodedKeyBuilder.WriteByte('%')
+			encodedKeyBuilder.WriteByte(upperhex[b>>4])
+			encodedKeyBuilder.WriteByte(upperhex[b&15])
 		}
 		return encodedKeyBuilder.String()
 	}

--- a/objectnode/util_test.go
+++ b/objectnode/util_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import "testing"
+
+func TestEncodeKey(t *testing.T) {
+	testCases := []struct {
+		name         string
+		key          string
+		encodingType string
+		expected     string
+	}{
+		{
+			name:         "raw key when encoding type is empty",
+			key:          "中文 文件名.txt",
+			encodingType: "",
+			expected:     "中文 文件名.txt",
+		},
+		{
+			name:         "utf8 key is percent encoded by byte",
+			key:          "中文文件名-20260528-1132.txt",
+			encodingType: "url",
+			expected:     "%E4%B8%AD%E6%96%87%E6%96%87%E4%BB%B6%E5%90%8D-20260528-1132.txt",
+		},
+		{
+			name:         "space is encoded as percent 20",
+			key:          "folder name/file name.txt",
+			encodingType: "url",
+			expected:     "folder%20name/file%20name.txt",
+		},
+		{
+			name:         "encoding type matching is case insensitive",
+			key:          "a+b*c",
+			encodingType: "URL",
+			expected:     "a%2Bb*c",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := encodeKey(tc.key, tc.encodingType)
+			if actual != tc.expected {
+				t.Fatalf("unexpected encoded key: expected(%q) actual(%q)", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- fix `encoding-type=url` list responses to percent-encode object keys by raw UTF-8 bytes instead of re-encoding each byte as a Unicode rune
- include `EncodingType` in `ListObjects` and `ListObjectsV2` XML responses so S3 clients can decode encoded keys correctly
- add a regression test for UTF-8 keys, spaces, and case-insensitive `encoding-type`

## Repro
Uploading `中文文件名-20260528-1132.txt` through objectnode previously produced:
- raw `ListObjectsV2`: `中文文件名-20260528-1132.txt`
- `encoding-type=url`: `%C3%A4%C2%B8%C2%AD...`

That double-encoded form broke MinIO Client interoperability. `mc ls` displayed garbled keys and `mc stat` could not resolve the object by its original UTF-8 name.

## Validation
- `go test ./objectnode -run TestEncodeKey -count=1 -v`
- rebuilt `cfs-server` on a live CubeFS test node and verified:
  - raw `ListObjectsV2` returns the original UTF-8 key
  - `encoding-type=url` returns `%E4%B8%AD...`
  - `mc ls` shows `中文文件名-20260528-1132.txt`
  - `mc stat 'cubefs91/test/中文文件名-20260528-1132.txt'` succeeds