### PR TITLE
fix(test): stabilize recycle timer and flashnode tests

### DIFF
--- a/remotecache/flashnode/flashnode_test.go
+++ b/remotecache/flashnode/flashnode_test.go
@@ -103,13 +103,20 @@ func newFlashnode() *FlashNode {
 }
 
 func TestFlashNode(t *testing.T) {
+	t.Setenv(cachengine.EnvDockerTmpfs, "on")
+	cachePath := t.TempDir()
+
 	t.Run("New", testNew)
-	t.Run("Config", testConfig)
+	if !t.Run("Config", func(t *testing.T) {
+		testConfig(t, cachePath)
+	}) {
+		return
+	}
 	t.Run("MissCache", testShouldCache)
 	t.Run("TCP", testTCP)
 	t.Run("HTTP", testHTTP)
 	t.Run("ManualScan", testManualScanner)
-	t.Run("Shotdown", testShutdown)
+	t.Run("Shutdown", testShutdown)
 }
 
 func testNew(t *testing.T) {
@@ -117,7 +124,7 @@ func testNew(t *testing.T) {
 	f.register()
 }
 
-func testConfig(t *testing.T) {
+func testConfig(t *testing.T, cachePath string) {
 	flashServer = newFlashnode()
 	httpServer = &http.Server{
 		Addr:    fmt.Sprintf("127.0.0.1:%d", flashHTTP),
@@ -133,7 +140,7 @@ func testConfig(t *testing.T) {
 		{`"readRps":0,`, `"readRps":-1,"cachePercent":0.001,`},
 		{``, `"cachePercent":0.9,`, `"cachePercent":0.001,`},
 		{`"cachePercent":0.2,`, `"cacheTotal":1024,`},
-		{fmt.Sprintf("\"diskDataPath\":[\"%s\"],", "/cfs/tmpfs:0"), `"diskDataPath":[],`},
+		{fmt.Sprintf("\"diskDataPath\":[\"%s:0\"],", cachePath), `"diskDataPath":[],`},
 		{`"disableTmpfs": true,`},
 		{`"reservedSpace":1,`},
 		{fmt.Sprintf("\"masterAddr\":[\"%s\"],", masterAddr), `"masterAddr":[],`},

--- a/util/recycle_timer_test.go
+++ b/util/recycle_timer_test.go
@@ -40,7 +40,7 @@ func TestRecycleTimer(t *testing.T) {
 	require.GreaterOrEqual(t, actual, smallBufSize)
 	require.GreaterOrEqual(t, inUsed, smallBufSize)
 
-	timer, err := util.NewRecycleTimer(1*time.Second, 0, largeBufSize)
+	timer, err := util.NewRecycleTimer(1*time.Second, 0, smallBufSize)
 	require.NoError(t, err)
 	defer timer.Stop()
 
@@ -74,7 +74,10 @@ func TestRecycleTimer(t *testing.T) {
 	require.GreaterOrEqual(t, actual, smallBufSize)
 	require.Less(t, inUsed, smallBufSize)
 
-	time.Sleep(2 * time.Second)
+	require.Eventually(t, func() bool {
+		current, err := loadutil.GetCurrentProcessMemory()
+		return err == nil && current < largeBufSize
+	}, 10*time.Second, 100*time.Millisecond)
 
 	actual, err = loadutil.GetCurrentProcessMemory()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes: #4021

### Motivation

`TestRecycleTimer` configured its minimum recycle limit to the same 2 GiB used
for the large test allocation. The timer only releases memory when process RSS
is greater than the Go heap plus that limit. In the reported failure, the
post-GC RSS/heap gap was below 2 GiB, so recycling correctly never triggered,
but the test still expected RSS to fall below 2 GiB after a fixed sleep.

`TestFlashNode` also assumed `/cfs/tmpfs` was a writable mount point. When that
setup failed, dependent TCP and HTTP subtests continued against an unstarted
server, and the final shutdown subtest attempted to close a nil channel.

### Modifications

- Use a 1 GiB recycle limit so the 2 GiB released allocation gives the timer a
  real trigger margin.
- Poll for asynchronous RSS release instead of assuming it completes within a
  fixed two-second delay.
- Give FlashNode a parent-scoped temporary cache directory and set the same
  test-only mount override used by CubeFS's Docker configuration.
- Stop dependent FlashNode subtests when configuration fails, preventing the
  misleading TCP/HTTP cascade and unsafe shutdown.
- Correct the `Shotdown` subtest name to `Shutdown`.

No production code or runtime configuration behavior is changed.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the testing checks.

The failure was reproduced on current `master` without an externally supplied
`DOCKER_FLASHNODE_TMPFS_OFF`: FlashNode configuration failed, dependent tests
cascaded, and shutdown panicked on a nil channel. The patched tests were then
verified as follows:

- `go test -count=1 -run '^TestRecycleTimer$' -v ./util` in three fresh processes
- `go test -count=1 -run '^TestFlashNode$' -v ./remotecache/flashnode` in three fresh processes
- `go test -p 1 -count=1 ./util ./remotecache/flashnode`
- Both targeted tests on Linux/arm64 with Go 1.26
- `gofumpt` on both changed files
- `golangci-lint run ... ./util ./remotecache/flashnode`
- `git diff --check`

The Go 1.18.10 tests used CubeFS's official Linux/amd64 build image with the
tmpfs override explicitly unset outside the test.

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [x] Other Tools
- [x] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

This is a test-only change with no user-facing configuration or API changes.

### Review Expection

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository

PR in forked repository:
https://github.com/AkashKumar7902/cubefs/tree/agent/stabilize-recycle-flashnode-tests
