### PR TITLE
docs: fix typo partiton -> partition

### DIFF
--- a/util/loadutil/disk.go
+++ b/util/loadutil/disk.go
@@ -52,7 +52,7 @@ func GetMatchParation(path string) (*disk.PartitionStat, error) {
 }
 
 var (
-	ErrInvalidDiskPartition = errors.New("invalid disk partiton")
+	ErrInvalidDiskPartition = errors.New("invalid disk partition")
 	ErrFailedToGetIoCounter = errors.New("failed to get io counter")
 )
 


### PR DESCRIPTION
Corrects the misspelling `partiton` -> `partition` in `util/loadutil/disk.go`.

Documentation only, no behaviour change.