### PR TITLE
fix(objectnode): use full ISO8601 timestamp in chunked SigV4 chunk signing

### DIFF
--- a/objectnode/auth_header.go
+++ b/objectnode/auth_header.go
@@ -233,7 +233,15 @@ func (auth *HeaderAuth) buildSignatureChunk(secretKey string) string {
 
 	signature := calculateSignature(signingKey, auth.stringToSign)
 
-	auth.request.Body = NewSignChunkedReader(auth.request.Body, signingKey, scope, cred.Date, signature)
+	// Per-chunk signing (https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html)
+	// uses the full ISO8601 request timestamp ("20060102T150405Z") in each chunk's
+	// string-to-sign, not the short credential-scope date ("20060102") -- every AWS SDK
+	// builds it this way (confirmed directly against aws-sdk-java-v2's
+	// SigV4ChunkExtensionProvider#getStringToSign, which uses credentialScope.getDatetime(),
+	// the full timestamp). Passing cred.Date here instead of cred.TimeStamp made every
+	// chunk signature verification fail unconditionally for any client that actually uses
+	// chunked/streaming SigV4 uploads, independent of SDK version.
+	auth.request.Body = NewSignChunkedReader(auth.request.Body, signingKey, scope, cred.TimeStamp, signature)
 
 	return signature
 }

