### PR TITLE
fix(client): return special file types from readdir

### DIFF
--- a/client/fs/const.go
+++ b/client/fs/const.go
@@ -15,6 +15,7 @@
 package fs
 
 import (
+	"os"
 	"syscall"
 	"time"
 
@@ -80,10 +81,22 @@ func ParseError(err error) fuse.Errno {
 
 // ParseType returns the dentry type.
 func ParseType(t uint32) fuse.DirentType {
-	if proto.IsDir(t) {
+	switch proto.OsModeType(t) {
+	case 0:
+		return fuse.DT_File
+	case os.ModeDir:
 		return fuse.DT_Dir
-	} else if proto.IsSymlink(t) {
+	case os.ModeSymlink:
 		return fuse.DT_Link
+	case os.ModeNamedPipe:
+		return fuse.DT_FIFO
+	case os.ModeSocket:
+		return fuse.DT_Socket
+	case os.ModeDevice:
+		return fuse.DT_Block
+	case os.ModeDevice | os.ModeCharDevice:
+		return fuse.DT_Char
+	default:
+		return fuse.DT_Unknown
 	}
-	return fuse.DT_File
 }

--- a/client/fs/const_test.go
+++ b/client/fs/const_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cubefs/cubefs/depends/bazil.org/fuse"
+	"github.com/cubefs/cubefs/proto"
+)
+
+func TestParseType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     os.FileMode
+		expected fuse.DirentType
+	}{
+		{name: "regular file", mode: 0o644, expected: fuse.DT_File},
+		{name: "directory", mode: os.ModeDir | 0o755, expected: fuse.DT_Dir},
+		{name: "symbolic link", mode: os.ModeSymlink | 0o777, expected: fuse.DT_Link},
+		{name: "named pipe", mode: os.ModeNamedPipe | 0o644, expected: fuse.DT_FIFO},
+		{name: "socket", mode: os.ModeSocket | 0o755, expected: fuse.DT_Socket},
+		{name: "block device", mode: os.ModeDevice | 0o600, expected: fuse.DT_Block},
+		{
+			name:     "character device",
+			mode:     os.ModeDevice | os.ModeCharDevice | 0o600,
+			expected: fuse.DT_Char,
+		},
+		{name: "unknown", mode: os.ModeIrregular | 0o600, expected: fuse.DT_Unknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual := ParseType(proto.Mode(test.mode)); actual != test.expected {
+				t.Fatalf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #1501

### Motivation

CubeFS persists Go file-mode type bits in directory entries, but `ParseType` only recognizes
directories and symbolic links. Every other entry is reported to FUSE as a regular file, so
callers such as Go's `os.ReadDir` receive the wrong type for named pipes and Unix sockets.

### Modifications

- Map stored Go file modes to the corresponding FUSE directory-entry types.
- Return `DT_Unknown` for irregular or unrecognized type combinations instead of reporting a
  regular file.
- Add table-driven coverage for regular files, directories, links, FIFOs, sockets, block and
  character devices, and unknown types.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

- [x] Make sure that the change passes the testing checks.

This change added tests and was verified in the official
`cubefs/cbfs-base:1.0-golang-1.18.10` Linux image after sourcing `build/cgo_env.sh`:

- `go test ./client/fs -run '^TestParseType$' -count=1`
- `go test ./client/fs -count=1`
- `CGO_ENABLED=0 golangci-lint run --issues-exit-code=1 --timeout 10m --skip-dirs depends --max-same-issues 1000 -D errcheck -E bodyclose ./client/fs`
- `git diff --check`

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [ ] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [x] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

### Review Expection

- [ ] `in-two-days`
- [x] `weekly`
- [ ] `free-time`
- [ ] `whenever`

### Matching PR in forked repository

PR in forked repository: https://github.com/AkashKumar7902/cubefs/tree/agent/fix-readdir-special-file-types
