### PR TITLE
fix(metanode): rebuild free lists after snapshot restore

### DIFF
--- a/metanode/free_list.go
+++ b/metanode/free_list.go
@@ -65,6 +65,22 @@ func (fl *freeList) Remove(ino uint64) {
 	}
 }
 
+func (fl *freeList) replace(other *freeList) {
+	if fl == other {
+		return
+	}
+
+	other.Lock()
+	defer other.Unlock()
+	fl.Lock()
+	defer fl.Unlock()
+
+	fl.list = other.list
+	fl.index = other.index
+	other.list = list.New()
+	other.index = make(map[uint64]*list.Element)
+}
+
 func (fl *freeList) Len() int {
 	fl.Lock()
 	defer fl.Unlock()

--- a/metanode/partition_fsm.go
+++ b/metanode/partition_fsm.go
@@ -693,6 +693,8 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 		txTree         = NewBtree()
 		txRbInodeTree  = NewBtree()
 		txRbDentryTree = NewBtree()
+		freeList       = newFreeList()
+		freeHybridList = newFreeList()
 		uniqChecker    = newUniqChecker()
 		verList        []*proto.VolVersionInfo
 	)
@@ -748,6 +750,8 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 			mp.txProcessor.txManager.txTree = txTree
 			mp.txProcessor.txResource.txRbInodeTree = txRbInodeTree
 			mp.txProcessor.txResource.txRbDentryTree = txRbDentryTree
+			mp.freeList.replace(freeList)
+			mp.freeHybridList.replace(freeHybridList)
 			mp.uniqChecker = uniqChecker
 			mp.multiVersionList.VerList = make([]*proto.VolVersionInfo, len(verList))
 			copy(mp.multiVersionList.VerList, verList)
@@ -860,6 +864,7 @@ func (mp *metaPartition) ApplySnapshot(peers []raftproto.Peer, iter raftproto.Sn
 				cursor = ino.Inode
 			}
 			inodeTree.ReplaceOrInsert(ino, true)
+			checkAndInsertFreeLists(ino, freeList, freeHybridList)
 			log.LogDebugf("ApplySnapshot: create inode: partitonID(%v) inode[%v].", mp.config.PartitionId, ino)
 		case opFSMCreateDentry:
 			dentry := &Dentry{}

--- a/metanode/partition_fsm_test.go
+++ b/metanode/partition_fsm_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metanode
+
+import (
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/stretchr/testify/require"
+)
+
+type sliceSnapshotIterator struct {
+	items [][]byte
+	index int
+}
+
+func (iter *sliceSnapshotIterator) Next() ([]byte, error) {
+	if iter.index >= len(iter.items) {
+		return nil, io.EOF
+	}
+	item := iter.items[iter.index]
+	iter.index++
+	return item, nil
+}
+
+func marshalSnapshotItem(t *testing.T, item *MetaItem) []byte {
+	t.Helper()
+	data, err := item.MarshalBinary()
+	require.NoError(t, err)
+	return data
+}
+
+func TestApplySnapshotRebuildsFreeLists(t *testing.T) {
+	manager := &metadataManager{
+		metaNode: &MetaNode{raftSyncSnapFormatVersion: SnapFormatVersion_1},
+	}
+	mp := newMetaPartition(1, manager)
+	mp.multiVersionList = &proto.VolVersionInfoList{}
+	mp.storedApplyId = 1
+	mp.extReset = make(chan struct{}, 1)
+
+	// Entries from the state replaced by the snapshot must not survive.
+	mp.freeList.Push(999)
+	mp.freeHybridList.Push(998)
+
+	deleted := NewInode(101, 0)
+	deleted.SetDeleteMark()
+	migration := NewInode(102, 0)
+	migration.SetDeleteMigrationExtentKeyImmediately()
+	live := NewInode(103, 0)
+
+	formatVersion := make([]byte, 8)
+	binary.BigEndian.PutUint32(formatVersion, SnapFormatVersion_1)
+	applyID := make([]byte, 8)
+	binary.BigEndian.PutUint64(applyID, 1)
+
+	iter := &sliceSnapshotIterator{items: [][]byte{
+		marshalSnapshotItem(t, NewMetaItem(opFSMSnapFormatVersion, nil, formatVersion)),
+		marshalSnapshotItem(t, NewMetaItem(opFSMApplyId, nil, applyID)),
+		marshalSnapshotItem(t, NewMetaItem(opFSMCreateInode, deleted.MarshalKey(), deleted.MarshalValue())),
+		marshalSnapshotItem(t, NewMetaItem(opFSMCreateInode, migration.MarshalKey(), migration.MarshalValue())),
+		marshalSnapshotItem(t, NewMetaItem(opFSMCreateInode, live.MarshalKey(), live.MarshalValue())),
+	}}
+
+	require.NoError(t, mp.ApplySnapshot(nil, iter))
+	require.NotNil(t, mp.inodeTree.Get(NewInode(live.Inode, 0)))
+	require.Equal(t, 1, mp.freeList.Len())
+	require.Equal(t, deleted.Inode, mp.freeList.Pop())
+	require.Equal(t, 1, mp.freeHybridList.Len())
+	require.Equal(t, migration.Inode, mp.freeHybridList.Pop())
+}
+
+func TestApplySnapshotKeepsFreeListsOnError(t *testing.T) {
+	manager := &metadataManager{
+		metaNode: &MetaNode{raftSyncSnapFormatVersion: SnapFormatVersion_1},
+	}
+	mp := newMetaPartition(1, manager)
+	mp.freeList.Push(999)
+	mp.freeHybridList.Push(998)
+
+	deleted := NewInode(101, 0)
+	deleted.SetDeleteMark()
+	formatVersion := make([]byte, 8)
+	binary.BigEndian.PutUint32(formatVersion, SnapFormatVersion_1)
+
+	iter := &sliceSnapshotIterator{items: [][]byte{
+		marshalSnapshotItem(t, NewMetaItem(opFSMSnapFormatVersion, nil, formatVersion)),
+		marshalSnapshotItem(t, NewMetaItem(opFSMCreateInode, deleted.MarshalKey(), deleted.MarshalValue())),
+		[]byte("invalid snapshot item"),
+	}}
+
+	require.Error(t, mp.ApplySnapshot(nil, iter))
+	require.Equal(t, 1, mp.freeList.Len())
+	require.Equal(t, uint64(999), mp.freeList.Pop())
+	require.Equal(t, 1, mp.freeHybridList.Len())
+	require.Equal(t, uint64(998), mp.freeHybridList.Pop())
+}

