### PR TITLE
fix(client): report valid inode usage in statfs

### DIFF
--- a/client/fs/super.go
+++ b/client/fs/super.go
@@ -408,9 +408,16 @@ func (s *Super) Node(ino, pino uint64, mode uint32) (fs.Node, error) {
 	return node, nil
 }
 
+func statfsInodeCounts(inodeCount uint64) (files, free uint64) {
+	const defaultMaxMetaPartitionInodeID uint64 = 1<<63 - 1
+	if inodeCount >= defaultMaxMetaPartitionInodeID {
+		return defaultMaxMetaPartitionInodeID, 0
+	}
+	return defaultMaxMetaPartitionInodeID, defaultMaxMetaPartitionInodeID - inodeCount
+}
+
 // Statfs handles the Statfs request and returns a set of statistics.
 func (s *Super) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
-	const defaultMaxMetaPartitionInodeID uint64 = 1<<63 - 1
 	total, used, inodeCount := s.mw.Statfs()
 	resp.Blocks = total / uint64(DefaultBlksize)
 	resp.Bfree = (total - used) / uint64(DefaultBlksize)
@@ -418,8 +425,7 @@ func (s *Super) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.
 	resp.Bsize = DefaultBlksize
 	resp.Namelen = DefaultMaxNameLen
 	resp.Frsize = DefaultBlksize
-	resp.Files = inodeCount
-	resp.Ffree = defaultMaxMetaPartitionInodeID - inodeCount
+	resp.Files, resp.Ffree = statfsInodeCounts(inodeCount)
 	return nil
 }
 

--- a/client/fs/super_test.go
+++ b/client/fs/super_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fs
+
+import "testing"
+
+func TestStatfsInodeCounts(t *testing.T) {
+	const maxInodeID uint64 = 1<<63 - 1
+	tests := []struct {
+		name         string
+		inodeCount   uint64
+		expectedFree uint64
+		expectedUsed uint64
+	}{
+		{
+			name:         "no used inodes",
+			inodeCount:   0,
+			expectedFree: maxInodeID,
+			expectedUsed: 0,
+		},
+		{
+			name:         "used inodes",
+			inodeCount:   42,
+			expectedFree: maxInodeID - 42,
+			expectedUsed: 42,
+		},
+		{
+			name:         "all inodes used",
+			inodeCount:   maxInodeID,
+			expectedFree: 0,
+			expectedUsed: maxInodeID,
+		},
+		{
+			name:         "inode count above maximum",
+			inodeCount:   maxInodeID + 1,
+			expectedFree: 0,
+			expectedUsed: maxInodeID,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			files, free := statfsInodeCounts(test.inodeCount)
+			if files != maxInodeID {
+				t.Fatalf("expected %d total inodes, got %d", maxInodeID, files)
+			}
+			if free != test.expectedFree {
+				t.Fatalf("expected %d free inodes, got %d", test.expectedFree, free)
+			}
+			if used := files - free; used != test.expectedUsed {
+				t.Fatalf("expected %d used inodes, got %d", test.expectedUsed, used)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #3458

### Motivation

CubeFS reports the current inode count in the FUSE `Files` field while calculating `Ffree`
from the maximum inode ID. `Files` represents total inodes and `Ffree` represents free inodes,
so the current response normally reports more free inodes than total inodes. As a result,
`df -i` cannot calculate and display valid inode usage.

### Modifications

- Report the maximum inode capacity as the total inode count.
- Calculate free inodes from the used count and saturate at zero to avoid unsigned underflow.
- Add table-driven tests for empty, normal, full, and over-limit inode counts.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the testing checks.

This change added tests and was verified in the official
`cubefs/cbfs-base:1.0-golang-1.18.10` Linux image after sourcing `build/cgo_env.sh`:

- `go test ./client/fs -run '^TestStatfsInodeCounts$' -count=1`
- `go test ./client/fs -count=1`
- `CGO_ENABLED=0 golangci-lint run --issues-exit-code=1 --timeout 10m --skip-dirs depends --max-same-issues 1000 -D errcheck -E bodyclose ./client/fs`

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [x] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Review Expection

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository

PR in forked repository: https://github.com/AkashKumar7902/cubefs/tree/agent/fix-statfs-inode-count
