### PR TITLE
fix(master): add retry for syncUpdateDataPartition on decommission status update

### DIFF
--- a/master/cluster.go
+++ b/master/cluster.go
@@ -6380,6 +6380,37 @@ func (c *Cluster) rangeAllParitions(f func(d *DataPartition) bool) {
 	}
 }
 
+// sync update data partition with retry,if retry all failed, log audit log
+func (c *Cluster) syncUpdateDataPartitionWithRetry(dp *DataPartition) error {
+	return retryPersistDataPartitionOp(dp.PartitionID, "syncUpdateDataPartition",
+		syncUpdateDPMaxRetries, syncUpdateDPRetryBaseInterval,
+		func() error { return c.syncUpdateDataPartition(dp) })
+}
+
+func retryPersistDataPartitionOp(partitionID uint64, opName string, maxRetries int, base time.Duration, fn func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if err := fn(); err == nil {
+			if attempt > 1 {
+				log.LogInfof("[retryPersistDataPartitionOp] %v dp(%v) succeeded after %v attempts",
+					opName, partitionID, attempt)
+			}
+			return nil
+		} else {
+			lastErr = err
+			log.LogWarnf("[retryPersistDataPartitionOp] %v dp(%v) attempt(%v/%v) failed: %v",
+				opName, partitionID, attempt, maxRetries, err)
+			if attempt < maxRetries {
+				time.Sleep(time.Duration(attempt) * base)
+			}
+		}
+	}
+	auditlog.LogMasterOp(opName,
+		fmt.Sprintf("dp(%v) all %v retries failed", partitionID, maxRetries), lastErr)
+	return errors.NewErrorf("dp(%v) %v failed after %v retries: %v",
+		partitionID, opName, maxRetries, lastErr)
+}
+
 func (c *Cluster) markDecommissionDataPartition(dp *DataPartition, src *DataNode, dstNodeSetID uint64, raftForce bool, migrateType uint32, weight int, triggerCondition string) (err error) {
 	addr := src.Addr
 	replica, err := dp.getReplica(addr)
@@ -6408,9 +6439,7 @@ func (c *Cluster) markDecommissionDataPartition(dp *DataPartition, src *DataNode
 		}
 	}
 
-	// TODO: handle error
-	updateErr := c.syncUpdateDataPartition(dp)
-	if updateErr != nil {
+	if updateErr := c.syncUpdateDataPartitionWithRetry(dp); updateErr != nil {
 		return errors.NewErrorf("dp(%v) mark decommission status failed, err(%v), updateErr(%v)", dp.PartitionID, err, updateErr)
 	}
 

--- a/master/cluster_retry_test.go
+++ b/master/cluster_retry_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package master
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// success on first try, no sleep
+func TestRetryPersistDataPartitionOp_SuccessOnFirstTry(t *testing.T) {
+	calls := 0
+	start := time.Now()
+	err := retryPersistDataPartitionOp(1, "testOp", 3, time.Millisecond, func() error {
+		calls++
+		return nil
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.Less(t, elapsed, 5*time.Millisecond)
+}
+
+// success after retry
+func TestRetryPersistDataPartitionOp_SuccessOnRetry(t *testing.T) {
+	calls := 0
+	err := retryPersistDataPartitionOp(2, "testOp", 3, time.Millisecond, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient raft error")
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, calls)
+}
+
+// all retries failed, check error message
+func TestRetryPersistDataPartitionOp_AllFail(t *testing.T) {
+	calls := 0
+	underlying := errors.New("raft down")
+	err := retryPersistDataPartitionOp(3, "testOp", 3, time.Millisecond, func() error {
+		calls++
+		return underlying
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 3, calls)
+	require.True(t, strings.Contains(err.Error(), "failed after 3 retries"))
+	require.True(t, strings.Contains(err.Error(), underlying.Error()))
+	require.True(t, strings.Contains(err.Error(), "dp(3)"))
+}
+
+// check linear backoff time
+func TestRetryPersistDataPartitionOp_LinearBackoff(t *testing.T) {
+	base := 20 * time.Millisecond
+	start := time.Now()
+	err := retryPersistDataPartitionOp(4, "testOp", 3, base, func() error {
+		return errors.New("boom")
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.GreaterOrEqual(t, elapsed, 3*base)
+	require.Less(t, elapsed, 6*base)
+}

--- a/master/const.go
+++ b/master/const.go
@@ -228,6 +228,8 @@ const (
 	EmptyCrcValue                          uint32 = 4045511210
 	DefaultZoneName                               = proto.DefaultZoneName
 	retrySendSyncTaskInternal                     = 3 * time.Second
+	syncUpdateDPMaxRetries                        = 3
+	syncUpdateDPRetryBaseInterval                 = time.Second
 	defaultRangeOfCountDifferencesAllowed         = 50
 	defaultMinusOfMaxInodeID                      = 1000
 	defaultNodeSetGrpBatchCnt                     = 3


### PR DESCRIPTION
<!-- Thanks for sending the pull request! -->

<!--
### Contribution Checklist

  - PR title format should be *type(scope): subject*. For details, see *[Pull Request Title](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message. For details, see *[Commit Message](https://github.com/cubefs/cubefs/blob/master/.github/workflows/check_pull_request.yml)*.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes: #4057 

<!-- or this PR is one task of an issue. -->

Main Issue: #4057 


### Motivation
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

In markDecommissionDataPartition, syncUpdateDataPartition(dp) fails immediately without retry. A transient raft issue (network jitter, leader change) can strand the decommission workflow and leave the partition in an inconsistent state. The original code carried a // TODO: handle error marker.

### Modifications
<!-- Describe the modifications you've done. -->

- Added syncUpdateDPMaxRetries=3 and syncUpdateDPRetryBaseInterval=1s in master/const.go
- Added syncUpdateDataPartitionWithRetry() with linear backoff retry in master/cluster.go
- Added retryPersistDataPartitionOp() helper, decoupled from *Cluster for testability
- Replaced the TODO call site in markDecommissionDataPartition
- Added 4 unit tests in master/cluster_retry_test.go


### Types of changes
<!-- Show in a checkbox-style, the expected types of changes your project is supposed to have: -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

This change added tests and can be verified as follows:
```bash
go test -run TestRetryPersistDataPartitionOp -v ./master
```


### Does this pull request potentially affect one of the following parts:
<!-- Which of the following parts are affected by this change? -->

- [x] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation
<!-- Is there a chinese and english document modification? -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Review Expection
<!-- How long would you like the team to be completed in your contributing? -->

- [x] `in-two-days`
- [ ] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository
<!-- enter the url if has PR in forked repository. -->

PR in forked repository: <!-- ENTER URL HERE -->

<!-- Thanks for contributing, best days! -->