### PR TITLE
fix(objectnode): accept CRC32 checksum for batch delete

### DIFF
--- a/objectnode/api_handler_object.go
+++ b/objectnode/api_handler_object.go
@@ -536,6 +536,24 @@ func (o *ObjectNode) headObjectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func verifyDeleteObjectsChecksum(header http.Header, body []byte) *ErrorCode {
+	// Preserve Content-MD5 as the authoritative checksum when both headers exist.
+	requestChecksum := header.Get(ContentMD5)
+	calculateChecksum := GetMD5
+	if requestChecksum == "" {
+		requestChecksum = header.Get(XAmzChecksumCRC32)
+		calculateChecksum = getCRC32
+	}
+
+	if requestChecksum == "" {
+		return MissingContentMD5
+	}
+	if requestChecksum != calculateChecksum(body) {
+		return BadDigest
+	}
+	return nil
+}
+
 // Delete objects (multiple objects)
 // API reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
 func (o *ObjectNode) deleteObjectsHandler(w http.ResponseWriter, r *http.Request) {
@@ -561,8 +579,7 @@ func (o *ObjectNode) deleteObjectsHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	requestMD5 := r.Header.Get(ContentMD5)
-	if requestMD5 == "" {
+	if r.Header.Get(ContentMD5) == "" && r.Header.Get(XAmzChecksumCRC32) == "" {
 		errorCode = MissingContentMD5
 		return
 	}
@@ -578,8 +595,7 @@ func (o *ObjectNode) deleteObjectsHandler(w http.ResponseWriter, r *http.Request
 		errorCode = UnexpectedContent
 		return
 	}
-	if requestMD5 != GetMD5(bytes) {
-		errorCode = BadDigest
+	if errorCode = verifyDeleteObjectsChecksum(r.Header, bytes); errorCode != nil {
 		return
 	}
 

--- a/objectnode/api_handler_object_test.go
+++ b/objectnode/api_handler_object_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package objectnode
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyDeleteObjectsChecksum(t *testing.T) {
+	body := []byte(`<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Object><Key>example</Key></Object></Delete>`)
+	header := func(values ...string) http.Header {
+		h := make(http.Header)
+		for i := 0; i < len(values); i += 2 {
+			h.Set(values[i], values[i+1])
+		}
+		return h
+	}
+
+	tests := []struct {
+		name      string
+		header    http.Header
+		errorCode *ErrorCode
+	}{
+		{
+			name:   "content md5",
+			header: header(ContentMD5, GetMD5(body)),
+		},
+		{
+			name:   "boto3 crc32",
+			header: header("x-amz-sdk-checksum-algorithm", "CRC32", XAmzChecksumCRC32, "upiFyg=="),
+		},
+		{
+			name:      "invalid content md5",
+			header:    header(ContentMD5, "invalid"),
+			errorCode: BadDigest,
+		},
+		{
+			name:      "invalid crc32",
+			header:    header(XAmzChecksumCRC32, "invalid"),
+			errorCode: BadDigest,
+		},
+		{
+			name:      "missing checksum",
+			header:    make(http.Header),
+			errorCode: MissingContentMD5,
+		},
+		{
+			name:      "content md5 takes precedence",
+			header:    header(ContentMD5, "invalid", XAmzChecksumCRC32, "upiFyg=="),
+			errorCode: BadDigest,
+		},
+		{
+			name:   "valid content md5 ignores invalid crc32",
+			header: header(ContentMD5, GetMD5(body), XAmzChecksumCRC32, "invalid"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.errorCode, verifyDeleteObjectsChecksum(test.header, body))
+		})
+	}
+}

--- a/objectnode/const.go
+++ b/objectnode/const.go
@@ -68,6 +68,7 @@ const (
 	XAmzCopySourceIfModifiedSince   = "x-amz-copy-source-if-modified-since"
 	XAmzCopySourceIfUnmodifiedSince = "x-amz-copy-source-if-unmodified-since"
 	XAmzDecodedContentLength        = "x-amz-decoded-content-length"
+	XAmzChecksumCRC32               = "x-amz-checksum-crc32"
 	XAmzTagging                     = "x-amz-tagging"
 	XAmzMetaPrefix                  = "x-amz-meta-"
 	XAmzMpPartsCount                = "x-amz-mp-parts-count"

--- a/objectnode/util.go
+++ b/objectnode/util.go
@@ -22,7 +22,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"net"
 	"net/http"
 	"net/url"
@@ -338,6 +340,12 @@ func GetMD5(b []byte) string {
 	hash := md5.New()
 	hash.Write(b)
 	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
+}
+
+func getCRC32(b []byte) string {
+	checksum := make([]byte, 4)
+	binary.BigEndian.PutUint32(checksum, crc32.ChecksumIEEE(b))
+	return base64.StdEncoding.EncodeToString(checksum)
 }
 
 func contains(items []string, key string) bool {


### PR DESCRIPTION
Fixes: #3813

### Motivation

[Boto3 1.36.0](https://github.com/boto/boto3/blob/89a83aaf7f314251ff23e39fb37facd94bac0fcf/.changes/1.36.0.json#L64)
changed `DeleteObjects` requests to use a flexible CRC32 checksum by default
instead of automatically adding `Content-MD5`. ObjectNode currently requires
`Content-MD5` before reading the request body, so otherwise valid batch-delete
requests from that client are rejected with `InvalidRequest`.

### Modifications

- Accept `x-amz-checksum-crc32` when `Content-MD5` is absent.
- Validate the request body with IEEE CRC32, encoded as four big-endian bytes
  in standard base64, rather than bypassing integrity validation.
- Keep `Content-MD5` authoritative when both checksum headers are present, so
  existing clients retain their previous validation behavior.
- Add deterministic regression coverage for the exact boto3 request shape,
  legacy MD5, invalid and missing checksums, and MD5 precedence.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the testing checks.

This change added tests and was verified in CubeFS's Go 1.18.10 Linux/amd64
container:

- `go test -count=20 -run '^TestVerifyDeleteObjectsChecksum$' ./objectnode`
- `go test -race -count=1 -run '^TestVerifyDeleteObjectsChecksum$' ./objectnode`
- `go test -count=1 ./objectnode`
- `gofumpt` on all changed Go files
- `golangci-lint run ... ./objectnode` using the repository's enabled linters
- `git diff --check`

The hard-coded boto3 fixture was also independently checked against both
`zlib.crc32` and a separate bitwise IEEE CRC32 implementation.

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [x] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

No configuration, deployment, or public API documentation changes are needed.

### Review Expection

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository

PR in forked repository:
https://github.com/AkashKumar7902/cubefs/tree/agent/fix-delete-objects-crc32