--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -755,16 +755,20 @@ func (mp *metaPartition) fsmBatchEvictInode(ib InodeBatch) (resp []*InodeRespons
 }
 
 func (mp *metaPartition) checkAndInsertFreeList(ino *Inode) {
+	checkAndInsertFreeLists(ino, mp.freeList, mp.freeHybridList)
+}
+
+func checkAndInsertFreeLists(ino *Inode, targetFreeList, targetFreeHybridList *freeList) {
 	if proto.IsDir(ino.Type) {
 		return
 	}
 	if ino.ShouldDelete() {
-		mp.freeList.Push(ino.Inode)
+		targetFreeList.Push(ino.Inode)
 	} else if ino.IsTempFile() {
 		ino.AccessTime = time.Now().Unix()
-		mp.freeList.Push(ino.Inode)
+		targetFreeList.Push(ino.Inode)
 	} else if ino.ShouldDeleteMigrationExtentKey(true) {
-		mp.freeHybridList.Push(ino.Inode)
+		targetFreeHybridList.Push(ino.Inode)
 	}
 }
 


### PR DESCRIPTION
Fixes: #4006

### Motivation

MetaNode's disk snapshot loader rebuilds `freeList` and `freeHybridList` while
loading inodes. The Raft `ApplySnapshot` path rebuilt and installed the inode tree
without rebuilding those queues. After a replica applied a snapshot, deleted or
migration-cleanup inodes could therefore remain in the tree without being queued
for reclamation.

### Modifications

- Reuse the disk-load inode classification for Raft snapshot items.
- Build both free lists alongside the temporary snapshot trees.
- Replace the live list contents under their existing locks only after a complete
  snapshot, preserving stable list pointers for concurrent readers and workers.
- Preserve the prior lists when snapshot decoding fails.
- Add regression coverage for deleted, migration-cleanup, live, and stale entries,
  plus the malformed-snapshot error path.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the relevant testing checks.

This change added tests and was verified as follows in CubeFS's Go 1.18.10
Linux/amd64 container:

- `go test -count=1 ./metanode -run '^TestApplySnapshot(Rebuilds|Keeps)FreeLists'`
- `go test -count=1 ./metanode`
- `gofumpt -l -d` on all changed Go files
- `golangci-lint run ... ./metanode` using the repository's enabled linters

The broader `docker/run_docker.sh --testcubefs` lane was also attempted under
amd64 emulation. It reached unrelated existing sparse-file assertion failures in
`datanode/storage` (`TestSeekHole` and `TestExtentRecovery`); the complete MetaNode
package passed separately with CGo and the prepared repository libraries.

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [x] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

No configuration, API, or snapshot wire-format behavior changes.

### Review Expection

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository

PR in forked repository:
https://github.com/AkashKumar7902/cubefs/tree/agent/fix-metanode-snapshot-free-list
