### PR TITLE
bugfix: avoid applying log concurrency

### DIFF
--- a/depends/tiglabs/raft/raft.go
+++ b/depends/tiglabs/raft/raft.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/cubefs/cubefs/depends/tiglabs/raft/logger"
@@ -168,6 +169,10 @@ func newRaft(config *Config, raftConfig *RaftConfig) (*raft, error) {
 	if logger.IsEnableDebug() {
 		logger.Debug("newRaft:%d, peers: %v", raft.config.NodeID, raftConfig.Peers)
 	}
+
+	// Wire the drain hook so becomeLeader can wait for applyc to be drained before
+	// recoverCommit. Set after construction, before starting the goroutines.
+	r.drainApplyc = raft.drainApplyc
 
 	util.RunWorker(raft.runApply, raft.handlePanic)
 	util.RunWorker(raft.run, raft.handlePanic)
@@ -755,6 +760,29 @@ func (s *raft) resetApply() {
 			}
 			pool.returnApply(apply)
 		default:
+			return
+		}
+	}
+}
+
+// drainApplyc waits until runApply has drained applyc so that curApplied catches
+// up with raftLog.applied.
+//
+// Prerequisite: the caller (run goroutine) is NOT in the readyc branch after this
+// returns, so it will not push new entries into applyc via apply(). Consequently,
+// when becomeLeader's recoverCommit runs synchronously afterwards, applyc is empty
+// and runApply is blocked on <-applyc; it cannot invoke sm.Apply concurrently with
+// recoverCommit. This prevents the ordering bug where a larger-index log is applied
+// before a smaller-index one.
+//
+// Under normal operation applyc has no backlog and drainApplyc returns after a single
+// condition check. It only waits when a follower with applyc backlog transitions to
+// leader (election).
+func (s *raft) drainApplyc() {
+	for s.curApplied.Get() < s.raftFsm.raftLog.applied {
+		select {
+		case <-time.After(time.Millisecond):
+		case <-s.stopc:
 			return
 		}
 	}

--- a/depends/tiglabs/raft/raft_fsm.go
+++ b/depends/tiglabs/raft/raft_fsm.go
@@ -76,6 +76,13 @@ type raftFsm struct {
 	//electionFirstBegin is used to mark the begin time of continuous election
 	//It is valid if and only if mo != nil.
 	electionFirstBegin time.Time
+
+	// drainApplyc waits until the async apply goroutine has drained applyc so that
+	// curApplied catches up with raftLog.applied. It is set by the owning raft after
+	// the apply goroutine starts, and is nil during construction (applyc not started
+	// yet). becomeLeader calls it before recoverCommit to avoid applying logs
+	// concurrently with the async apply goroutine.
+	drainApplyc func()
 }
 
 func (fsm *raftFsm) getReplicas() (m string) {

--- a/depends/tiglabs/raft/raft_fsm_leader.go
+++ b/depends/tiglabs/raft/raft_fsm_leader.go
@@ -29,6 +29,12 @@ func (r *raftFsm) becomeLeader() {
 	if r.state == stateFollower {
 		panic(AppPanicError(fmt.Sprintf("[raft->becomeLeader][%v] invalid transition [follower -> leader].", r.id)))
 	}
+	// Wait until the async apply goroutine has drained applyc before recoverCommit,
+	// so recoverCommit does not apply logs concurrently with it. drainApplyc is nil
+	// during construction (applyc not started yet), in which case no drain is needed.
+	if r.drainApplyc != nil {
+		r.drainApplyc()
+	}
 	r.recoverCommit()
 	lasti := r.raftLog.lastIndex()
 	r.step = stepLeader


### PR DESCRIPTION
This fix prevents concurrent log application during leader election to avoid ordering bugs where larger-index logs are applied before smaller-index ones.

Changes:
- Add `drainApplyc` hook to wait for async apply goroutine to drain before recoverCommit
- Wire the hook in newRaft before starting goroutines
- Call drainApplyc in becomeLeader before recoverCommit