### PR TITLE
fix(datanode): close metadataFp in ExtentStore.Close to avoid fd leak

### DIFF
--- a/datanode/storage/extent_store.go
+++ b/datanode/storage/extent_store.go
@@ -1002,6 +1002,11 @@ func (s *ExtentStore) Close() {
 		}
 	}
 
+	if s.metadataFp != nil {
+		s.metadataFp.Sync()
+		s.metadataFp.Close()
+	}
+
 	s.stopMutex.Lock()
 	defer s.stopMutex.Unlock()
 	s.setClosed(true)


### PR DESCRIPTION
Fixes #4089
ExtentStore.Close 关闭了 tinyExtentDeleteFp、normalExtentDeleteFp、verifyExtentFp 等文件句柄，但遗漏了 metadataFp，导致 datanode 关闭 extent store 时文件描述符泄漏。本提交补充关闭 metadataFp，含 Sync + Close，并带 nil 保护。