### PR TITLE
fix(proto): widen the version list buffer size so a peer count above 3855 is readable

### DIFF
--- a/proto/packet.go
+++ b/proto/packet.go
@@ -1216,7 +1216,12 @@ func (p *Packet) ReadFromConnWithVer(c net.Conn, timeoutSec int) (err error) {
 		cnt := binary.BigEndian.Uint16(cntByte)
 		log.LogDebugf("action[ReadFromConnWithVer] op %s verseq %v, extType %d, cnt %d",
 			p.GetOpMsg(), p.VerSeq, p.ExtentType, cnt)
-		verData := make([]byte, cnt*verInfoCnt)
+		// cnt is a uint16 read from the connection, and verInfoCnt is 17, so
+		// cnt*verInfoCnt is computed in uint16 arithmetic and wraps: a cnt of
+		// 3856 asks for 65552 bytes but yields a 16 byte buffer, and the short
+		// read below then rejects the packet. Widen the multiplication so the
+		// buffer matches what cnt actually describes.
+		verData := make([]byte, int(cnt)*verInfoCnt)
 		if _, err = io.ReadFull(c, verData); err != nil {
 			err = fmt.Errorf("reqId(%v) opCode(%v) protoVer(%v) remote(%v), read ver slice from conn failed: %v",
 				p.GetReqID(), p.GetOpMsg(), p.ProtoVersion, c.RemoteAddr(), err)

--- a/proto/packet_verlist_test.go
+++ b/proto/packet_verlist_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The CubeFS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package proto
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/cubefs/cubefs/util"
+	"github.com/stretchr/testify/require"
+)
+
+// buildVersionListPacket returns the bytes a peer would send for a packet carrying
+// a version list of cnt entries: a header with VersionListFlag set, the uint16
+// count, then cnt entries of verInfoCnt bytes each.
+func buildVersionListPacket(cnt uint16) []byte {
+	header := make([]byte, util.PacketHeaderSize)
+	header[0] = ProtoMagic
+	header[1] = VersionListFlag // ExtentType; no MultiVersion/ProtocolVersion extras
+
+	body := make([]byte, 0, 2+int(cnt)*verInfoCnt)
+	body = binary.BigEndian.AppendUint16(body, cnt)
+	for i := 0; i < int(cnt); i++ {
+		entry := make([]byte, verInfoCnt)
+		binary.BigEndian.PutUint64(entry[0:8], uint64(i+1)) // Ver
+		binary.BigEndian.PutUint64(entry[8:16], 0)          // DelTime
+		entry[16] = 0                                       // Status
+		body = append(body, entry...)
+	}
+	return append(header, body...)
+}
+
+// TestReadFromConnWithVerCount drives ReadFromConnWithVer over a real conn with
+// version-list counts either side of the uint16 boundary.
+//
+// verInfoCnt is 17, so a count above 3855 overflows uint16 arithmetic when it is
+// used to size the buffer: 3856*17 is 65552, which wraps to 16. The packet is then
+// under-read and rejected, so a peer cannot send a version list longer than 3855
+// entries at all.
+//
+// The assertion is that the packet parses and yields the entries that were sent.
+// It fails on the unwidened multiplication, where the short buffer makes
+// UnmarshalVersionSlice return EOF.
+func TestReadFromConnWithVerCount(t *testing.T) {
+	InitBufferPool(32 * 1024)
+
+	for _, cnt := range []uint16{0, 1, 100, 3855, 3856, 5000} {
+		t.Run("", func(t *testing.T) {
+			wire := buildVersionListPacket(cnt)
+
+			client, server := net.Pipe()
+			defer client.Close()
+			defer server.Close()
+
+			go func() {
+				_, _ = client.Write(wire)
+			}()
+
+			p := &Packet{}
+			err := p.ReadFromConnWithVer(server, NoReadDeadlineTime)
+			require.NoError(t, err, "cnt=%d must parse", cnt)
+			require.Len(t, p.VerList, int(cnt), "cnt=%d", cnt)
+			for i, v := range p.VerList {
+				require.Equal(t, uint64(i+1), v.Ver, "cnt=%d entry %d", cnt, i)
+			}
+		})
+	}
+}
+
+// TestVersionListBufferSizeDoesNotWrap states the arithmetic directly, so the
+// boundary is documented even if the wire format changes.
+func TestVersionListBufferSizeDoesNotWrap(t *testing.T) {
+	for _, cnt := range []uint16{3856, 30000, 65535} {
+		widened := int(cnt) * verInfoCnt
+		wrapped := int(cnt * verInfoCnt) // what uint16 arithmetic yields
+		require.Greater(t, widened, wrapped,
+			"cnt=%d: uint16 arithmetic wraps here, which is the case under test", cnt)
+		require.Equal(t, int(cnt)*17, widened, "cnt=%d", cnt)
+	}
+}


### PR DESCRIPTION
## What

`ReadFromConnWithVer` reads a `uint16` count off the connection and sizes the version-list buffer with it:

```go
cnt := binary.BigEndian.Uint16(cntByte)
...
verData := make([]byte, cnt*verInfoCnt)
if _, err = io.ReadFull(c, verData); err != nil { ... }
err = p.UnmarshalVersionSlice(int(cnt), verData)
```

`cnt` is a `uint16` and `verInfoCnt` is 17, so `cnt*verInfoCnt` is evaluated in `uint16` arithmetic and **wraps for any `cnt` above 3855**. `io.ReadFull` is then given a buffer far shorter than the packet body, the read comes up short, and the packet is rejected.

This is not an over-allocation — it is a truncation, and the practical effect is that **a version list longer than 3855 entries cannot be received at all**. The count comes from a peer, so it is reachable from the network.

## Measured in the `proto` package

```
cnt=3855   cnt*verInfoCnt (uint16) = 65535   needed 65535     ok
cnt=3856   cnt*verInfoCnt (uint16) = 16      needed 65552
cnt=30000  cnt*verInfoCnt (uint16) = 51248   needed 510000
cnt=65535  cnt*verInfoCnt (uint16) = 65519   needed 1114095
```

## Scope of the impact

`UnmarshalVersionSlice` reads through a `bytes.Buffer` with `binary.Read`, so a short
buffer makes it return `EOF` rather than read out of bounds. I checked this directly
rather than assuming it:

```
UnmarshalVersionSlice(3856,  make([]byte, 16))     -> EOF, 0 items
UnmarshalVersionSlice(65535, make([]byte, 65519))  -> unexpected EOF, 0 items
```

So this is a **correctness and availability** bug, not a memory-safety one. An earlier
revision of this PR described it as reading past the end of the buffer; that was wrong
and I have corrected it here and in the code comment.

## Fix

Widen the multiplication:

```go
verData := make([]byte, int(cnt)*verInfoCnt)
```

`io.ReadFull` still bounds how much is actually read from the connection, so this does not let a peer make the process read more than it sends — it only makes the buffer size agree with the count that was announced.

## Testing

`proto/packet_verlist_test.go`:

- **`TestReadFromConnWithVerCount`** drives the real `ReadFromConnWithVer` over a
  `net.Pipe`, writing a header with `VersionListFlag` set followed by the `uint16`
  count and `cnt` entries, for `cnt` of 0 / 1 / 100 / **3855 / 3856** / 5000. It asserts
  the packet parses and that `VerList` holds exactly the entries that were sent.
- **`TestVersionListBufferSizeDoesNotWrap`** states the arithmetic directly, so the
  boundary stays documented if the wire format changes.

Control run — with `proto/packet.go` reverted to the unwidened multiplication and these
tests kept:

```
--- FAIL: TestReadFromConnWithVerCount/#04   cnt=3856 must parse
--- FAIL: TestReadFromConnWithVerCount/#05   cnt=5000 must parse
```

`cnt <= 3855` passes on both trees, so the failure lands exactly on the overflow
boundary. With the fix applied, `go test ./proto/` passes in full; `gofmt` and
`go vet ./proto/` are clean.

## Disclosure

This change was prepared with AI assistance. Every number above is from a run on the
diff as submitted, and I can explain and revise it during review.
