### PR TITLE
fix(metanode): remove empty directories on eviction

### DIFF
--- a/metanode/partition_fsmop_inode.go
+++ b/metanode/partition_fsmop_inode.go
@@ -727,7 +727,7 @@ func (mp *metaPartition) fsmEvictInode(ino *Inode) (resp *InodeResponse) {
 	}
 	if proto.IsDir(i.Type) {
 		if i.IsEmptyDirAndNoSnapshot() {
-			i.SetDeleteMark()
+			mp.inodeTree.Delete(i)
 		}
 		return
 	}

--- a/metanode/partition_fsmop_inode_test.go
+++ b/metanode/partition_fsmop_inode_test.go
@@ -1,0 +1,80 @@
+// Copyright 2018 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metanode
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cubefs/cubefs/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFSMEvictInodeDirectory(t *testing.T) {
+	const inodeID = 101
+
+	tests := []struct {
+		name       string
+		prepare    func(*Inode)
+		wantExists bool
+	}{
+		{
+			name:       "empty directory",
+			wantExists: false,
+		},
+		{
+			name: "non-empty directory",
+			prepare: func(inode *Inode) {
+				inode.NLink = 3
+			},
+			wantExists: true,
+		},
+		{
+			name: "directory with snapshot",
+			prepare: func(inode *Inode) {
+				inode.multiSnap = NewMultiSnap(2)
+				inode.multiSnap.multiVersions = []*Inode{NewInode(inode.Inode, inode.Type)}
+			},
+			wantExists: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mp := &metaPartition{
+				inodeTree: NewBtree(),
+				freeList:  newFreeList(),
+			}
+			inode := NewInode(inodeID, uint32(os.ModeDir))
+			if test.prepare != nil {
+				test.prepare(inode)
+			}
+			_, inserted := mp.inodeTree.ReplaceOrInsert(inode, false)
+			require.True(t, inserted)
+
+			resp := mp.fsmEvictInode(NewInode(inodeID, 0))
+
+			require.EqualValues(t, proto.OpOk, resp.Status)
+			got := mp.inodeTree.Get(NewInode(inodeID, 0))
+			if test.wantExists {
+				require.NotNil(t, got)
+				require.False(t, got.(*Inode).ShouldDelete())
+			} else {
+				require.Nil(t, got)
+			}
+			require.Zero(t, mp.freeList.Len())
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #1565

### Motivation

`fsmEvictInode` marks an eligible empty directory as deleted but leaves it in
the inode tree. Directory inodes are intentionally excluded from the free list,
so no later worker reclaims the marked inode. Lookups treat the inode as absent,
while MetaNode snapshots continue to retain it.

### Modifications

- Delete snapshot-free empty directories directly from the inode tree during
  eviction.
- Preserve non-empty directories and directories with snapshot layers.
- Add regression coverage for all three cases and verify that directories are
  not added to the free list.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the testing checks.

This change added tests and was verified in CubeFS's Go 1.18.10 Linux/amd64
build image:

- `go test -count=1 -run '^TestFSMEvictInodeDirectory$' -v ./metanode`
- `go test -count=1 ./metanode`
- `golangci-lint run ... ./metanode` using the repository's enabled linters
- `gofmt` on the added test and `git diff --check`

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [x] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

No public API, configuration, deployment, or wire-format behavior changes.

### Review Expection

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository

PR in forked repository:
https://github.com/AkashKumar7902/cubefs/tree/agent/fix-empty-dir-eviction