--- a/objectnode/auth_header_test.go
+++ b/objectnode/auth_header_test.go
@@ -15,8 +15,11 @@
 package objectnode
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -244,4 +247,54 @@ func TestHeaderAuthV4SignatureMatch(t *testing.T) {
 	ha, err = NewHeaderAuth(request)
 	require.NoError(t, err)
 	require.True(t, ha.SignatureMatch(secretKey, wildcards))
+}
+
+// TestHeaderAuthV4ChunkedBodySignatureMatch is a regression test for
+// buildSignatureChunk wiring NewSignChunkedReader up with the wrong signing
+// datetime (it passed the short credential-scope date, e.g. "20130524",
+// instead of the full ISO8601 request timestamp, e.g. "20130524T000000Z",
+// that https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
+// -- and every AWS SDK -- actually uses for each chunk's string-to-sign).
+// That bug made SignatureMatch itself still return true (it only governs
+// the seed/outer request signature), but every subsequent read of the
+// wrapped chunked body would fail with "signature of chunk does not match",
+// so this test must actually read the body through, not just check
+// SignatureMatch's return value like TestHeaderAuthV4SignatureMatch does.
+//
+// Uses the same official AWS chunked-upload example
+// (examplebucket/chunkObject.txt) as TestHeaderAuthV4SignatureMatch's
+// "Chunked PUT Object" case and TestSignChunkedReader.
+func TestHeaderAuthV4ChunkedBodySignatureMatch(t *testing.T) {
+	secretKey := "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	wildcards, err := NewWildcards([]string{"s3.amazonaws.com"})
+	require.NoError(t, err)
+
+	body := bytes.NewBuffer(nil)
+	body.WriteString("10000;chunk-signature=ad80c730a21e5b8d04586a2213dd63b9a0e99e0e2307b0ade35a65485a288648\r\n")
+	body.WriteString(strings.Repeat("a", 65536))
+	body.WriteString("\r\n")
+	body.WriteString("400;chunk-signature=0055627c9e194cb4542bae2aa5492e3c1575bbb81b612b7d234b86a503ef5497\r\n")
+	body.WriteString(strings.Repeat("a", 1024))
+	body.WriteString("\r\n")
+	body.WriteString("0;chunk-signature=b6c6ea8a5354eaf15b3cb7646744f4275b71ea724fed81ceb9323e279d449df9\r\n")
+	body.WriteString("\r\n")
+
+	request := httptest.NewRequest("PUT", "http://s3.amazonaws.com/examplebucket/chunkObject.txt", body)
+	request.Header.Set(Authorization, "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=content-encoding;content-length;host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-storage-class,Signature=4f232c4386841ef735655705268965c44a0e4690baa4adea153f7db9fa80a0a9")
+	request.Header.Set(Host, "s3.amazonaws.com")
+	request.Header.Set(ContentEncoding, "aws-chunked")
+	request.Header.Set(ContentLength, "66824")
+	request.Header.Set(XAmzDecodedContentLength, "66560")
+	request.Header.Set(XAmzDate, "20130524T000000Z")
+	request.Header.Set(XAmzStorageClass, "REDUCED_REDUNDANCY")
+	request.Header.Set(XAmzContentSha256, "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+
+	ha, err := NewHeaderAuth(request)
+	require.NoError(t, err)
+	require.True(t, ha.SignatureMatch(secretKey, wildcards))
+
+	decoded, err := io.ReadAll(request.Body)
+	require.NoError(t, err, "reading the chunked body must not fail with \"signature of chunk does not match\"")
+	require.Equal(t, 66560, len(decoded))
+	require.Equal(t, strings.Repeat("a", 66560), string(decoded))
 }


### PR DESCRIPTION
### Motivation

`buildSignatureChunk` in `objectnode/auth_header.go` passed the short credential-scope date (`cred.Date`, e.g. `"20260722"`) to `NewSignChunkedReader` as each chunk's signing datetime, instead of the full ISO8601 request timestamp (`cred.TimeStamp`, e.g. `"20260722T085745Z"`) that AWS's chunked SigV4 spec requires there (per [sigv4-streaming.html](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html), and confirmed against `aws-sdk-java-v2`'s own `SigV4ChunkExtensionProvider#getStringToSign`, which uses `credentialScope.getDatetime()` -- the full timestamp).

This made every per-chunk signature verification fail unconditionally for any client using chunked/streaming SigV4 uploads, independent of client SDK version -- reproduced with Hadoop's S3A connector across `hadoop-aws` 3.4.2/3.4.3 and AWS SDK v2 bundle 2.29.52/2.35.4, and confirmed fixed against the same client stack after this change.

### Modifications

One-line fix in `buildSignatureChunk`: pass `cred.TimeStamp` (full ISO8601 timestamp) instead of `cred.Date` (short date) into `NewSignChunkedReader`, matching the datetime AWS's spec and every SDK actually use for the per-chunk string-to-sign.

Adds `TestHeaderAuthV4ChunkedBodySignatureMatch`, a regression test that exercises the actual buggy code path (`HeaderAuth.SignatureMatch` plus reading the wrapped chunked body through), using the same official AWS chunked-upload example (`examplebucket/chunkObject.txt`) already used by `TestHeaderAuthV4SignatureMatch`'s "Chunked PUT Object" case and `TestSignChunkedReader`. The existing `TestSignChunkedReader` alone could never have caught this bug: it calls `NewSignChunkedReader` directly with the correct full-timestamp value, bypassing the buggy call site in `buildSignatureChunk` entirely. Confirmed this new test fails with the exact real-world error (`"signature of chunk does not match"`) when the bug is reintroduced, and passes with the fix, without affecting any other existing test in the package.

**Not a breaking change in practice**: every standards-compliant SDK already computes chunk signatures using the full timestamp (verified against `aws-sdk-java-v2`'s own source), so no compliant client could have ever successfully completed a chunked upload against ObjectNode before this fix -- every such upload was already failing 100% of the time with `"signature of chunk does not match"`, regardless of SDK/version. This fixes previously-broken functionality; it can't regress a client that was never able to complete a chunked upload in the first place. Only a hypothetical non-standard client deliberately reverse-engineered to sign chunks the same (incorrect) way ObjectNode previously expected would be affected, which no known SDK does. Clients that avoid chunked encoding (e.g. older SDKs defaulting to a single non-chunked signed PUT for small objects) never exercised this code path and are unaffected either way.

### Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] So on...

### Verifying this change

This change added tests and can be verified as follows:

- `TestHeaderAuthV4ChunkedBodySignatureMatch` (new) exercises the real bug: it builds the same official AWS chunked-upload request `TestHeaderAuthV4SignatureMatch` already uses, calls `SignatureMatch` (which wires up the chunked body reader), then actually reads the decoded body through and asserts it succeeds and matches the expected content. Confirmed this test fails with `"signature of chunk does not match"` when the one-line fix is reverted, and passes with it applied -- with `go test ./objectnode/... -run 'TestHeaderAuthV4ChunkedBodySignatureMatch|TestHeaderAuthV4SignatureMatch|TestSignChunkedReader|TestParseSignChunkedHeader'` green in both directions as expected.
- Also verified end-to-end against a real running CubeFS cluster: a real Spark write (Hadoop `hadoop-aws` 3.4.2 and 3.4.3, AWS SDK v2 bundle 2.29.52 and 2.35.4) through `ObjectNode`'s S3 API failed with `AWSStatus500Exception: ... signature of chunk does not match` before this fix, and succeeded (write + readback verified) after rebuilding `ObjectNode` with it applied -- both against an isolated standalone instance and the real multi-replica deployment.

### Does this pull request potentially affect one of the following parts:

- [ ] Master
- [ ] MetaNode
- [ ] DataNode
- [x] ObjectNode
- [ ] AuthNode
- [ ] LcNode
- [ ] Blobstore
- [ ] Client
- [ ] Cli
- [ ] SDK
- [ ] Other Tools
- [ ] Common Packages
- [ ] Dependencies
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [ ] `doc-required`
- [x] `doc-not-needed`
- [ ] `doc-complete`

No user-facing behavior or configuration changes -- this only makes ObjectNode's chunk-signature verification match the AWS spec it was already supposed to implement.
